### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lorcana-deploy.yml
+++ b/.github/workflows/lorcana-deploy.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/mtgban/mtgban-website/security/code-scanning/1](https://github.com/mtgban/mtgban-website/security/code-scanning/1)

To resolve this issue, add a `permissions` block to the `deploy` job (or at the workflow root) specifying the least required privileges. Based on the steps in the job, only a read permission to repository contents appears required—no steps involve modifying issues, pull requests, workflows, or repository contents. Insert the line `permissions: contents: read` beneath either the workflow root (after the name and before `on:`) or, as is most standard for fine-grained control, inside the `deploy` job, directly after `runs-on: ubuntu-latest`. Since you were only shown the job definition and not the complete root context, adding it to the job is safest and clear.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
