### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete string escaping or encoding

### DIFF
--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -48,7 +48,7 @@ async function autocomplete(form, inp, sealed) {
                 b.innerHTML += arr[i].substr(val.length);
 
                 /* Insert a input field that will hold the current array item's value */
-                b.innerHTML += "<input type='hidden' value='" + arr[i].replace("'", "&apos;").replace("\"", "&quot;") + "'>";
+                b.innerHTML += "<input type='hidden' value='" + arr[i].replace(/'/g, "&apos;").replace(/\"/g, "&quot;") + "'>";
                 /* Execute a function when someone clicks on the item value (DIV element) */
                 b.addEventListener("click", function(e) {
                     /* Insert the value for the autocomplete text field */


### PR DESCRIPTION
Potential fix for [https://github.com/mtgban/mtgban-website/security/code-scanning/3](https://github.com/mtgban/mtgban-website/security/code-scanning/3)

To fix the problem, all single and double quotes in `arr[i]` should be correctly escaped before being inserted into the generated HTML string. This requires replacing *all* occurrences, not just the first. Instead of using the string pattern to `.replace()` (which only affects the first match), a regular expression with the global flag `/g` must be used for each replacement.

Specifically, in `js/autocomplete.js` on line 51, replace:

```js
arr[i].replace("'", "&apos;").replace("\"", "&quot;")
```

with:

```js
arr[i].replace(/'/g, "&apos;").replace(/"/g, "&quot;")
```

This ensures *every* single quote and double quote in `arr[i]` is replaced appropriately. No additional imports or helper methods are required. The rest of the code and escaping logic can remain unchanged, as the fix directly corrects the escaping for input values.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
