### PR TITLE
Modernize sleepers menu

### DIFF
--- a/css/sleepers.css
+++ b/css/sleepers.css
@@ -3,7 +3,16 @@
    ═══════════════════════════════════════ */
 
 .sleepers-page {
-    padding: 20px 32px 80px;
+    max-width: 1600px;
+    margin: 0 auto;
+    padding: 20px 48px 80px;
+}
+
+.sleepers-page-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    margin-bottom: 24px;
 }
 
 .sleepers-page h1 {
@@ -16,27 +25,31 @@
 .sleepers-page-subtitle {
     color: var(--activetext);
     font-size: 16px;
-    margin: 0 0 28px 0;
+    margin: 0;
 }
 
-/* ── Two-column body: main + sidebar ── */
-.sleepers-page-body {
-    display: grid;
-    grid-template-columns: 1fr 500px;
-    gap: 12px;
-    align-items: start;
-}
-
-.sleepers-page-main {
-    min-width: 0;
-}
-
-.sleepers-page-sidebar {
-    position: sticky;
-    top: 20px;
+.sleepers-filters-btn {
     display: flex;
-    flex-direction: column;
-    gap: 16px;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 20px;
+    border-radius: var(--radius-md);
+    background: var(--surface-1);
+    border: 1px solid var(--border-subtle);
+    text-decoration: none;
+    color: var(--activetext);
+    font-size: 15px;
+    font-weight: 600;
+    white-space: nowrap;
+    transition: all 0.15s;
+    flex-shrink: 0;
+    margin-top: 4px;
+}
+
+.sleepers-filters-btn:hover {
+    border-color: var(--accent-border);
+    color: var(--normal);
+    background: var(--surface-2);
 }
 
 /* ── Tool strip: horizontal row of cards ── */
@@ -322,15 +335,15 @@
 
 
 /* ═══════════════════════════════════════
-   Sidebar: Info Card + Example Tiers
+   Info Card
    ═══════════════════════════════════════ */
 
 .sleepers-info-card {
-    flex: 1;
     background: var(--surface-1);
     border: 1px solid var(--border-subtle);
     border-radius: var(--radius-lg);
     padding: 22px 24px;
+    margin-bottom: 20px;
 }
 
 .sleepers-info-card h3 {
@@ -394,89 +407,6 @@
     background: rgba(255,191,64,0.15);
     color: #e6a817;
 }
-
-.sleepers-opts-link {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-    background: var(--surface-1);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 14px 22px;
-    text-decoration: none;
-    color: var(--activetext);
-    font-size: 15px;
-    font-weight: 500;
-    transition: all 0.2s;
-}
-
-.sleepers-opts-link:hover {
-    border-color: var(--accent-border);
-    color: var(--normal);
-}
-
-.sleepers-opts-link .opts-icon {
-    font-size: 18px;
-}
-
-/* ── Example tier display ── */
-.sleepers-example {
-    background: var(--surface-1);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 18px;
-}
-
-.sleepers-example-label {
-    font-size: 13px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: var(--text-dim);
-    margin-bottom: 12px;
-}
-
-.sleepers-example-tiers {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-}
-
-.sleepers-example-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-}
-
-.sleepers-example-letter {
-    width: 28px;
-    height: 28px;
-    border-radius: 4px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 13px;
-    font-weight: 700;
-    color: #1a1a1a;
-    flex-shrink: 0;
-}
-
-.sleepers-example-cards {
-    display: flex;
-    gap: 3px;
-    flex: 1;
-    min-width: 0;
-}
-
-img.sleepers-example-card {
-    width: auto;
-    height: 56px;
-    border-radius: 3px;
-    flex-shrink: 0;
-    object-fit: cover;
-}
-
 
 /* ═══════════════════════════════════════
    Results View (tier rows)
@@ -646,12 +576,6 @@ img.sleepers-example-card {
    ═══════════════════════════════════════ */
 
 @media (max-width: 900px) {
-    .sleepers-page-body {
-        grid-template-columns: 1fr;
-    }
-    .sleepers-page-sidebar {
-        position: static;
-    }
     .sleepers-tools-strip {
         grid-template-columns: repeat(2, 1fr);
     }

--- a/sleep.go
+++ b/sleep.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"math"
-	"math/rand"
 	"net/http"
 	"slices"
 	"sort"
@@ -89,38 +88,9 @@ func Sleepers(w http.ResponseWriter, r *http.Request) {
 	default:
 		pageVars.Subtitle = "Index"
 
-		exampleCards := pickExampleCards()
-		pageVars.Sleepers = exampleCards
-		pageVars.SleepersKeys = SleeperLetters
-		pageVars.SleepersColors = SleeperColors
-		pageVars.Metadata = map[string]GenericCard{}
-		for _, cardIds := range exampleCards {
-			for _, cardId := range cardIds {
-				pageVars.Metadata[cardId] = uuid2card(cardId, true, false, false)
-			}
-		}
-
 		render(w, "sleep.html", pageVars)
 
 		return
-	case "example":
-		// Internal endpoint for fetching fresh example cards
-		pageVars.Subtitle = "Example"
-
-		exampleCards := pickExampleCards()
-		pageVars.Sleepers = exampleCards
-		pageVars.SleepersKeys = SleeperLetters
-		pageVars.SleepersColors = SleeperColors
-		pageVars.Metadata = map[string]GenericCard{}
-		for _, cardIds := range exampleCards {
-			for _, cardId := range cardIds {
-				pageVars.Metadata[cardId] = uuid2card(cardId, true, false, false)
-			}
-		}
-
-		render(w, "sleep.html", pageVars)
-		return
-
 	case "options":
 		pageVars.Subtitle = "Options"
 
@@ -534,75 +504,6 @@ func noOversize(co *mtgmatcher.CardObject) (float64, bool) {
 		return 0, true
 	}
 	return 1, false
-}
-
-// Pick random card UUIDs for the example tier display on the Index page.
-// Returns a map of tier letter to card IDs with increasing counts per tier.
-func pickExampleCards() map[string][]string {
-	// Cards per tier: S=1, A=1, B=2, C=2, D=3, E=3, F=3
-	counts := []int{1, 1, 2, 2, 3, 3, 3}
-	total := 0
-	for _, c := range counts {
-		total += c
-	}
-
-	uuids := mtgmatcher.GetUUIDs()
-	if len(uuids) == 0 {
-		return nil
-	}
-
-	// Pick valid random cards
-	var picked []string
-	attempts := 0
-	for len(picked) < total && attempts < total*20 {
-		attempts++
-		uuid := uuids[rand.Intn(len(uuids))]
-
-		co, err := mtgmatcher.GetUUID(uuid)
-		if err != nil {
-			continue
-		}
-
-		// Skip foils, promos, tokens, oversized, and cards without images
-		if co.Foil || co.Etched || co.IsPromo || co.Rarity == "oversize" {
-			continue
-		}
-		if co.Layout == "token" || co.Layout == "emblem" || co.Layout == "art_series" {
-			continue
-		}
-		if co.Images["thumbnail"] == "" {
-			continue
-		}
-
-		// Avoid duplicates
-		dup := false
-		for _, p := range picked {
-			if p == uuid {
-				dup = true
-				break
-			}
-		}
-		if dup {
-			continue
-		}
-
-		picked = append(picked, uuid)
-	}
-
-	// Distribute across tiers
-	result := map[string][]string{}
-	idx := 0
-	for i, letter := range SleeperLetters {
-		if i >= len(counts) {
-			break
-		}
-		for j := 0; j < counts[i] && idx < len(picked); j++ {
-			result[letter] = append(result[letter], picked[idx])
-			idx++
-		}
-	}
-
-	return result
 }
 
 // Return a map of letter : []cardId from a map of cardId : amount

--- a/templates/sleep.html
+++ b/templates/sleep.html
@@ -47,164 +47,141 @@
         <h1>{{.ErrorMessage}}</h1>
     {{else if eq .Subtitle "Index"}}
         <div class="sleepers-page">
-            <h1>Sleepers</h1>
-            <p class="sleepers-page-subtitle">Cards the market hasn't caught up on yet. Ranked S through F.</p>
+            <div class="sleepers-page-header">
+                <div>
+                    <h1>Sleepers</h1>
+                    <p class="sleepers-page-subtitle">Cards the market hasn't caught up on yet.</p>
+                </div>
+                <a class="sleepers-filters-btn" href="?page=options">
+                    <span>&#9881;</span> Filters
+                </a>
+            </div>
 
-            <div class="sleepers-page-body">
-                <div class="sleepers-page-main">
-                    <!-- Tool strip -->
-                    <div class="sleepers-tools-strip">
-                        <a class="sleepers-tool" href="?page=bulk">
-                            <div class="tool-top">
-                                <span class="tool-icon" style="background:rgba(255,127,127,0.15); color:var(--tier-s);">&#128142;</span>
-                                <span class="tool-arrow">&rarr;</span>
-                            </div>
-                            <h3>Bulk Me Up</h3>
-                            <p>Cards deviating from their set average over the last 5 years. Unexpected gems in bulk.</p>
+            <div class="sleepers-info-card">
+                <h3>&#128161; About Sleepers</h3>
+                <p>Results are tiered <strong>S through F</strong>. Higher tiers = stronger signals. These tools identify cards where market pricing hasn't kept pace with demand, scarcity, or cross-market pricing differences.</p>
+                <div class="sleepers-tier-perks">
+                    <div class="sleepers-tier-perk">
+                        <span class="tier-perk-badge tier-perk-legacy">Legacy</span>
+                        <span>Unlocks Ocean Gap preset comparisons</span>
+                    </div>
+                    <div class="sleepers-tier-perk">
+                        <span class="tier-perk-badge tier-perk-vintage">Vintage</span>
+                        <span>Unlocks custom seller pairing</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Tool strip -->
+            <div class="sleepers-tools-strip">
+                <a class="sleepers-tool" href="?page=bulk">
+                    <div class="tool-top">
+                        <span class="tool-icon" style="background:rgba(255,127,127,0.15); color:var(--tier-s);">&#128142;</span>
+                        <span class="tool-arrow">&rarr;</span>
+                    </div>
+                    <h3>Bulk Me Up</h3>
+                    <p>Cards deviating from their set average over the last 5 years. Unexpected gems in bulk.</p>
+                </a>
+                <a class="sleepers-tool" href="?page=reprint">
+                    <div class="tool-top">
+                        <span class="tool-icon" style="background:rgba(255,191,127,0.15); color:var(--tier-a);">&#128197;</span>
+                        <span class="tool-arrow">&rarr;</span>
+                    </div>
+                    <h3>Long Time No Reprint</h3>
+                    <p>No reprint in 2+ years. Excludes bulk, Reserved List, and non-tournament cards.</p>
+                </a>
+                <a class="sleepers-tool" href="?page=mismatch">
+                    <div class="tool-top">
+                        <span class="tool-icon" style="background:rgba(127,255,127,0.15); color:var(--tier-c);">&#128200;</span>
+                        <span class="tool-arrow">&rarr;</span>
+                    </div>
+                    <h3>Market Mismatch</h3>
+                    <p>Buylist exceeds market price, or priced below TCG Low. Arbitrage signals.</p>
+                </a>
+                <a class="sleepers-tool" href="?page=hotlist">
+                    <div class="tool-top">
+                        <span class="tool-icon" style="background:rgba(255,255,127,0.15); color:var(--tier-b);">&#128293;</span>
+                        <span class="tool-arrow">&rarr;</span>
+                    </div>
+                    <h3>Hotlist</h3>
+                    <p>Most buylist growth over the past 3 months. Spot emerging trends early.</p>
+                </a>
+            </div>
+
+            <!-- Ocean Gap: presets + custom builder -->
+            <div class="sleepers-comparator">
+                <div class="sleepers-comparator-left">
+                    <h2>
+                        &#127754; Ocean Gap
+                        <span class="beta-tag">Beta</span>
+                    </h2>
+                    <p class="comp-desc">Compare two sellers. Find where one has cheaper cards than the other.</p>
+
+                    <div class="sleepers-comp-presets">
+                        <a class="sleepers-comp-preset" href="?page=gap&ref=TCGLow&target=MKMLow">
+                            <span class="ref-name">TCGLow</span>
+                            <span class="vs">vs</span>
+                            <span class="target-name">MKMLow</span>
+                            <span class="preset-arrow">&rarr;</span>
                         </a>
-                        <a class="sleepers-tool" href="?page=reprint">
-                            <div class="tool-top">
-                                <span class="tool-icon" style="background:rgba(255,191,127,0.15); color:var(--tier-a);">&#128197;</span>
-                                <span class="tool-arrow">&rarr;</span>
-                            </div>
-                            <h3>Long Time No Reprint</h3>
-                            <p>No reprint in 2+ years. Excludes bulk, Reserved List, and non-tournament cards.</p>
+                        <a class="sleepers-comp-preset" href="?page=gap&ref=TCGLow&target=MKMTrend">
+                            <span class="ref-name">TCGLow</span>
+                            <span class="vs">vs</span>
+                            <span class="target-name">MKMTrend</span>
+                            <span class="preset-arrow">&rarr;</span>
                         </a>
-                        <a class="sleepers-tool" href="?page=mismatch">
-                            <div class="tool-top">
-                                <span class="tool-icon" style="background:rgba(127,255,127,0.15); color:var(--tier-c);">&#128200;</span>
-                                <span class="tool-arrow">&rarr;</span>
-                            </div>
-                            <h3>Market Mismatch</h3>
-                            <p>Buylist exceeds market price, or priced below TCG Low. Arbitrage signals.</p>
+                        <a class="sleepers-comp-preset" href="?page=gap&ref=MKMTrend&target=CK">
+                            <span class="ref-name">MKMTrend</span>
+                            <span class="vs">vs</span>
+                            <span class="target-name">Card Kingdom</span>
+                            <span class="preset-arrow">&rarr;</span>
                         </a>
-                        <a class="sleepers-tool" href="?page=hotlist">
-                            <div class="tool-top">
-                                <span class="tool-icon" style="background:rgba(255,255,127,0.15); color:var(--tier-b);">&#128293;</span>
-                                <span class="tool-arrow">&rarr;</span>
-                            </div>
-                            <h3>Hotlist</h3>
-                            <p>Most buylist growth over the past 3 months. Spot emerging trends early.</p>
+                        <a class="sleepers-comp-preset" href="?page=gap&ref=MKMTrend&target=SCG">
+                            <span class="ref-name">MKMTrend</span>
+                            <span class="vs">vs</span>
+                            <span class="target-name">SCG</span>
+                            <span class="preset-arrow">&rarr;</span>
+                        </a>
+                        <a class="sleepers-comp-preset" href="?page=gap&ref=MKMTrend&target=MP">
+                            <span class="ref-name">MKMTrend</span>
+                            <span class="vs">vs</span>
+                            <span class="target-name">Manapool</span>
+                            <span class="preset-arrow">&rarr;</span>
                         </a>
                     </div>
-
-                    <!-- Ocean Gap: presets + custom builder -->
-                    <div class="sleepers-comparator">
-                        <div class="sleepers-comparator-left">
-                            <h2>
-                                &#127754; Ocean Gap
-                                <span class="beta-tag">Beta</span>
-                            </h2>
-                            <p class="comp-desc">Compare two sellers. Find where one has cheaper cards than the other.</p>
-
-                            <div class="sleepers-comp-presets">
-                                <a class="sleepers-comp-preset" href="?page=gap&ref=TCGLow&target=MKMLow">
-                                    <span class="ref-name">TCGLow</span>
-                                    <span class="vs">vs</span>
-                                    <span class="target-name">MKMLow</span>
-                                    <span class="preset-arrow">&rarr;</span>
-                                </a>
-                                <a class="sleepers-comp-preset" href="?page=gap&ref=TCGLow&target=MKMTrend">
-                                    <span class="ref-name">TCGLow</span>
-                                    <span class="vs">vs</span>
-                                    <span class="target-name">MKMTrend</span>
-                                    <span class="preset-arrow">&rarr;</span>
-                                </a>
-                                <a class="sleepers-comp-preset" href="?page=gap&ref=MKMTrend&target=CK">
-                                    <span class="ref-name">MKMTrend</span>
-                                    <span class="vs">vs</span>
-                                    <span class="target-name">Card Kingdom</span>
-                                    <span class="preset-arrow">&rarr;</span>
-                                </a>
-                                <a class="sleepers-comp-preset" href="?page=gap&ref=MKMTrend&target=SCG">
-                                    <span class="ref-name">MKMTrend</span>
-                                    <span class="vs">vs</span>
-                                    <span class="target-name">SCG</span>
-                                    <span class="preset-arrow">&rarr;</span>
-                                </a>
-                                <a class="sleepers-comp-preset" href="?page=gap&ref=MKMTrend&target=MP">
-                                    <span class="ref-name">MKMTrend</span>
-                                    <span class="vs">vs</span>
-                                    <span class="target-name">Manapool</span>
-                                    <span class="preset-arrow">&rarr;</span>
-                                </a>
-                            </div>
-                        </div>
-
-                        {{if .CanShowAll}}
-                        <div class="sleepers-comparator-right">
-                            <div class="sleepers-comp-custom-title">Custom Comparison</div>
-                            <form class="sleepers-comp-builder" action="sleepers" method="GET">
-                                <input type="hidden" name="page" value="gap">
-                                <label>Reference Seller</label>
-                                <select name="ref" id="ref" onchange="checkSleepersCompare()">
-                                    <option value="" disabled selected>Pick a reference...</option>
-                                    {{range .SellerKeys}}
-                                        <option value="{{.}}">{{scraper_name .}}</option>
-                                    {{end}}
-                                </select>
-                                <div class="sleepers-comp-vs-divider">VS</div>
-                                <label>Target Seller</label>
-                                <select name="target" id="target" onchange="checkSleepersCompare()">
-                                    <option value="" disabled selected>Pick where to buy...</option>
-                                    {{range .SellerKeys}}
-                                        <option value="{{.}}">{{scraper_name .}}</option>
-                                    {{end}}
-                                </select>
-                                <button type="submit" class="sleepers-comp-go" id="sleepers-comp-go" disabled>Compare</button>
-                            </form>
-                        </div>
-                        {{else if $.ShowUpsell}}
-                        <div class="sleepers-comparator-right">
-                            <div class="sleepers-comp-custom-title">Custom Comparison</div>
-                            <div class="sleepers-upsell">
-                                <em>Increase your tier to compare any seller on Sleepers!</em>
-                            </div>
-                        </div>
-                        {{end}}
-                    </div>
-
-                    <a class="sleepers-opts-link" href="?page=options">
-                        <span class="opts-icon">&#9881;</span>
-                        Customize Filters
-                    </a>
                 </div>
 
-                <div class="sleepers-page-sidebar">
-                    <div class="sleepers-info-card">
-                        <h3>&#128161; About Sleepers</h3>
-                        <p>Results are tiered <strong>S through F</strong>. Higher tiers = stronger signals. These tools identify cards where market pricing hasn't kept pace with demand, scarcity, or cross-market pricing differences.</p>
-                        <div class="sleepers-tier-perks">
-                            <div class="sleepers-tier-perk">
-                                <span class="tier-perk-badge tier-perk-legacy">Legacy</span>
-                                <span>Ocean Gap preset comparisons</span>
-                            </div>
-                            <div class="sleepers-tier-perk">
-                                <span class="tier-perk-badge tier-perk-vintage">Vintage</span>
-                                <span>Custom seller pairing</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="sleepers-example">
-                        <div class="sleepers-example-label">Example Results</div>
-                        <div class="sleepers-example-tiers">
-                            {{range $i, $letter := .SleepersKeys}}
-                                {{$bgColor := index $.SleepersColors $i}}
-                                {{$cardIds := index $.Sleepers $letter}}
-                                <div class="sleepers-example-row">
-                                    <span class="sleepers-example-letter" style="background-color: {{$bgColor}};">{{$letter}}</span>
-                                    <div class="sleepers-example-cards">
-                                        {{range $cardIds}}
-                                            {{$card := index $.Metadata .}}
-                                            <img class="sleepers-example-card" loading="lazy" src="{{$card.ImageURL}}" title="{{$card.Name}}" alt="{{$card.Name}}">
-                                        {{end}}
-                                    </div>
-                                </div>
+                {{if .CanShowAll}}
+                <div class="sleepers-comparator-right">
+                    <div class="sleepers-comp-custom-title">Custom Comparison</div>
+                    <form class="sleepers-comp-builder" action="sleepers" method="GET">
+                        <input type="hidden" name="page" value="gap">
+                        <label>Reference Seller</label>
+                        <select name="ref" id="ref" onchange="checkSleepersCompare()">
+                            <option value="" disabled selected>Pick a reference...</option>
+                            {{range .SellerKeys}}
+                                <option value="{{.}}">{{scraper_name .}}</option>
                             {{end}}
-                        </div>
+                        </select>
+                        <div class="sleepers-comp-vs-divider">VS</div>
+                        <label>Target Seller</label>
+                        <select name="target" id="target" onchange="checkSleepersCompare()">
+                            <option value="" disabled selected>Pick where to buy...</option>
+                            {{range .SellerKeys}}
+                                <option value="{{.}}">{{scraper_name .}}</option>
+                            {{end}}
+                        </select>
+                        <button type="submit" class="sleepers-comp-go" id="sleepers-comp-go" disabled>Compare</button>
+                    </form>
+                </div>
+                {{else if $.ShowUpsell}}
+                <div class="sleepers-comparator-right">
+                    <div class="sleepers-comp-custom-title">Custom Comparison</div>
+                    <div class="sleepers-upsell">
+                        <em>Increase your tier to compare any seller on Sleepers!</em>
                     </div>
                 </div>
+                {{end}}
             </div>
         </div>
 


### PR DESCRIPTION
- Redesigned Sleepers index page with card-based tool selector, Ocean Gap comparator widget with presets + custom builder (tier-gated), info card with tier perk badges, and compact filters button
- Modernized Options page with card-based sections and CSS grid layout
- Added back-link header to results view, removed max-width constraint for full-width tier display
- Created dedicated css/sleepers.css
- Added shared surface/layout CSS variables to main.css (will conflict with master if PR #49 merges first: the .light-theme/.dark-theme variable blocks and the table.tiers td div rule at EOF need manual merge)

Conflict notes
css/main.css will have merge conflicts - the conflict is just deduplication.

fixes #36 