### PR TITLE
Add command palette and interactive user guide

### DIFF
--- a/css/command-palette.css
+++ b/css/command-palette.css
@@ -143,13 +143,20 @@
 
 /* Category header */
 .cp-category-header {
-    padding: 8px 16px 4px;
-    font-size: 0.7rem;
-    font-weight: 700;
+    padding: 6px 16px 4px;
+    margin-top: 4px;
+    font-size: 0.65rem;
+    font-weight: 600;
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--greytext, #888);
     user-select: none;
+    border-top: 1px solid var(--border-subtle, rgba(0, 0, 0, 0.06));
+}
+
+.cp-category-header:first-child {
+    border-top: none;
+    margin-top: 0;
 }
 
 /* Result row */

--- a/css/command-palette.css
+++ b/css/command-palette.css
@@ -323,24 +323,29 @@
 /* ── 7. Toast ───────────────────────────────────────────── */
 .cp-toast {
     position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(20px);
-    background: var(--normal, #111);
-    color: var(--background, #fff);
-    padding: 8px 16px;
+    bottom: 1em;
+    right: -100%;
+    padding: 0.6em 1em;
+    font-size: 0.8rem;
+    font-weight: 600;
+    background: var(--lightblack, #161616);
+    color: var(--green, #4caf50);
+    border: 1px solid var(--green, #4caf50);
     border-radius: 8px;
-    font-size: 0.85rem;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.2s, transform 0.2s;
     z-index: 600;
+    transition: right 300ms ease;
     white-space: nowrap;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+    pointer-events: none;
+}
+
+.light-theme .cp-toast {
+    background: var(--realwhite, #fcfcfc);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
 }
 
 .cp-toast.show {
-    opacity: 1;
-    transform: translateX(-50%) translateY(0);
+    right: 1em;
 }
 
 /* ── 8. Save Sub-input ──────────────────────────────────── */

--- a/css/command-palette.css
+++ b/css/command-palette.css
@@ -1,1 +1,371 @@
-/* Command Palette — placeholder */
+/* ============================================================
+   Command Palette — overlay, dialog, results, toast, save flow
+   ============================================================ */
+
+/* ── 1. Overlay ─────────────────────────────────────────── */
+.cp-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    z-index: 500;
+    justify-content: center;
+    align-items: flex-start;
+    padding-top: 20vh;
+}
+
+.cp-overlay.open {
+    display: flex;
+}
+
+/* ── 2. Dialog ──────────────────────────────────────────── */
+.cp-dialog {
+    width: 100%;
+    max-width: 640px;
+    max-height: 70vh;
+    background: var(--background, #fff);
+    border: 1px solid var(--border-moderate, rgba(0, 0, 0, 0.12));
+    border-radius: 12px;
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.25);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    animation: cp-appear 0.15s ease-out;
+}
+
+@keyframes cp-appear {
+    from {
+        opacity: 0;
+        transform: scale(0.96) translateY(-8px);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1) translateY(0);
+    }
+}
+
+/* ── 3. Input Row ───────────────────────────────────────── */
+.cp-input-row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border-subtle, rgba(0, 0, 0, 0.08));
+    flex-shrink: 0;
+}
+
+/* Mode indicator pill */
+.cp-mode-indicator {
+    display: none;
+    align-items: center;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.cp-mode-indicator.active {
+    display: flex;
+}
+
+.cp-mode-indicator[data-mode="help"] {
+    background: color-mix(in srgb, var(--ainfo, #559eff) 15%, transparent);
+    color: var(--ainfo, #559eff);
+}
+
+.cp-mode-indicator[data-mode="nav"] {
+    background: color-mix(in srgb, var(--awarn, #f59e0b) 15%, transparent);
+    color: var(--awarn, #f59e0b);
+}
+
+.cp-mode-indicator[data-mode="saved"] {
+    background: color-mix(in srgb, #8b5cf6 15%, transparent);
+    color: #8b5cf6;
+}
+
+/* Search input */
+.cp-input {
+    flex: 1;
+    border: none;
+    outline: none;
+    background: transparent;
+    font: inherit;
+    font-size: 1rem;
+    color: var(--normal, #111);
+    min-width: 0;
+}
+
+.cp-input::placeholder {
+    color: var(--greytext, #888);
+}
+
+/* Shortcut pill (ESC) */
+.cp-shortcut {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 6px;
+    background: var(--surface-2, rgba(0, 0, 0, 0.06));
+    border: 1px solid var(--border-subtle, rgba(0, 0, 0, 0.08));
+    border-radius: 4px;
+    font-size: 0.7rem;
+    color: var(--greytext, #888);
+    white-space: nowrap;
+    flex-shrink: 0;
+    font-family: inherit;
+}
+
+/* ── 4. Results ─────────────────────────────────────────── */
+.cp-results {
+    overflow-y: auto;
+    scrollbar-width: thin;
+    scrollbar-color: var(--border-moderate, rgba(0, 0, 0, 0.12)) transparent;
+    max-height: calc(70vh - 110px);
+    flex: 1 1 auto;
+}
+
+.cp-results::-webkit-scrollbar {
+    width: 6px;
+}
+
+.cp-results::-webkit-scrollbar-thumb {
+    background: var(--border-moderate, rgba(0, 0, 0, 0.12));
+    border-radius: 3px;
+}
+
+.cp-results::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+/* Category header */
+.cp-category-header {
+    padding: 8px 16px 4px;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--greytext, #888);
+    user-select: none;
+}
+
+/* Result row */
+.cp-result {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 16px;
+    cursor: pointer;
+    transition: background 0.1s;
+}
+
+.cp-result:hover {
+    background: var(--surface-1, rgba(0, 0, 0, 0.04));
+}
+
+.cp-result.active {
+    background: color-mix(in srgb, var(--ainfo, #559eff) 15%, transparent);
+}
+
+/* Result icon */
+.cp-result-icon {
+    width: 20px;
+    height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    color: var(--greytext, #888);
+}
+
+.cp-result-icon svg {
+    width: 16px;
+    height: 16px;
+}
+
+.cp-result.active .cp-result-icon {
+    color: var(--ainfo, #559eff);
+}
+
+/* Result body */
+.cp-result-body {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.cp-result-title {
+    font-size: 0.9rem;
+    color: var(--normal, #111);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.cp-result-subtitle {
+    font-size: 0.75rem;
+    color: var(--greytext, #888);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.cp-result-inline {
+    font-size: 0.75rem;
+    font-family: monospace;
+    color: var(--ainfo, #559eff);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Badge pill */
+.cp-result-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    background: var(--surface-2, rgba(0, 0, 0, 0.06));
+    color: var(--greytext, #888);
+    flex-shrink: 0;
+}
+
+/* Delete button (shown on hover) */
+.cp-result-delete {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    color: var(--adanger, #ef4444);
+    padding: 0;
+    border-radius: 4px;
+    flex-shrink: 0;
+}
+
+.cp-result-delete svg {
+    width: 14px;
+    height: 14px;
+}
+
+.cp-result:hover .cp-result-delete {
+    display: flex;
+}
+
+/* Right column */
+.cp-result-right {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 4px;
+    flex-shrink: 0;
+}
+
+/* ── 5. Footer ──────────────────────────────────────────── */
+.cp-footer {
+    display: flex;
+    justify-content: center;
+    gap: 16px;
+    padding: 8px 16px;
+    border-top: 1px solid var(--border-subtle, rgba(0, 0, 0, 0.08));
+    font-size: 0.7rem;
+    color: var(--greytext, #888);
+    flex-shrink: 0;
+}
+
+.cp-footer-hint {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.cp-footer kbd {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 5px;
+    background: var(--surface-2, rgba(0, 0, 0, 0.06));
+    border: 1px solid var(--border-subtle, rgba(0, 0, 0, 0.08));
+    border-radius: 4px;
+    font-size: 0.65rem;
+    font-family: inherit;
+    color: var(--greytext, #888);
+    line-height: 1.4;
+}
+
+/* ── 6. Empty State ─────────────────────────────────────── */
+.cp-empty {
+    padding: 24px 16px;
+    text-align: center;
+    color: var(--greytext, #888);
+    font-size: 0.9rem;
+}
+
+/* ── 7. Toast ───────────────────────────────────────────── */
+.cp-toast {
+    position: fixed;
+    bottom: 24px;
+    left: 50%;
+    transform: translateX(-50%) translateY(20px);
+    background: var(--normal, #111);
+    color: var(--background, #fff);
+    padding: 8px 16px;
+    border-radius: 8px;
+    font-size: 0.85rem;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s, transform 0.2s;
+    z-index: 600;
+    white-space: nowrap;
+}
+
+.cp-toast.show {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+}
+
+/* ── 8. Save Sub-input ──────────────────────────────────── */
+.cp-save-row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 16px;
+    border-top: 1px solid var(--border-subtle, rgba(0, 0, 0, 0.08));
+    background: var(--surface-1, rgba(0, 0, 0, 0.04));
+    flex-shrink: 0;
+}
+
+.cp-save-label {
+    font-size: 0.8rem;
+    color: var(--greytext, #888);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.cp-save-input {
+    flex: 1;
+    border: none;
+    outline: none;
+    background: transparent;
+    font: inherit;
+    font-size: 0.9rem;
+    color: var(--normal, #111);
+    min-width: 0;
+}
+
+.cp-save-input::placeholder {
+    color: var(--greytext, #888);
+}

--- a/css/command-palette.css
+++ b/css/command-palette.css
@@ -1,0 +1,1 @@
+/* Command Palette — placeholder */

--- a/css/guide.css
+++ b/css/guide.css
@@ -8,7 +8,7 @@
     flex-direction: row;
     max-width: 1200px;
     margin: 0 auto;
-    padding: var(--content-padding-top, 60px) var(--page-gutter, 3vw) 4em;
+    padding: 0 var(--page-gutter, 3vw) 4em;
     gap: 2em;
 }
 
@@ -95,7 +95,7 @@
 /* ── Hero ── */
 .guide-hero {
     text-align: center;
-    padding: 0 0 2.5em;
+    padding: 0 0 1em;
 }
 .guide-hero h1 {
     font-size: 2rem;

--- a/css/guide.css
+++ b/css/guide.css
@@ -1,0 +1,312 @@
+/* ============================================================
+   Guide Page — layout, sidebar, hero, sections, tables, examples
+   ============================================================ */
+
+/* ── Layout ── */
+.guide-container {
+    display: flex;
+    flex-direction: row;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: var(--content-padding-top, 60px) var(--page-gutter, 3vw) 4em;
+}
+
+/* ── Sidebar ── */
+.guide-sidebar {
+    width: 220px;
+    flex-shrink: 0;
+    position: sticky;
+    top: var(--nav-height, 48px);
+    height: calc(100vh - var(--nav-height, 48px));
+    overflow-y: auto;
+    padding: 1em 0 2em;
+}
+.guide-sidebar::-webkit-scrollbar { width: 5px; }
+.guide-sidebar::-webkit-scrollbar-thumb { background: var(--surface-3, #e2e4e6); border-radius: 3px; }
+
+.guide-sidebar-header {
+    padding: 0 12px 12px;
+}
+
+.guide-filter-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 8px 12px;
+    border-radius: var(--radius-sm, 6px);
+    border: 1px solid var(--border-moderate, rgba(0,0,0,0.12));
+    background: var(--surface-1, #fff);
+    color: var(--normal, #000);
+    font-size: var(--text-lg, 0.875rem);
+    font-family: inherit;
+    outline: none;
+}
+.guide-filter-input:focus {
+    border-color: var(--ainfo, dodgerblue);
+}
+.guide-filter-input::placeholder {
+    color: var(--text-dim, #6b7280);
+}
+
+.guide-sidebar-nav {
+    padding: 0 4px;
+}
+
+.guide-nav-category {
+    font-size: var(--text-xs, 0.625rem);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-dim, #6b7280);
+    padding: 14px 12px 4px;
+}
+
+.guide-nav-link {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 12px;
+    font-size: var(--text-lg, 0.875rem);
+    color: var(--activetext, #4b5786);
+    text-decoration: none;
+    border-radius: var(--radius-sm, 6px);
+    transition: background 0.12s, color 0.12s;
+}
+.guide-nav-link:hover {
+    background: var(--surface-2, #f0f0f2);
+    color: var(--normal, #000);
+}
+.guide-nav-link.active {
+    background: var(--accent-muted, rgba(85,158,255,0.08));
+    color: var(--ainfo, dodgerblue);
+}
+.guide-nav-link svg {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+}
+
+/* ── Hero ── */
+.guide-hero {
+    text-align: center;
+    padding: 0 0 2em;
+}
+.guide-hero h1 {
+    font-size: var(--text-11xl, 2rem);
+    font-weight: 700;
+    color: var(--headingtext, #17375e);
+    margin: 0 0 0.25em;
+}
+.guide-hero-sub {
+    font-size: var(--text-3xl, 1.0625rem);
+    color: var(--greytext, #4b5786);
+    margin: 0 0 0.75em;
+}
+.guide-hero-shortcut {
+    font-size: var(--text-base, 0.75rem);
+    color: var(--text-dim, #6b7280);
+}
+.guide-hero-shortcut kbd {
+    display: inline-block;
+    padding: 2px 7px;
+    font-size: var(--text-sm, 0.6875rem);
+    font-family: inherit;
+    background: var(--surface-2, #f0f0f2);
+    border: 1px solid var(--border-moderate, rgba(0,0,0,0.12));
+    border-radius: 4px;
+    color: var(--normal, #000);
+}
+
+/* ── Category Divider ── */
+.guide-category-divider {
+    border-bottom: 1px solid var(--border-subtle, rgba(0,0,0,0.06));
+    padding: 2em 0 0.5em;
+    margin-bottom: 0.5em;
+}
+.guide-category-divider h2 {
+    font-size: var(--text-7xl, 1.375rem);
+    font-weight: 700;
+    color: var(--headingtext, #17375e);
+    margin: 0;
+}
+
+/* ── Sections ── */
+.guide-section {
+    padding: 1.25em 0;
+    border-bottom: 1px solid var(--border-subtle, rgba(0,0,0,0.06));
+    scroll-margin-top: calc(var(--nav-height, 48px) + 20px);
+}
+
+.guide-section-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 0.5em;
+}
+.guide-section-header svg {
+    width: 20px;
+    height: 20px;
+    color: var(--ainfo, dodgerblue);
+    flex-shrink: 0;
+}
+.guide-section-header h3 {
+    font-size: var(--text-5xl, 1.1875rem);
+    font-weight: 600;
+    color: var(--headingtext, #17375e);
+    margin: 0;
+}
+
+.guide-section-desc {
+    font-size: 0.9rem;
+    line-height: 1.6;
+    color: var(--normal, #000);
+    margin-bottom: 0.75em;
+}
+.guide-section-desc code {
+    display: inline-block;
+    padding: 1px 5px;
+    font-size: 0.85em;
+    background: var(--surface-2, #f0f0f2);
+    border-radius: 4px;
+    color: var(--syntax-text, dodgerblue);
+    font-family: var(--font-mono, monospace);
+}
+.guide-section-desc kbd {
+    display: inline-block;
+    padding: 1px 5px;
+    font-size: 0.85em;
+    background: var(--surface-2, #f0f0f2);
+    border: 1px solid var(--border-moderate, rgba(0,0,0,0.12));
+    border-radius: 4px;
+    font-family: inherit;
+    color: var(--normal, #000);
+}
+
+/* ── Tables ── */
+.guide-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.85rem;
+    margin-bottom: 0.75em;
+}
+.guide-table th {
+    text-align: left;
+    font-weight: 600;
+    padding: 6px 10px;
+    border-bottom: 2px solid var(--border-moderate, rgba(0,0,0,0.12));
+    color: var(--headingtext, #17375e);
+}
+.guide-table td {
+    padding: 5px 10px;
+    border-bottom: 1px solid var(--border-subtle, rgba(0,0,0,0.06));
+    color: var(--normal, #000);
+}
+.guide-table tr:hover td {
+    background: var(--surface-1, #fff);
+}
+.guide-table td code {
+    display: inline-block;
+    padding: 1px 5px;
+    font-size: 0.9em;
+    background: var(--surface-2, #f0f0f2);
+    border-radius: 4px;
+    font-family: var(--font-mono, monospace);
+    color: var(--syntax-text, dodgerblue);
+}
+
+/* ── Examples ── */
+.guide-examples {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+.guide-example {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    border-left: 3px solid var(--ainfo, dodgerblue);
+    background: var(--bg-example, var(--surface-1, #fff));
+    border-radius: 0 var(--radius-sm, 6px) var(--radius-sm, 6px) 0;
+    position: relative;
+}
+.guide-example-query {
+    font-family: var(--font-mono, monospace);
+    font-size: var(--text-lg, 0.875rem);
+    color: var(--ainfo, dodgerblue);
+    text-decoration: none;
+    white-space: nowrap;
+}
+.guide-example-query:hover {
+    text-decoration: underline;
+}
+.guide-example-desc {
+    font-size: var(--text-base, 0.75rem);
+    color: var(--greytext, #4b5786);
+}
+.guide-example-copy {
+    margin-left: auto;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--text-dim, #6b7280);
+    padding: 4px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    opacity: 0;
+    transition: opacity 0.15s;
+}
+.guide-example:hover .guide-example-copy {
+    opacity: 1;
+}
+.guide-example-copy:hover {
+    color: var(--ainfo, dodgerblue);
+    background: var(--surface-2, #f0f0f2);
+}
+.guide-example-copy svg {
+    width: 14px;
+    height: 14px;
+}
+
+/* ── Hidden by filter ── */
+.guide-section.hidden-by-filter {
+    display: none;
+}
+.guide-nav-link.hidden-by-filter {
+    display: none;
+}
+.guide-nav-category.hidden-by-filter {
+    display: none;
+}
+.guide-category-divider.hidden-by-filter {
+    display: none;
+}
+
+/* ── Responsive ── */
+@media (max-width: 900px) {
+    .guide-container {
+        flex-direction: column;
+    }
+    .guide-sidebar {
+        width: 100%;
+        position: static;
+        height: auto;
+        overflow-y: visible;
+        padding: 1em 0 0;
+        border-bottom: 1px solid var(--border-subtle, rgba(0,0,0,0.06));
+    }
+    .guide-sidebar-nav {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 2px;
+        padding: 0 4px 8px;
+    }
+    .guide-nav-category {
+        width: 100%;
+        padding: 8px 8px 2px;
+    }
+    .guide-nav-link {
+        padding: 4px 8px;
+        font-size: var(--text-base, 0.75rem);
+    }
+}

--- a/css/guide.css
+++ b/css/guide.css
@@ -9,6 +9,7 @@
     max-width: 1200px;
     margin: 0 auto;
     padding: var(--content-padding-top, 60px) var(--page-gutter, 3vw) 4em;
+    gap: 2em;
 }
 
 /* ── Sidebar ── */
@@ -20,31 +21,34 @@
     height: calc(100vh - var(--nav-height, 48px));
     overflow-y: auto;
     padding: 1em 0 2em;
+    scrollbar-width: thin;
 }
 .guide-sidebar::-webkit-scrollbar { width: 5px; }
-.guide-sidebar::-webkit-scrollbar-thumb { background: var(--surface-3, #e2e4e6); border-radius: 3px; }
+.guide-sidebar::-webkit-scrollbar-thumb { background: var(--surface-3, #ccc); border-radius: 3px; }
 
 .guide-sidebar-header {
-    padding: 0 12px 12px;
+    padding: 0 8px 12px;
 }
 
 .guide-filter-input {
     width: 100%;
     box-sizing: border-box;
     padding: 8px 12px;
-    border-radius: var(--radius-sm, 6px);
+    border-radius: 6px;
     border: 1px solid var(--border-moderate, rgba(0,0,0,0.12));
-    background: var(--surface-1, #fff);
+    background: var(--surface-1, rgba(0,0,0,0.03));
     color: var(--normal, #000);
-    font-size: var(--text-lg, 0.875rem);
+    font-size: 0.85rem;
     font-family: inherit;
     outline: none;
+    transition: border-color 0.15s;
 }
 .guide-filter-input:focus {
-    border-color: var(--ainfo, dodgerblue);
+    border-color: var(--ainfo, #559eff);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--ainfo, #559eff) 20%, transparent);
 }
 .guide-filter-input::placeholder {
-    color: var(--text-dim, #6b7280);
+    color: var(--greytext, #888);
 }
 
 .guide-sidebar-nav {
@@ -52,32 +56,35 @@
 }
 
 .guide-nav-category {
-    font-size: var(--text-xs, 0.625rem);
+    font-size: 0.6rem;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: var(--text-dim, #6b7280);
-    padding: 14px 12px 4px;
+    color: var(--greytext, #888);
+    padding: 16px 8px 4px;
 }
 
 .guide-nav-link {
     display: flex;
     align-items: center;
     gap: 6px;
-    padding: 5px 12px;
-    font-size: var(--text-lg, 0.875rem);
-    color: var(--activetext, #4b5786);
+    padding: 5px 8px;
+    font-size: 0.82rem;
+    color: var(--normal, #000);
     text-decoration: none;
-    border-radius: var(--radius-sm, 6px);
-    transition: background 0.12s, color 0.12s;
+    border-radius: 4px;
+    transition: background 0.1s, color 0.1s;
+    opacity: 0.7;
 }
 .guide-nav-link:hover {
-    background: var(--surface-2, #f0f0f2);
-    color: var(--normal, #000);
+    background: var(--surface-2, rgba(0,0,0,0.06));
+    opacity: 1;
 }
 .guide-nav-link.active {
-    background: var(--accent-muted, rgba(85,158,255,0.08));
-    color: var(--ainfo, dodgerblue);
+    background: color-mix(in srgb, var(--ainfo, #559eff) 12%, transparent);
+    color: var(--ainfo, #559eff);
+    opacity: 1;
+    font-weight: 500;
 }
 .guide-nav-link svg {
     width: 14px;
@@ -88,29 +95,29 @@
 /* ── Hero ── */
 .guide-hero {
     text-align: center;
-    padding: 0 0 2em;
+    padding: 0 0 2.5em;
 }
 .guide-hero h1 {
-    font-size: var(--text-11xl, 2rem);
+    font-size: 2rem;
     font-weight: 700;
     color: var(--headingtext, #17375e);
     margin: 0 0 0.25em;
 }
 .guide-hero-sub {
-    font-size: var(--text-3xl, 1.0625rem);
-    color: var(--greytext, #4b5786);
+    font-size: 1.05rem;
+    color: var(--greytext, #888);
     margin: 0 0 0.75em;
 }
 .guide-hero-shortcut {
-    font-size: var(--text-base, 0.75rem);
-    color: var(--text-dim, #6b7280);
+    font-size: 0.8rem;
+    color: var(--greytext, #888);
 }
 .guide-hero-shortcut kbd {
     display: inline-block;
     padding: 2px 7px;
-    font-size: var(--text-sm, 0.6875rem);
+    font-size: 0.75rem;
     font-family: inherit;
-    background: var(--surface-2, #f0f0f2);
+    background: var(--surface-2, rgba(0,0,0,0.06));
     border: 1px solid var(--border-moderate, rgba(0,0,0,0.12));
     border-radius: 4px;
     color: var(--normal, #000);
@@ -118,99 +125,123 @@
 
 /* ── Category Divider ── */
 .guide-category-divider {
-    border-bottom: 1px solid var(--border-subtle, rgba(0,0,0,0.06));
-    padding: 2em 0 0.5em;
-    margin-bottom: 0.5em;
+    padding: 2.5em 0 0.75em;
+    margin-bottom: 0;
 }
 .guide-category-divider h2 {
-    font-size: var(--text-7xl, 1.375rem);
+    font-size: 1.3rem;
     font-weight: 700;
     color: var(--headingtext, #17375e);
     margin: 0;
+    padding-bottom: 0.5em;
+    border-bottom: 2px solid var(--ainfo, #559eff);
+    display: inline-block;
 }
 
-/* ── Sections ── */
+/* ── Sections (card container) ── */
 .guide-section {
-    padding: 1.25em 0;
-    border-bottom: 1px solid var(--border-subtle, rgba(0,0,0,0.06));
+    background: var(--surface-1, rgba(0,0,0,0.02));
+    border: 1px solid var(--border-subtle, rgba(0,0,0,0.06));
+    border-radius: 10px;
+    padding: 1.25em 1.5em;
+    margin: 1em 0;
     scroll-margin-top: calc(var(--nav-height, 48px) + 20px);
+    transition: border-color 0.15s;
+}
+.guide-section:hover {
+    border-color: var(--border-moderate, rgba(0,0,0,0.12));
 }
 
 .guide-section-header {
     display: flex;
     align-items: center;
-    gap: 8px;
-    margin-bottom: 0.5em;
+    gap: 10px;
+    margin-bottom: 0.75em;
+    padding-bottom: 0.5em;
+    border-bottom: 1px solid var(--border-subtle, rgba(0,0,0,0.06));
 }
 .guide-section-header svg {
-    width: 20px;
-    height: 20px;
-    color: var(--ainfo, dodgerblue);
+    width: 22px;
+    height: 22px;
+    color: var(--ainfo, #559eff);
     flex-shrink: 0;
 }
 .guide-section-header h3 {
-    font-size: var(--text-5xl, 1.1875rem);
+    font-size: 1.1rem;
     font-weight: 600;
     color: var(--headingtext, #17375e);
     margin: 0;
 }
 
 .guide-section-desc {
-    font-size: 0.9rem;
-    line-height: 1.6;
+    font-size: 0.88rem;
+    line-height: 1.65;
     color: var(--normal, #000);
     margin-bottom: 0.75em;
 }
 .guide-section-desc code {
     display: inline-block;
-    padding: 1px 5px;
+    padding: 1px 6px;
     font-size: 0.85em;
-    background: var(--surface-2, #f0f0f2);
+    background: color-mix(in srgb, var(--ainfo, #559eff) 10%, var(--background, #f8f8f8));
+    border: 1px solid color-mix(in srgb, var(--ainfo, #559eff) 20%, transparent);
     border-radius: 4px;
-    color: var(--syntax-text, dodgerblue);
-    font-family: var(--font-mono, monospace);
+    color: var(--ainfo, #559eff);
+    font-family: monospace;
 }
 .guide-section-desc kbd {
     display: inline-block;
-    padding: 1px 5px;
-    font-size: 0.85em;
-    background: var(--surface-2, #f0f0f2);
+    padding: 1px 6px;
+    font-size: 0.82em;
+    background: var(--surface-2, rgba(0,0,0,0.06));
     border: 1px solid var(--border-moderate, rgba(0,0,0,0.12));
     border-radius: 4px;
     font-family: inherit;
     color: var(--normal, #000);
+    box-shadow: 0 1px 0 var(--border-moderate, rgba(0,0,0,0.12));
 }
 
 /* ── Tables ── */
 .guide-table {
     width: 100%;
-    border-collapse: collapse;
+    border-collapse: separate;
+    border-spacing: 0;
     font-size: 0.85rem;
     margin-bottom: 0.75em;
+    border: 1px solid var(--border-subtle, rgba(0,0,0,0.06));
+    border-radius: 8px;
+    overflow: hidden;
 }
 .guide-table th {
     text-align: left;
     font-weight: 600;
-    padding: 6px 10px;
-    border-bottom: 2px solid var(--border-moderate, rgba(0,0,0,0.12));
-    color: var(--headingtext, #17375e);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 8px 12px;
+    background: var(--surface-2, rgba(0,0,0,0.04));
+    color: var(--greytext, #888);
+    border-bottom: 1px solid var(--border-moderate, rgba(0,0,0,0.12));
 }
 .guide-table td {
-    padding: 5px 10px;
-    border-bottom: 1px solid var(--border-subtle, rgba(0,0,0,0.06));
+    padding: 7px 12px;
+    border-bottom: 1px solid var(--border-subtle, rgba(0,0,0,0.04));
     color: var(--normal, #000);
 }
+.guide-table tr:last-child td {
+    border-bottom: none;
+}
 .guide-table tr:hover td {
-    background: var(--surface-1, #fff);
+    background: var(--surface-1, rgba(0,0,0,0.02));
 }
 .guide-table td code {
     display: inline-block;
-    padding: 1px 5px;
-    font-size: 0.9em;
-    background: var(--surface-2, #f0f0f2);
+    padding: 1px 6px;
+    font-size: 0.88em;
+    background: color-mix(in srgb, var(--ainfo, #559eff) 8%, var(--background, #f8f8f8));
     border-radius: 4px;
-    font-family: var(--font-mono, monospace);
-    color: var(--syntax-text, dodgerblue);
+    font-family: monospace;
+    color: var(--ainfo, #559eff);
 }
 
 /* ── Examples ── */
@@ -218,21 +249,27 @@
     display: flex;
     flex-direction: column;
     gap: 6px;
+    margin-top: 0.5em;
 }
 .guide-example {
     display: flex;
     align-items: center;
-    gap: 10px;
-    padding: 8px 12px;
-    border-left: 3px solid var(--ainfo, dodgerblue);
-    background: var(--bg-example, var(--surface-1, #fff));
-    border-radius: 0 var(--radius-sm, 6px) var(--radius-sm, 6px) 0;
+    gap: 12px;
+    padding: 8px 14px;
+    border-left: 3px solid var(--ainfo, #559eff);
+    background: color-mix(in srgb, var(--ainfo, #559eff) 5%, var(--background, #f8f8f8));
+    border-radius: 0 8px 8px 0;
     position: relative;
+    transition: background 0.1s;
+}
+.guide-example:hover {
+    background: color-mix(in srgb, var(--ainfo, #559eff) 10%, var(--background, #f8f8f8));
 }
 .guide-example-query {
-    font-family: var(--font-mono, monospace);
-    font-size: var(--text-lg, 0.875rem);
-    color: var(--ainfo, dodgerblue);
+    font-family: monospace;
+    font-size: 0.88rem;
+    font-weight: 500;
+    color: var(--ainfo, #559eff);
     text-decoration: none;
     white-space: nowrap;
 }
@@ -240,15 +277,16 @@
     text-decoration: underline;
 }
 .guide-example-desc {
-    font-size: var(--text-base, 0.75rem);
-    color: var(--greytext, #4b5786);
+    flex: 1;
+    font-size: 0.78rem;
+    color: var(--greytext, #888);
 }
 .guide-example-copy {
     margin-left: auto;
     background: none;
     border: none;
     cursor: pointer;
-    color: var(--text-dim, #6b7280);
+    color: var(--greytext, #888);
     padding: 4px;
     border-radius: 4px;
     display: flex;
@@ -257,11 +295,12 @@
     transition: opacity 0.15s;
 }
 .guide-example:hover .guide-example-copy {
-    opacity: 1;
+    opacity: 0.6;
 }
 .guide-example-copy:hover {
-    color: var(--ainfo, dodgerblue);
-    background: var(--surface-2, #f0f0f2);
+    opacity: 1 !important;
+    color: var(--ainfo, #559eff);
+    background: var(--surface-2, rgba(0,0,0,0.06));
 }
 .guide-example-copy svg {
     width: 14px;
@@ -269,23 +308,16 @@
 }
 
 /* ── Hidden by filter ── */
-.guide-section.hidden-by-filter {
-    display: none;
-}
-.guide-nav-link.hidden-by-filter {
-    display: none;
-}
-.guide-nav-category.hidden-by-filter {
-    display: none;
-}
-.guide-category-divider.hidden-by-filter {
-    display: none;
-}
+.guide-section.hidden-by-filter { display: none; }
+.guide-nav-link.hidden-by-filter { display: none; }
+.guide-nav-category.hidden-by-filter { display: none; }
+.guide-category-divider.hidden-by-filter { display: none; }
 
 /* ── Responsive ── */
 @media (max-width: 900px) {
     .guide-container {
         flex-direction: column;
+        gap: 0;
     }
     .guide-sidebar {
         width: 100%;
@@ -294,6 +326,7 @@
         overflow-y: visible;
         padding: 1em 0 0;
         border-bottom: 1px solid var(--border-subtle, rgba(0,0,0,0.06));
+        margin-bottom: 1em;
     }
     .guide-sidebar-nav {
         display: flex;
@@ -303,10 +336,13 @@
     }
     .guide-nav-category {
         width: 100%;
-        padding: 8px 8px 2px;
+        padding: 8px 4px 2px;
     }
     .guide-nav-link {
         padding: 4px 8px;
-        font-size: var(--text-base, 0.75rem);
+        font-size: 0.75rem;
+    }
+    .guide-section {
+        padding: 1em;
     }
 }

--- a/css/search.css
+++ b/css/search.css
@@ -877,7 +877,6 @@
 }
 .price-row .price-best {
     color: var(--asuccess);
-    font-weight: 700;
 }
 .price-row .price-warn[data-tooltip]:hover::after {
     content: attr(data-tooltip);

--- a/guide.go
+++ b/guide.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"net/http"
+)
+
+func Guide(w http.ResponseWriter, r *http.Request) {
+	sig := getSignatureFromCookies(r)
+	pageVars := genPageNav("Guide", sig)
+	pageVars.IsMobile = isMobileRequest(r)
+	if pageVars.IsMobile {
+		pageVars.Nav = filterNavForMobile(pageVars.Nav)
+	}
+	render(w, "guide.html", pageVars)
+}

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -37,6 +37,18 @@
         } catch (e) {}
     }
 
+    function recordRecentSearch(query) {
+        if (!query || query.trim().length < 2) return;
+        query = query.trim();
+        var recent = getJSON(RECENT_KEY);
+        recent = recent.filter(function(s) {
+            return (s.q || '').toLowerCase() !== query.toLowerCase();
+        });
+        recent.unshift({ q: query, t: Date.now() });
+        if (recent.length > 15) recent = recent.slice(0, 15);
+        setJSON(RECENT_KEY, recent);
+    }
+
     function escapeHtml(str) {
         var div = document.createElement('div');
         div.textContent = str;
@@ -223,7 +235,7 @@
                     title: r.q,
                     subtitle: 'Recent search',
                     icon: 'clock',
-                    action: function(q) { return function() { window.location.href = '/search?q=' + encodeURIComponent(q); }; }(r.q)
+                    action: function(q) { return function() { recordRecentSearch(q); window.location.href = '/search?q=' + encodeURIComponent(q); }; }(r.q)
                 });
             }
         }
@@ -345,7 +357,7 @@
                     title: cardNames[i],
                     subtitle: 'Search for "' + cardNames[i] + '"',
                     icon: 'search',
-                    action: (function(name) { return function() { window.location.href = '/search?q=' + encodeURIComponent(name); }; })(cardNames[i])
+                    action: (function(name) { return function() { recordRecentSearch(name); window.location.href = '/search?q=' + encodeURIComponent(name); }; })(cardNames[i])
                 });
             }
         }
@@ -430,6 +442,7 @@
                             }
                         }
                         setJSON(SAVED_KEY, all);
+                        recordRecentSearch(cmd.query);
                         window.location.href = '/search?q=' + encodeURIComponent(cmd.query);
                     }; })(s)
                 });

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -635,7 +635,18 @@
                 items = items.concat(savedItems);
             }
         } else {
-            // General search — combine sources
+            // Always offer direct search with full query (supports syntax like s:3ED)
+            if (query) {
+                items.push({
+                    type: 'search',
+                    title: 'Search: ' + query,
+                    subtitle: 'Run full search with syntax support',
+                    icon: 'search',
+                    action: function(q) { return function() { recordRecentSearch(q); window.location.href = '/search?q=' + encodeURIComponent(q); }; }(query)
+                });
+            }
+
+            // General search - combine sources
             var recentItems = getRecentResults(query, 3);
             var cmdItems = getStaticCommands(query);
             var savedItems2 = getSavedResults(query);
@@ -727,17 +738,47 @@
         dialog.appendChild(row);
         saveInput.focus();
 
+        var pendingConflict = null;
+
         saveInput.addEventListener('keydown', function(e) {
             if (e.key === 'Enter' || e.keyCode === 13) {
                 e.preventDefault();
+
+                // If awaiting overwrite confirmation
+                if (pendingConflict) {
+                    var answer = saveInput.value.trim().toLowerCase();
+                    if (answer === 'y' || answer === 'yes') {
+                        saveCommand(pendingConflict.name, pendingConflict.query, true);
+                        removeSaveRow();
+                        input.focus();
+                    } else {
+                        // Cancel - go back to name input
+                        pendingConflict = null;
+                        label.textContent = 'Name:';
+                        saveInput.value = '';
+                        saveInput.placeholder = 'Enter a name for this search...';
+                        saveInput.maxLength = MAX_NAME;
+                    }
+                    return;
+                }
+
                 var name = saveInput.value.trim();
                 if (!name) {
                     showToast('Please enter a name');
                     return;
                 }
-                saveCommand(name, searchInput.value.trim());
-                removeSaveRow();
-                input.focus();
+                var conflict = saveCommand(name, searchInput.value.trim(), false);
+                if (conflict) {
+                    // Show confirmation prompt in the save row
+                    pendingConflict = { name: name, query: searchInput.value.trim() };
+                    label.textContent = '"' + name + '" exists with: ' + conflict.existing.query + ' — Overwrite?';
+                    saveInput.value = '';
+                    saveInput.placeholder = 'y / n';
+                    saveInput.maxLength = 3;
+                } else {
+                    removeSaveRow();
+                    input.focus();
+                }
             } else if (e.key === 'Escape' || e.keyCode === 27) {
                 e.preventDefault();
                 removeSaveRow();
@@ -751,15 +792,42 @@
         if (row) row.parentNode.removeChild(row);
     }
 
-    function saveCommand(name, query) {
+    // Returns null if saved, or a conflict object if confirmation needed
+    function saveCommand(name, query, forceOverwrite) {
         var saved = getJSON(SAVED_KEY);
+
+        // Same query already saved - just update the name silently
+        for (var i = 0; i < saved.length; i++) {
+            if (saved[i].query === query) {
+                saved[i].name = name.substring(0, MAX_NAME);
+                saved[i].lastUsed = Date.now();
+                setJSON(SAVED_KEY, saved);
+                showToast('Updated: ' + name);
+                return null;
+            }
+        }
+
+        // Same name exists with different query - needs confirmation
+        for (var j = 0; j < saved.length; j++) {
+            if (saved[j].name.toLowerCase() === name.toLowerCase()) {
+                if (!forceOverwrite) {
+                    return { existing: saved[j] };
+                }
+                // Overwrite confirmed
+                saved[j].query = query;
+                saved[j].lastUsed = Date.now();
+                setJSON(SAVED_KEY, saved);
+                showToast('Overwritten: ' + name);
+                return null;
+            }
+        }
 
         if (saved.length >= MAX_SAVED) {
             showToast('Maximum ' + MAX_SAVED + ' saved commands reached');
-            return;
+            return null;
         }
 
-        var cmd = {
+        saved.push({
             id: 'cmd_' + Date.now(),
             name: name.substring(0, MAX_NAME),
             query: query,
@@ -768,11 +836,10 @@
             created: Date.now(),
             lastUsed: Date.now(),
             useCount: 0
-        };
-
-        saved.push(cmd);
+        });
         setJSON(SAVED_KEY, saved);
         showToast('Saved: ' + name);
+        return null;
     }
 
     function deleteSavedCommand(savedId) {

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -88,7 +88,7 @@
     footer.className = 'cp-footer';
     footer.innerHTML = '<span><kbd>\u2191\u2193</kbd> Navigate</span>' +
         '<span><kbd>Enter</kbd> Select</span>' +
-        '<span><kbd>?:</kbd> Help</span>' +
+        '<span><kbd>?</kbd> Help</span>' +
         '<span><kbd>Esc</kbd> Close</span>';
 
     dialog.appendChild(inputRow);
@@ -123,7 +123,8 @@
         document.body.style.overflow = 'hidden';
         input.value = '';
         modeIndicator.textContent = '';
-        modeIndicator.style.display = 'none';
+        modeIndicator.className = 'cp-mode-indicator';
+        modeIndicator.removeAttribute('data-mode');
         activeIndex = -1;
         renderDefault();
         input.focus();
@@ -159,14 +160,14 @@
 
     // ── Mode detection ───────────────────────────────────────────────
     function detectMode(val) {
-        if (/^(\?:|help:|syntax:)/i.test(val)) return 'help';
+        if (val.charAt(0) === '?' || /^(help:|syntax:)/i.test(val)) return 'help';
         if (val.charAt(0) === '>') return 'nav';
         if (/^saved:/i.test(val)) return 'saved';
         return 'search';
     }
 
     function stripPrefix(val) {
-        if (/^(\?:|help:|syntax:)/i.test(val)) return val.replace(/^(\?:|help:|syntax:)/i, '').trim();
+        if (/^(\?\s*|help:|syntax:|\?:)/i.test(val)) return val.replace(/^(\?\s*|help:|syntax:|\?:)/i, '').trim();
         if (val.charAt(0) === '>') return val.substring(1).trim();
         if (/^saved:/i.test(val)) return val.replace(/^saved:/i, '').trim();
         return val;
@@ -223,7 +224,7 @@
                     title: r.q,
                     subtitle: 'Recent search',
                     icon: 'clock',
-                    action: function(q) { return function() { window.location.href = '?q=' + encodeURIComponent(q); }; }(r.q)
+                    action: function(q) { return function() { window.location.href = '/search?q=' + encodeURIComponent(q); }; }(r.q)
                 });
             }
         }
@@ -241,7 +242,7 @@
                     title: f.name,
                     subtitle: (f.set ? f.set : '') + (f.number ? ' #' + f.number : ''),
                     icon: 'star',
-                    action: function(q) { return function() { window.location.href = '?q=' + encodeURIComponent(q); }; }(f.query)
+                    action: function(q) { return function() { window.location.href = '/search?q=' + encodeURIComponent(q); }; }(f.query)
                 });
             }
         }
@@ -363,7 +364,7 @@
                     title: cardNames[i],
                     subtitle: 'Search for "' + cardNames[i] + '"',
                     icon: 'search',
-                    action: (function(name) { return function() { window.location.href = '?q=' + encodeURIComponent(name); }; })(cardNames[i])
+                    action: (function(name) { return function() { window.location.href = '/search?q=' + encodeURIComponent(name); }; })(cardNames[i])
                 });
             }
         }
@@ -448,7 +449,7 @@
                             }
                         }
                         setJSON(SAVED_KEY, all);
-                        window.location.href = '?q=' + encodeURIComponent(cmd.query);
+                        window.location.href = '/search?q=' + encodeURIComponent(cmd.query);
                     }; })(s)
                 });
             }
@@ -489,7 +490,7 @@
         for (var i = 0; i < items.length; i++) {
             var item = items[i];
             if (item.type === 'header') {
-                html += '<div class="cp-category">' + escapeHtml(item.title) + '</div>';
+                html += '<div class="cp-category-header">' + escapeHtml(item.title) + '</div>';
                 continue;
             }
 
@@ -510,7 +511,7 @@
                 html += '<span class="cp-result-badge">' + escapeHtml(badgeLabel) + '</span>';
             }
             if (item.type === 'saved') {
-                html += '<button class="cp-delete-btn" data-saved-id="' + escapeHtml(item.savedId) + '" title="Delete">';
+                html += '<button class="cp-result-delete" data-saved-id="' + escapeHtml(item.savedId) + '" title="Delete">';
                 html += '<i data-lucide="trash-2"></i>';
                 html += '</button>';
             }
@@ -538,7 +539,7 @@
             (function(index) {
                 resultEls[index].addEventListener('click', function(e) {
                     // Check if delete button was clicked
-                    var deleteBtn = e.target.closest('.cp-delete-btn');
+                    var deleteBtn = e.target.closest('.cp-result-delete');
                     if (deleteBtn) {
                         e.stopPropagation();
                         var savedId = deleteBtn.getAttribute('data-saved-id');
@@ -584,17 +585,21 @@
 
         // Update mode indicator
         if (mode === 'help') {
-            modeIndicator.textContent = '?:';
-            modeIndicator.style.display = '';
+            modeIndicator.textContent = 'HELP';
+            modeIndicator.setAttribute('data-mode', 'help');
+            modeIndicator.className = 'cp-mode-indicator active';
         } else if (mode === 'nav') {
-            modeIndicator.textContent = '>';
-            modeIndicator.style.display = '';
+            modeIndicator.textContent = 'NAV';
+            modeIndicator.setAttribute('data-mode', 'nav');
+            modeIndicator.className = 'cp-mode-indicator active';
         } else if (mode === 'saved') {
-            modeIndicator.textContent = 'saved:';
-            modeIndicator.style.display = '';
+            modeIndicator.textContent = 'SAVED';
+            modeIndicator.setAttribute('data-mode', 'saved');
+            modeIndicator.className = 'cp-mode-indicator active';
         } else {
             modeIndicator.textContent = '';
-            modeIndicator.style.display = 'none';
+            modeIndicator.className = 'cp-mode-indicator';
+            modeIndicator.removeAttribute('data-mode');
         }
 
         // Empty input → show defaults
@@ -681,7 +686,11 @@
         renderResults(items);
     }
 
-    input.addEventListener('input', handleInput);
+    var inputTimer = null;
+    input.addEventListener('input', function() {
+        if (inputTimer) clearTimeout(inputTimer);
+        inputTimer = setTimeout(handleInput, 80);
+    });
 
     // ── Saved commands ───────────────────────────────────────────────
     function showSaveRow() {

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -462,6 +462,7 @@
         var items = [];
         var recent = getRecentResults(null, 5);
         var favs = getFavoriteResults(null, 3);
+        var saved = getSavedResults(null);
         var nav = getNavResults(null);
 
         if (recent.length > 0) {
@@ -471,6 +472,10 @@
         if (favs.length > 0) {
             items.push({ type: 'header', title: 'Favorites' });
             items = items.concat(favs);
+        }
+        if (saved.length > 0) {
+            items.push({ type: 'header', title: 'Saved Commands' });
+            items = items.concat(saved.slice(0, 3));
         }
         if (nav.length > 0) {
             items.push({ type: 'header', title: 'Pages' });
@@ -633,6 +638,7 @@
             var recentItems = getRecentResults(query, 3);
             var favItems = getFavoriteResults(query, 3);
             var cmdItems = getStaticCommands(query);
+            var savedItems2 = getSavedResults(query);
             var cardItems = getCardResults(query, 5);
             var navItems2 = getNavResults(query);
 
@@ -643,6 +649,10 @@
             if (favItems.length > 0) {
                 items.push({ type: 'header', title: 'Favorites' });
                 items = items.concat(favItems.slice(0, 3));
+            }
+            if (savedItems2.length > 0) {
+                items.push({ type: 'header', title: 'Saved Commands' });
+                items = items.concat(savedItems2.slice(0, 3));
             }
             if (cmdItems.length > 0) {
                 items.push({ type: 'header', title: 'Commands' });

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -18,7 +18,6 @@
 
     // ── localStorage helpers ─────────────────────────────────────────
     var RECENT_KEY = 'mtgban_recent_searches';
-    var FAV_KEY = 'mtgban_favorites';
     var SAVED_KEY = 'mtgban_saved_commands';
     var MAX_SAVED = 50;
     var MAX_NAME = 60;
@@ -225,24 +224,6 @@
                     subtitle: 'Recent search',
                     icon: 'clock',
                     action: function(q) { return function() { window.location.href = '/search?q=' + encodeURIComponent(q); }; }(r.q)
-                });
-            }
-        }
-        return results;
-    }
-
-    function getFavoriteResults(query, limit) {
-        var favs = getJSON(FAV_KEY);
-        var results = [];
-        for (var i = 0; i < favs.length && results.length < limit; i++) {
-            var f = favs[i];
-            if (!query || scoreMatch(query, f.name, null) > 0) {
-                results.push({
-                    type: 'favorite',
-                    title: f.name,
-                    subtitle: (f.set ? f.set : '') + (f.number ? ' #' + f.number : ''),
-                    icon: 'star',
-                    action: function(q) { return function() { window.location.href = '/search?q=' + encodeURIComponent(q); }; }(f.query)
                 });
             }
         }
@@ -461,17 +442,12 @@
     function renderDefault() {
         var items = [];
         var recent = getRecentResults(null, 5);
-        var favs = getFavoriteResults(null, 3);
         var saved = getSavedResults(null);
         var nav = getNavResults(null);
 
         if (recent.length > 0) {
             items.push({ type: 'header', title: 'Recent Searches' });
             items = items.concat(recent);
-        }
-        if (favs.length > 0) {
-            items.push({ type: 'header', title: 'Favorites' });
-            items = items.concat(favs);
         }
         if (saved.length > 0) {
             items.push({ type: 'header', title: 'Saved Commands' });
@@ -511,7 +487,7 @@
             }
             html += '</div>';
             html += '<div class="cp-result-right">';
-            var badgeLabel = item.type === 'recent' ? 'Recent' : item.type === 'favorite' ? 'Favorite' : item.type === 'nav' ? 'Navigate' : item.type === 'card' ? 'Card' : item.type === 'command' ? 'Action' : item.type === 'saved' ? 'Saved' : item.type === 'syntax' ? 'Syntax' : item.type === 'help' ? item.badge || 'Help' : '';
+            var badgeLabel = item.type === 'recent' ? 'Recent' : item.type === 'nav' ? 'Navigate' : item.type === 'card' ? 'Card' : item.type === 'command' ? 'Action' : item.type === 'saved' ? 'Saved' : item.type === 'syntax' ? 'Syntax' : item.type === 'help' ? item.badge || 'Help' : '';
             if (badgeLabel) {
                 html += '<span class="cp-result-badge">' + escapeHtml(badgeLabel) + '</span>';
             }
@@ -636,7 +612,6 @@
         } else {
             // General search — combine sources
             var recentItems = getRecentResults(query, 3);
-            var favItems = getFavoriteResults(query, 3);
             var cmdItems = getStaticCommands(query);
             var savedItems2 = getSavedResults(query);
             var cardItems = getCardResults(query, 5);
@@ -645,10 +620,6 @@
             if (recentItems.length > 0) {
                 items.push({ type: 'header', title: 'Recent Searches' });
                 items = items.concat(recentItems.slice(0, 3));
-            }
-            if (favItems.length > 0) {
-                items.push({ type: 'header', title: 'Favorites' });
-                items = items.concat(favItems.slice(0, 3));
             }
             if (savedItems2.length > 0) {
                 items.push({ type: 'header', title: 'Saved Commands' });

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -1,1 +1,840 @@
-/* Command Palette — placeholder */
+/* Command Palette — keyboard-driven search, navigation, help, and saved commands */
+(function() {
+    'use strict';
+
+    // ── Mobile guard ─────────────────────────────────────────────────
+    if (!window.__BAN_PALETTE || window.innerWidth < 768) return;
+
+    var palette = window.__BAN_PALETTE;
+    var guide = window.__BAN_GUIDE || { sections: [] };
+
+    // ── State ────────────────────────────────────────────────────────
+    var activeIndex = -1;
+    var resultItems = [];
+    var previousFocus = null;
+    var isOpen = false;
+    var cardNames = null;
+    var cardNamesLoading = false;
+
+    // ── localStorage helpers ─────────────────────────────────────────
+    var RECENT_KEY = 'mtgban_recent_searches';
+    var FAV_KEY = 'mtgban_favorites';
+    var SAVED_KEY = 'mtgban_saved_commands';
+    var MAX_SAVED = 50;
+    var MAX_NAME = 60;
+
+    function getJSON(key) {
+        try {
+            var data = localStorage.getItem(key);
+            return data ? JSON.parse(data) : [];
+        } catch (e) {
+            return [];
+        }
+    }
+
+    function setJSON(key, val) {
+        try {
+            localStorage.setItem(key, JSON.stringify(val));
+        } catch (e) {}
+    }
+
+    function escapeHtml(str) {
+        var div = document.createElement('div');
+        div.textContent = str;
+        return div.innerHTML;
+    }
+
+    // ── DOM creation ─────────────────────────────────────────────────
+    var overlay = document.createElement('div');
+    overlay.className = 'cp-overlay';
+    overlay.id = 'cp-overlay';
+
+    var dialog = document.createElement('div');
+    dialog.className = 'cp-dialog';
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('aria-modal', 'true');
+
+    // Input row
+    var inputRow = document.createElement('div');
+    inputRow.className = 'cp-input-row';
+
+    var modeIndicator = document.createElement('span');
+    modeIndicator.className = 'cp-mode-indicator';
+    modeIndicator.id = 'cp-mode';
+
+    var input = document.createElement('input');
+    input.className = 'cp-input';
+    input.id = 'cp-input';
+    input.placeholder = 'Search cards, commands, help...';
+    input.setAttribute('autocomplete', 'off');
+
+    var escKbd = document.createElement('kbd');
+    escKbd.className = 'cp-shortcut';
+    escKbd.textContent = 'ESC';
+
+    inputRow.appendChild(modeIndicator);
+    inputRow.appendChild(input);
+    inputRow.appendChild(escKbd);
+
+    // Results
+    var resultsEl = document.createElement('div');
+    resultsEl.className = 'cp-results';
+    resultsEl.id = 'cp-results';
+    resultsEl.setAttribute('role', 'listbox');
+    resultsEl.setAttribute('aria-label', 'Results');
+
+    // Footer
+    var footer = document.createElement('div');
+    footer.className = 'cp-footer';
+    footer.innerHTML = '<span><kbd>\u2191\u2193</kbd> Navigate</span>' +
+        '<span><kbd>Enter</kbd> Select</span>' +
+        '<span><kbd>?:</kbd> Help</span>' +
+        '<span><kbd>Esc</kbd> Close</span>';
+
+    dialog.appendChild(inputRow);
+    dialog.appendChild(resultsEl);
+    dialog.appendChild(footer);
+    overlay.appendChild(dialog);
+    document.body.appendChild(overlay);
+
+    // Toast
+    var toast = document.createElement('div');
+    toast.className = 'cp-toast';
+    toast.id = 'cp-toast';
+    document.body.appendChild(toast);
+
+    // ── Toast helper ─────────────────────────────────────────────────
+    var toastTimer = null;
+    function showToast(msg) {
+        toast.textContent = msg;
+        toast.classList.add('show');
+        if (toastTimer) clearTimeout(toastTimer);
+        toastTimer = setTimeout(function() {
+            toast.classList.remove('show');
+        }, 2000);
+    }
+
+    // ── Open / Close ─────────────────────────────────────────────────
+    function openPalette() {
+        if (isOpen) return;
+        isOpen = true;
+        previousFocus = document.activeElement;
+        overlay.classList.add('open');
+        document.body.style.overflow = 'hidden';
+        input.value = '';
+        modeIndicator.textContent = '';
+        modeIndicator.style.display = 'none';
+        activeIndex = -1;
+        renderDefault();
+        input.focus();
+
+        // Lazy-load card names on first open
+        if (!cardNames && !cardNamesLoading && typeof fetchNames === 'function') {
+            cardNamesLoading = true;
+            fetchNames('false').then(function(names) {
+                cardNames = names || [];
+                cardNamesLoading = false;
+            }).catch(function() {
+                cardNamesLoading = false;
+            });
+        }
+    }
+
+    function closePalette() {
+        if (!isOpen) return;
+        isOpen = false;
+        overlay.classList.remove('open');
+        document.body.style.overflow = '';
+        removeSaveRow();
+        if (previousFocus) {
+            previousFocus.focus();
+            previousFocus = null;
+        }
+    }
+
+    // ── Click overlay to close ───────────────────────────────────────
+    overlay.addEventListener('click', function(e) {
+        if (e.target === overlay) closePalette();
+    });
+
+    // ── Mode detection ───────────────────────────────────────────────
+    function detectMode(val) {
+        if (/^(\?:|help:|syntax:)/i.test(val)) return 'help';
+        if (val.charAt(0) === '>') return 'nav';
+        if (/^saved:/i.test(val)) return 'saved';
+        return 'search';
+    }
+
+    function stripPrefix(val) {
+        if (/^(\?:|help:|syntax:)/i.test(val)) return val.replace(/^(\?:|help:|syntax:)/i, '').trim();
+        if (val.charAt(0) === '>') return val.substring(1).trim();
+        if (/^saved:/i.test(val)) return val.replace(/^saved:/i, '').trim();
+        return val;
+    }
+
+    // ── Matching algorithm ───────────────────────────────────────────
+    function scoreMatch(query, name, keywords) {
+        var q = query.toLowerCase();
+        var n = name.toLowerCase();
+
+        // Prefix match
+        if (n.indexOf(q) === 0) return 3;
+
+        // Word-boundary match
+        var words = n.split(/[\s\-_]+/);
+        for (var i = 0; i < words.length; i++) {
+            if (words[i].indexOf(q) === 0) return 2;
+        }
+
+        // Substring in name
+        if (n.indexOf(q) >= 0) return 1;
+
+        // Keywords
+        if (keywords) {
+            var kw = keywords;
+            if (typeof kw === 'string') kw = kw.split(/[\s,]+/);
+            for (var j = 0; j < kw.length; j++) {
+                if (kw[j].toLowerCase().indexOf(q) >= 0) return 1;
+            }
+        }
+
+        return 0;
+    }
+
+    // ── Card name matching (mirrors autocomplete.js) ─────────────────
+    function matchCardName(query, name) {
+        var q = query.toUpperCase();
+        if (name.substr(0, query.length).toUpperCase() === q) return true;
+        if (name.normalize('NFD').replace(/[\u0300-\u036f]/g, '').substr(0, query.length).toUpperCase() === q) return true;
+        if (name.replace(/^The /g, '').substr(0, query.length).toUpperCase() === q) return true;
+        if (name.replace(/[^A-Za-z0-9 ]/g, '').substr(0, query.length).toUpperCase() === q) return true;
+        return false;
+    }
+
+    // ── Search sources ───────────────────────────────────────────────
+    function getRecentResults(query, limit) {
+        var recent = getJSON(RECENT_KEY);
+        var results = [];
+        for (var i = 0; i < recent.length && results.length < limit; i++) {
+            var r = recent[i];
+            if (!query || scoreMatch(query, r.q, null) > 0) {
+                results.push({
+                    type: 'recent',
+                    title: r.q,
+                    subtitle: 'Recent search',
+                    icon: 'clock',
+                    action: function(q) { return function() { window.location.href = '?q=' + encodeURIComponent(q); }; }(r.q)
+                });
+            }
+        }
+        return results;
+    }
+
+    function getFavoriteResults(query, limit) {
+        var favs = getJSON(FAV_KEY);
+        var results = [];
+        for (var i = 0; i < favs.length && results.length < limit; i++) {
+            var f = favs[i];
+            if (!query || scoreMatch(query, f.name, null) > 0) {
+                results.push({
+                    type: 'favorite',
+                    title: f.name,
+                    subtitle: (f.set ? f.set : '') + (f.number ? ' #' + f.number : ''),
+                    icon: 'star',
+                    action: function(q) { return function() { window.location.href = '?q=' + encodeURIComponent(q); }; }(f.query)
+                });
+            }
+        }
+        return results;
+    }
+
+    function getNavResults(query) {
+        var nav = palette.nav || [];
+        var results = [];
+        for (var i = 0; i < nav.length; i++) {
+            var n = nav[i];
+            if (!query || scoreMatch(query, n.name, null) > 0) {
+                results.push({
+                    type: 'nav',
+                    title: n.name,
+                    subtitle: 'Navigate to ' + n.name,
+                    icon: n.icon || 'arrow-right',
+                    action: function(link) { return function() { window.location.href = link; }; }(n.link),
+                    score: query ? scoreMatch(query, n.name, null) : 0
+                });
+            }
+        }
+        if (query) {
+            results.sort(function(a, b) { return b.score - a.score; });
+        }
+        return results;
+    }
+
+    function getStaticCommands(query) {
+        var commands = [
+            {
+                name: 'Toggle Theme',
+                icon: 'sun-moon',
+                keywords: ['dark', 'light', 'night', 'day', 'theme', 'mode'],
+                action: function() {
+                    var t = localStorage.getItem('theme') === 'dark' ? 'light' : 'dark';
+                    document.body.classList.toggle('dark-theme', t === 'dark');
+                    document.body.classList.toggle('light-theme', t === 'light');
+                    localStorage.setItem('theme', t);
+                    var toggle = document.getElementById('theme-toggle');
+                    if (toggle) toggle.title = t === 'dark' ? 'Nightbound' : 'Daybound';
+                    closePalette();
+                    showToast('Theme: ' + t);
+                }
+            },
+            {
+                name: 'Random Card',
+                icon: 'shuffle',
+                keywords: ['random', 'surprise', 'lucky'],
+                action: function() { window.location.href = '/random'; }
+            },
+            {
+                name: 'Random Sealed',
+                icon: 'package',
+                keywords: ['random', 'sealed', 'booster', 'pack'],
+                action: function() { window.location.href = '/random?sealed=true'; }
+            },
+            {
+                name: 'Open Guide',
+                icon: 'book-open',
+                keywords: ['guide', 'help', 'documentation', 'syntax'],
+                action: function() { window.location.href = '/guide'; }
+            },
+            {
+                name: 'Copy URL',
+                icon: 'link',
+                keywords: ['copy', 'url', 'link', 'share', 'clipboard'],
+                action: function() {
+                    if (navigator.clipboard) {
+                        navigator.clipboard.writeText(window.location.href).then(function() {
+                            showToast('URL copied to clipboard');
+                        });
+                    } else {
+                        showToast('Clipboard not available');
+                    }
+                    closePalette();
+                }
+            }
+        ];
+
+        // Conditionally add "Save Current Search"
+        var searchInput = document.getElementById('searchbox');
+        if (searchInput && searchInput.value && searchInput.value.trim()) {
+            commands.push({
+                name: 'Save Current Search',
+                icon: 'bookmark-plus',
+                keywords: ['save', 'bookmark', 'store', 'command'],
+                action: function() { showSaveRow(); }
+            });
+        }
+
+        var results = [];
+        for (var i = 0; i < commands.length; i++) {
+            var c = commands[i];
+            if (!query || scoreMatch(query, c.name, c.keywords) > 0) {
+                results.push({
+                    type: 'command',
+                    title: c.name,
+                    subtitle: '',
+                    icon: c.icon,
+                    action: c.action,
+                    score: query ? scoreMatch(query, c.name, c.keywords) : 0
+                });
+            }
+        }
+        if (query) {
+            results.sort(function(a, b) { return b.score - a.score; });
+        }
+        return results;
+    }
+
+    function getCardResults(query, limit) {
+        if (!cardNames || !query || query.length < 2) return [];
+        var results = [];
+        for (var i = 0; i < cardNames.length && results.length < limit; i++) {
+            if (matchCardName(query, cardNames[i])) {
+                results.push({
+                    type: 'card',
+                    title: cardNames[i],
+                    subtitle: 'Search for "' + cardNames[i] + '"',
+                    icon: 'search',
+                    action: (function(name) { return function() { window.location.href = '?q=' + encodeURIComponent(name); }; })(cardNames[i])
+                });
+            }
+        }
+        return results;
+    }
+
+    function getHelpResults(query) {
+        var sections = guide.sections || [];
+        var results = [];
+        for (var i = 0; i < sections.length && results.length < 10; i++) {
+            var s = sections[i];
+            var match = !query || scoreMatch(query, s.title, s.keywords) > 0;
+            if (!match && s.summary) {
+                match = scoreMatch(query, s.summary, null) > 0;
+            }
+            if (!match && s.snippets) {
+                for (var j = 0; j < s.snippets.length; j++) {
+                    if (s.snippets[j].toLowerCase().indexOf(query.toLowerCase()) >= 0) {
+                        match = true;
+                        break;
+                    }
+                }
+            }
+            if (match) {
+                var isSyntax = s.category === 'Search Syntax';
+                var subtitle = s.summary || '';
+                var snippetText = '';
+                if (isSyntax && s.snippets && s.snippets.length > 0) {
+                    snippetText = s.snippets.join('  ');
+                }
+                results.push({
+                    type: 'help',
+                    title: s.title,
+                    subtitle: subtitle,
+                    snippets: snippetText,
+                    icon: s.icon || 'help-circle',
+                    isSyntax: isSyntax,
+                    sectionId: s.id,
+                    action: isSyntax
+                        ? (function(snip) { return function() {
+                            if (navigator.clipboard && snip) {
+                                navigator.clipboard.writeText(snip).then(function() {
+                                    showToast('Copied: ' + snip);
+                                });
+                            }
+                            closePalette();
+                        }; })(s.snippets && s.snippets[0] ? s.snippets[0] : '')
+                        : (function(id) { return function() { window.location.href = '/guide#' + id; }; })(s.id),
+                    altAction: isSyntax
+                        ? (function(id) { return function() { window.location.href = '/guide#' + id; }; })(s.id)
+                        : null,
+                    score: query ? scoreMatch(query, s.title, s.keywords) : 0
+                });
+            }
+        }
+        if (query) {
+            results.sort(function(a, b) { return b.score - a.score; });
+        }
+        return results;
+    }
+
+    function getSavedResults(query) {
+        var saved = getJSON(SAVED_KEY);
+        var results = [];
+        for (var i = 0; i < saved.length; i++) {
+            var s = saved[i];
+            if (!query || scoreMatch(query, s.name, s.query) > 0) {
+                results.push({
+                    type: 'saved',
+                    title: s.name,
+                    subtitle: s.query,
+                    icon: s.icon || 'bookmark',
+                    savedId: s.id,
+                    action: (function(cmd) { return function() {
+                        // Update usage tracking
+                        var all = getJSON(SAVED_KEY);
+                        for (var k = 0; k < all.length; k++) {
+                            if (all[k].id === cmd.id) {
+                                all[k].lastUsed = Date.now();
+                                all[k].useCount = (all[k].useCount || 0) + 1;
+                                break;
+                            }
+                        }
+                        setJSON(SAVED_KEY, all);
+                        window.location.href = '?q=' + encodeURIComponent(cmd.query);
+                    }; })(s)
+                });
+            }
+        }
+        return results;
+    }
+
+    // ── Default results ──────────────────────────────────────────────
+    function renderDefault() {
+        var items = [];
+        var recent = getRecentResults(null, 5);
+        var favs = getFavoriteResults(null, 3);
+        var nav = getNavResults(null);
+
+        if (recent.length > 0) {
+            items.push({ type: 'header', title: 'Recent Searches' });
+            items = items.concat(recent);
+        }
+        if (favs.length > 0) {
+            items.push({ type: 'header', title: 'Favorites' });
+            items = items.concat(favs);
+        }
+        if (nav.length > 0) {
+            items.push({ type: 'header', title: 'Pages' });
+            items = items.concat(nav);
+        }
+
+        renderResults(items);
+    }
+
+    // ── Render results ───────────────────────────────────────────────
+    function renderResults(items) {
+        resultItems = [];
+        activeIndex = -1;
+        var html = '';
+        var idx = 0;
+
+        for (var i = 0; i < items.length; i++) {
+            var item = items[i];
+            if (item.type === 'header') {
+                html += '<div class="cp-category">' + escapeHtml(item.title) + '</div>';
+                continue;
+            }
+
+            var activeClass = idx === 0 ? ' active' : '';
+            html += '<div class="cp-result' + activeClass + '" role="option" data-index="' + idx + '">';
+            html += '<div class="cp-result-icon"><i data-lucide="' + escapeHtml(item.icon || 'search') + '"></i></div>';
+            html += '<div class="cp-result-body">';
+            html += '<div class="cp-result-title">' + escapeHtml(item.title) + '</div>';
+            if (item.snippets) {
+                html += '<div class="cp-result-inline">' + escapeHtml(item.snippets) + '</div>';
+            } else if (item.subtitle) {
+                html += '<div class="cp-result-subtitle">' + escapeHtml(item.subtitle) + '</div>';
+            }
+            html += '</div>';
+            html += '<div class="cp-result-right">';
+            if (item.type === 'saved') {
+                html += '<button class="cp-delete-btn" data-saved-id="' + escapeHtml(item.savedId) + '" title="Delete">';
+                html += '<i data-lucide="trash-2"></i>';
+                html += '</button>';
+            }
+            html += '</div>';
+            html += '</div>';
+
+            resultItems.push(item);
+            idx++;
+        }
+
+        resultsEl.innerHTML = html;
+
+        if (idx > 0) {
+            activeIndex = 0;
+        }
+
+        // Render Lucide icons
+        if (typeof lucide !== 'undefined' && lucide.createIcons) {
+            lucide.createIcons({ nodes: resultsEl.querySelectorAll('[data-lucide]') });
+        }
+
+        // Bind click handlers
+        var resultEls = resultsEl.querySelectorAll('.cp-result');
+        for (var r = 0; r < resultEls.length; r++) {
+            (function(index) {
+                resultEls[index].addEventListener('click', function(e) {
+                    // Check if delete button was clicked
+                    var deleteBtn = e.target.closest('.cp-delete-btn');
+                    if (deleteBtn) {
+                        e.stopPropagation();
+                        var savedId = deleteBtn.getAttribute('data-saved-id');
+                        deleteSavedCommand(savedId);
+                        return;
+                    }
+                    activeIndex = index;
+                    executeResult(false);
+                });
+            })(r);
+        }
+    }
+
+    // ── Navigation helpers ───────────────────────────────────────────
+    function setActive(index) {
+        var els = resultsEl.querySelectorAll('.cp-result');
+        for (var i = 0; i < els.length; i++) {
+            els[i].classList.remove('active');
+        }
+        if (index >= 0 && index < els.length) {
+            els[index].classList.add('active');
+            // Scroll into view
+            els[index].scrollIntoView({ block: 'nearest' });
+        }
+        activeIndex = index;
+    }
+
+    function executeResult(shiftKey) {
+        if (activeIndex < 0 || activeIndex >= resultItems.length) return;
+        var item = resultItems[activeIndex];
+        if (shiftKey && item.altAction) {
+            item.altAction();
+        } else if (item.action) {
+            item.action();
+        }
+    }
+
+    // ── Search dispatcher ────────────────────────────────────────────
+    function handleInput() {
+        var raw = input.value;
+        var mode = detectMode(raw);
+        var query = stripPrefix(raw).trim();
+
+        // Update mode indicator
+        if (mode === 'help') {
+            modeIndicator.textContent = '?:';
+            modeIndicator.style.display = '';
+        } else if (mode === 'nav') {
+            modeIndicator.textContent = '>';
+            modeIndicator.style.display = '';
+        } else if (mode === 'saved') {
+            modeIndicator.textContent = 'saved:';
+            modeIndicator.style.display = '';
+        } else {
+            modeIndicator.textContent = '';
+            modeIndicator.style.display = 'none';
+        }
+
+        // Empty input → show defaults
+        if (!raw.trim()) {
+            renderDefault();
+            return;
+        }
+
+        var items = [];
+
+        if (mode === 'help') {
+            var helpItems = getHelpResults(query);
+            if (helpItems.length > 0) {
+                items.push({ type: 'header', title: 'Help' });
+                items = items.concat(helpItems);
+            }
+        } else if (mode === 'nav') {
+            var navItems = getNavResults(query);
+            if (navItems.length > 0) {
+                items.push({ type: 'header', title: 'Pages' });
+                items = items.concat(navItems);
+            }
+        } else if (mode === 'saved') {
+            var savedItems = getSavedResults(query);
+            if (savedItems.length > 0) {
+                items.push({ type: 'header', title: 'Saved Commands' });
+                items = items.concat(savedItems);
+            }
+        } else {
+            // General search — combine sources
+            var recentItems = getRecentResults(query, 3);
+            var favItems = getFavoriteResults(query, 3);
+            var cmdItems = getStaticCommands(query);
+            var cardItems = getCardResults(query, 5);
+            var navItems2 = getNavResults(query);
+
+            if (recentItems.length > 0) {
+                items.push({ type: 'header', title: 'Recent Searches' });
+                items = items.concat(recentItems.slice(0, 3));
+            }
+            if (favItems.length > 0) {
+                items.push({ type: 'header', title: 'Favorites' });
+                items = items.concat(favItems.slice(0, 3));
+            }
+            if (cmdItems.length > 0) {
+                items.push({ type: 'header', title: 'Commands' });
+                items = items.concat(cmdItems.slice(0, 3));
+            }
+            if (cardItems.length > 0) {
+                items.push({ type: 'header', title: 'Cards' });
+                items = items.concat(cardItems);
+            }
+            if (navItems2.length > 0) {
+                items.push({ type: 'header', title: 'Pages' });
+                items = items.concat(navItems2.slice(0, 3));
+            }
+        }
+
+        renderResults(items);
+    }
+
+    input.addEventListener('input', handleInput);
+
+    // ── Saved commands ───────────────────────────────────────────────
+    function showSaveRow() {
+        removeSaveRow();
+
+        var searchInput = document.getElementById('searchbox');
+        if (!searchInput || !searchInput.value || !searchInput.value.trim()) {
+            showToast('No search to save');
+            return;
+        }
+
+        var row = document.createElement('div');
+        row.className = 'cp-save-row';
+        row.id = 'cp-save-row';
+
+        var label = document.createElement('span');
+        label.className = 'cp-save-label';
+        label.textContent = 'Name:';
+
+        var saveInput = document.createElement('input');
+        saveInput.className = 'cp-save-input';
+        saveInput.id = 'cp-save-input';
+        saveInput.placeholder = 'Enter a name for this search...';
+        saveInput.maxLength = MAX_NAME;
+
+        row.appendChild(label);
+        row.appendChild(saveInput);
+        dialog.appendChild(row);
+        saveInput.focus();
+
+        saveInput.addEventListener('keydown', function(e) {
+            if (e.key === 'Enter' || e.keyCode === 13) {
+                e.preventDefault();
+                var name = saveInput.value.trim();
+                if (!name) {
+                    showToast('Please enter a name');
+                    return;
+                }
+                saveCommand(name, searchInput.value.trim());
+                removeSaveRow();
+                input.focus();
+            } else if (e.key === 'Escape' || e.keyCode === 27) {
+                e.preventDefault();
+                removeSaveRow();
+                input.focus();
+            }
+        });
+    }
+
+    function removeSaveRow() {
+        var row = document.getElementById('cp-save-row');
+        if (row) row.parentNode.removeChild(row);
+    }
+
+    function saveCommand(name, query) {
+        var saved = getJSON(SAVED_KEY);
+
+        if (saved.length >= MAX_SAVED) {
+            showToast('Maximum ' + MAX_SAVED + ' saved commands reached');
+            return;
+        }
+
+        var cmd = {
+            id: 'cmd_' + Date.now(),
+            name: name.substring(0, MAX_NAME),
+            query: query,
+            icon: 'bookmark',
+            userEmail: palette.user || '',
+            created: Date.now(),
+            lastUsed: Date.now(),
+            useCount: 0
+        };
+
+        saved.push(cmd);
+        setJSON(SAVED_KEY, saved);
+        showToast('Saved: ' + name);
+    }
+
+    function deleteSavedCommand(savedId) {
+        var saved = getJSON(SAVED_KEY);
+        var found = false;
+        for (var i = 0; i < saved.length; i++) {
+            if (saved[i].id === savedId) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) return;
+
+        // Simple confirmation
+        saved = saved.filter(function(s) { return s.id !== savedId; });
+        setJSON(SAVED_KEY, saved);
+        showToast('Command deleted');
+
+        // Re-render current results
+        handleInput();
+    }
+
+    // ── Keyboard: global ─────────────────────────────────────────────
+    document.addEventListener('keydown', function(e) {
+        // Ctrl/Cmd+K to toggle
+        if ((e.ctrlKey || e.metaKey) && (e.key === 'k' || e.keyCode === 75)) {
+            e.preventDefault();
+            if (isOpen) {
+                closePalette();
+            } else {
+                openPalette();
+            }
+            return;
+        }
+
+        // "/" when no input focused
+        if (e.key === '/' && !isOpen) {
+            var tag = document.activeElement ? document.activeElement.tagName.toLowerCase() : '';
+            var isInput = tag === 'input' || tag === 'textarea' || tag === 'select';
+            var isEditable = document.activeElement && document.activeElement.isContentEditable;
+            if (!isInput && !isEditable) {
+                e.preventDefault();
+                openPalette();
+                return;
+            }
+        }
+    });
+
+    // ── Keyboard: internal (palette open) ────────────────────────────
+    input.addEventListener('keydown', function(e) {
+        var key = e.key || '';
+        var code = e.keyCode || 0;
+
+        // Arrow down
+        if (key === 'ArrowDown' || code === 40) {
+            e.preventDefault();
+            if (resultItems.length === 0) return;
+            var next = activeIndex + 1;
+            if (next >= resultItems.length) next = 0;
+            setActive(next);
+            return;
+        }
+
+        // Arrow up
+        if (key === 'ArrowUp' || code === 38) {
+            e.preventDefault();
+            if (resultItems.length === 0) return;
+            var prev = activeIndex - 1;
+            if (prev < 0) prev = resultItems.length - 1;
+            setActive(prev);
+            return;
+        }
+
+        // Enter
+        if (key === 'Enter' || code === 13) {
+            e.preventDefault();
+            executeResult(e.shiftKey);
+            return;
+        }
+
+        // Escape
+        if (key === 'Escape' || code === 27) {
+            e.preventDefault();
+            closePalette();
+            return;
+        }
+
+        // Ctrl/Cmd+S — save current search
+        if ((e.ctrlKey || e.metaKey) && (key === 's' || code === 83)) {
+            e.preventDefault();
+            showSaveRow();
+            return;
+        }
+    });
+
+    // Also handle Escape when save input is focused
+    dialog.addEventListener('keydown', function(e) {
+        if ((e.key === 'Escape' || e.keyCode === 27) && e.target.id !== 'cp-input') {
+            e.preventDefault();
+            if (document.getElementById('cp-save-row')) {
+                removeSaveRow();
+                input.focus();
+            } else {
+                closePalette();
+            }
+        }
+    });
+
+})();

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -49,6 +49,17 @@
         setJSON(RECENT_KEY, recent);
     }
 
+    // Check if a section is accessible based on nav permissions
+    var navNames = {};
+    var nav = PALETTE.nav || [];
+    for (var ni = 0; ni < nav.length; ni++) {
+        navNames[nav[ni].name] = true;
+    }
+    function isSectionAllowed(section) {
+        if (!section.requiresNav) return true;
+        return !!navNames[section.requiresNav];
+    }
+
     function escapeHtml(str) {
         var div = document.createElement('div');
         div.textContent = str;
@@ -369,6 +380,7 @@
         var results = [];
         for (var i = 0; i < sections.length && results.length < 10; i++) {
             var s = sections[i];
+            if (!isSectionAllowed(s)) continue;
             var match = !query || scoreMatch(query, s.title, s.keywords) > 0;
             if (!match && s.summary) {
                 match = scoreMatch(query, s.summary, null) > 0;

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -258,7 +258,7 @@
                     type: 'nav',
                     title: n.name,
                     subtitle: 'Navigate to ' + n.name,
-                    icon: n.icon || 'arrow-right',
+                    icon: n.icon || 'compass',
                     action: function(link) { return function() { window.location.href = link; }; }(n.link),
                     score: query ? scoreMatch(query, n.name, null) : 0
                 });
@@ -274,7 +274,7 @@
         var commands = [
             {
                 name: 'Toggle Theme',
-                icon: 'sun-moon',
+                icon: (localStorage.getItem('theme') === 'dark') ? 'sun' : 'moon',
                 keywords: ['dark', 'light', 'night', 'day', 'theme', 'mode'],
                 action: function() {
                     var t = localStorage.getItem('theme') === 'dark' ? 'light' : 'dark';
@@ -289,7 +289,7 @@
             },
             {
                 name: 'Random Card',
-                icon: 'shuffle',
+                icon: 'dice-5',
                 keywords: ['random', 'surprise', 'lucky'],
                 action: function() { window.location.href = '/random'; }
             },
@@ -297,7 +297,7 @@
                 name: 'Random Sealed',
                 icon: 'package',
                 keywords: ['random', 'sealed', 'booster', 'pack'],
-                action: function() { window.location.href = '/random?sealed=true'; }
+                action: function() { window.location.href = '/randomsealed'; }
             },
             {
                 name: 'Open Guide',
@@ -306,7 +306,7 @@
                 action: function() { window.location.href = '/guide'; }
             },
             {
-                name: 'Copy URL',
+                name: 'Copy Page URL',
                 icon: 'link',
                 keywords: ['copy', 'url', 'link', 'share', 'clipboard'],
                 action: function() {
@@ -505,6 +505,10 @@
             }
             html += '</div>';
             html += '<div class="cp-result-right">';
+            var badgeLabel = item.type === 'recent' ? 'Recent' : item.type === 'favorite' ? 'Favorite' : item.type === 'nav' ? 'Navigate' : item.type === 'card' ? 'Card' : item.type === 'command' ? 'Action' : item.type === 'saved' ? 'Saved' : item.type === 'syntax' ? 'Syntax' : item.type === 'help' ? item.badge || 'Help' : '';
+            if (badgeLabel) {
+                html += '<span class="cp-result-badge">' + escapeHtml(badgeLabel) + '</span>';
+            }
             if (item.type === 'saved') {
                 html += '<button class="cp-delete-btn" data-saved-id="' + escapeHtml(item.savedId) + '" title="Delete">';
                 html += '<i data-lucide="trash-2"></i>';
@@ -649,6 +653,31 @@
             }
         }
 
+        // Enforce global 10-item cap (excluding headers)
+        var nonHeaders = [];
+        var headers = [];
+        for (var x = 0; x < items.length; x++) {
+            if (items[x].type === 'header') {
+                headers.push({ item: items[x], nextIndex: nonHeaders.length });
+            } else {
+                nonHeaders.push(items[x]);
+            }
+        }
+        if (nonHeaders.length > 10) {
+            nonHeaders = nonHeaders.slice(0, 10);
+        }
+        // Rebuild with headers only for items that survived the cap
+        var capped = [];
+        var hi = 0;
+        for (var y = 0; y < nonHeaders.length; y++) {
+            while (hi < headers.length && headers[hi].nextIndex <= y) {
+                capped.push(headers[hi].item);
+                hi++;
+            }
+            capped.push(nonHeaders[y]);
+        }
+        items = capped;
+
         renderResults(items);
     }
 
@@ -777,6 +806,14 @@
         }
     });
 
+    // ── Focus trap on dialog level ─────────────────────────────────────
+    dialog.addEventListener('keydown', function(e) {
+        if ((e.key === 'Tab' || e.keyCode === 9) && e.target !== input) {
+            e.preventDefault();
+            input.focus();
+        }
+    });
+
     // ── Keyboard: internal (palette open) ────────────────────────────
     input.addEventListener('keydown', function(e) {
         var key = e.key || '';
@@ -820,6 +857,13 @@
         if ((e.ctrlKey || e.metaKey) && (key === 's' || code === 83)) {
             e.preventDefault();
             showSaveRow();
+            return;
+        }
+
+        // Focus trap — Tab cycles within palette
+        if (key === 'Tab' || code === 9) {
+            e.preventDefault();
+            input.focus();
             return;
         }
     });

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -51,7 +51,7 @@
 
     // Check if a section is accessible based on nav permissions
     var navNames = {};
-    var nav = PALETTE.nav || [];
+    var nav = palette.nav || [];
     for (var ni = 0; ni < nav.length; ni++) {
         navNames[nav[ni].name] = true;
     }

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -1,0 +1,1 @@
+/* Command Palette — placeholder */

--- a/js/guide-data.js
+++ b/js/guide-data.js
@@ -37,14 +37,14 @@ window.__BAN_GUIDE = {
             title: 'Saved Commands',
             icon: 'bookmark',
             summary: 'Save, manage, and reuse your most-used search queries from the palette.',
-            snippets: ['saved:', 'Ctrl+S to save'],
+            snippets: ['saved:'],
             keywords: ['saved', 'bookmark', 'favorite', 'command', 'recall', 'reuse', 'store', 'manage', 'delete'],
             content: {
-                description: 'Any search query can be saved as a named command for quick reuse. To save the current query, press <code>Ctrl+S</code> (or use the save icon in the search bar). Saved commands appear in the palette under the <code>saved:</code> prefix.<br><br>To manage saved commands, open the palette and type <code>saved:</code> — you can rename, delete, or run any entry from there.',
+                description: 'Any search query can be saved as a named command for quick reuse. On a search results page, open the palette and select <strong>Save Current Search</strong>, or press <code>Ctrl+S</code> / <code>Cmd+S</code> while the palette is open. You will be prompted to name the command.<br><br>Saved commands appear in the palette by default and can be filtered with the <code>saved:</code> prefix. Hover over a saved command to reveal a delete button.',
                 table: [
-                    { value: 'Ctrl+S', short: 'Save current search as a command' },
-                    { value: 'saved:', short: 'Browse saved commands in palette' },
-                    { value: 'Delete key', short: 'Delete highlighted saved command' }
+                    { value: 'Save Current Search', short: 'Palette command (appears on search results pages)' },
+                    { value: 'Ctrl+S / Cmd+S', short: 'Save palette input as a command (while palette is open)' },
+                    { value: 'saved:', short: 'Browse saved commands in palette' }
                 ],
                 examples: [
                     { query: 'saved:fetchlands', desc: 'Run the "fetchlands" saved search' },

--- a/js/guide-data.js
+++ b/js/guide-data.js
@@ -11,20 +11,20 @@ window.__BAN_GUIDE = {
             category: 'Command Palette',
             title: 'Getting Started',
             icon: 'terminal',
-            summary: 'Open the command palette with Ctrl+K / Cmd+K or type / in the search box.',
-            snippets: ['Ctrl+K', 'Cmd+K', '?:', '>'],
+            summary: 'Open the command palette with Ctrl+K / Cmd+K or / when no input is focused',
+            snippets: ['Ctrl+K', 'Cmd+K', '?', '>'],
             keywords: ['palette', 'keyboard', 'shortcut', 'command', 'help', 'search', 'open', 'ctrl k', 'cmd k', 'slash', 'modes'],
             content: {
-                description: 'The command palette gives you fast keyboard-driven access to search syntax help and site navigation. Open it with <code>Ctrl+K</code> (Windows/Linux) or <code>Cmd+K</code> (Mac), or by typing <code>/</code> anywhere in the main search box.<br><br>Once open, you can switch modes using prefixes:<br><code>?:</code> — inline syntax help<br><code>&gt;</code> — navigate to a page<br><code>saved:</code> — recall a saved search command',
+                description: 'The command palette gives you fast keyboard-driven access to search syntax help and site navigation. Open it with <code>Ctrl+K</code> (Windows/Linux) or <code>Cmd+K</code> (Mac), or by pressing <code>/</code> when no input field is focused.<br><br>Once open, you can switch modes using prefixes:<br><code>?</code> — inline syntax help<br><code>&gt;</code> — navigate to a page<br><code>saved:</code> — recall a saved search command',
                 table: [
                     { value: 'Ctrl+K / Cmd+K', short: 'Open palette from anywhere' },
-                    { value: '/', short: 'Open palette from search box' },
-                    { value: '?:', short: 'Show inline syntax reference' },
+                    { value: '/', short: 'Open palette when no input is focused' },
+                    { value: '?', short: 'Show inline syntax reference' },
                     { value: '>', short: 'Navigate to a site page' },
                     { value: 'saved:', short: 'Access saved search commands' }
                 ],
                 examples: [
-                    { query: '?:rarity', desc: 'Show rarity syntax help inline' },
+                    { query: '? rarity', desc: 'Show rarity syntax help inline' },
                     { query: '>newspaper', desc: 'Navigate to the Newspaper page' },
                     { query: 'saved:my list', desc: 'Run a saved search command' }
                 ]

--- a/js/guide-data.js
+++ b/js/guide-data.js
@@ -545,6 +545,7 @@ window.__BAN_GUIDE = {
         {
             id: 'feature-newspaper',
             category: 'Features',
+            requiresNav: 'Newspaper',
             title: 'Newspaper',
             icon: 'newspaper',
             summary: 'Daily Spike scores, buylist changes, seller count trends, SYP list, and archive.',
@@ -563,6 +564,7 @@ window.__BAN_GUIDE = {
         {
             id: 'feature-sleepers',
             category: 'Features',
+            requiresNav: 'Sleepers',
             title: 'Sleepers',
             icon: 'moon',
             summary: 'Discover undervalued cards with bulk, reprint, mismatch, and gap analysis across tiers.',
@@ -578,6 +580,7 @@ window.__BAN_GUIDE = {
         {
             id: 'feature-upload',
             category: 'Features',
+            requiresNav: 'Upload',
             title: 'Upload & Optimize',
             icon: 'upload',
             summary: 'Upload a collection (CSV, Excel, Moxfield, Deckbox) and optimize across buylist vendors.',
@@ -593,6 +596,7 @@ window.__BAN_GUIDE = {
         {
             id: 'feature-arbitrage',
             category: 'Features',
+            requiresNav: 'Arbitrage',
             title: 'Arbitrage',
             icon: 'trending-up',
             summary: 'Find price gaps between retail and buylist; filter by condition, foil, rarity, and more.',

--- a/js/guide-data.js
+++ b/js/guide-data.js
@@ -1,2 +1,629 @@
-/* Guide Data — placeholder */
-window.__BAN_GUIDE = { sections: [] };
+/* Guide Data — Shared Content Registry
+ * Single source of truth for the command palette and /guide page.
+ */
+window.__BAN_GUIDE = {
+    sections: [
+
+        // ─── Command Palette ──────────────────────────────────────────────
+
+        {
+            id: 'palette',
+            category: 'Command Palette',
+            title: 'Getting Started',
+            icon: 'terminal',
+            summary: 'Open the command palette with Ctrl+K / Cmd+K or type / in the search box.',
+            snippets: ['Ctrl+K', 'Cmd+K', '?:', '>'],
+            keywords: ['palette', 'keyboard', 'shortcut', 'command', 'help', 'search', 'open', 'ctrl k', 'cmd k', 'slash', 'modes'],
+            content: {
+                description: 'The command palette gives you fast keyboard-driven access to search syntax help and site navigation. Open it with <code>Ctrl+K</code> (Windows/Linux) or <code>Cmd+K</code> (Mac), or by typing <code>/</code> anywhere in the main search box.<br><br>Once open, you can switch modes using prefixes:<br><code>?:</code> — inline syntax help<br><code>&gt;</code> — navigate to a page<br><code>saved:</code> — recall a saved search command',
+                table: [
+                    { value: 'Ctrl+K / Cmd+K', short: 'Open palette from anywhere' },
+                    { value: '/', short: 'Open palette from search box' },
+                    { value: '?:', short: 'Show inline syntax reference' },
+                    { value: '>', short: 'Navigate to a site page' },
+                    { value: 'saved:', short: 'Access saved search commands' }
+                ],
+                examples: [
+                    { query: '?:rarity', desc: 'Show rarity syntax help inline' },
+                    { query: '>newspaper', desc: 'Navigate to the Newspaper page' },
+                    { query: 'saved:my list', desc: 'Run a saved search command' }
+                ]
+            }
+        },
+
+        {
+            id: 'saved-commands',
+            category: 'Command Palette',
+            title: 'Saved Commands',
+            icon: 'bookmark',
+            summary: 'Save, manage, and reuse your most-used search queries from the palette.',
+            snippets: ['saved:', 'Ctrl+S to save'],
+            keywords: ['saved', 'bookmark', 'favorite', 'command', 'recall', 'reuse', 'store', 'manage', 'delete'],
+            content: {
+                description: 'Any search query can be saved as a named command for quick reuse. To save the current query, press <code>Ctrl+S</code> (or use the save icon in the search bar). Saved commands appear in the palette under the <code>saved:</code> prefix.<br><br>To manage saved commands, open the palette and type <code>saved:</code> — you can rename, delete, or run any entry from there.',
+                table: [
+                    { value: 'Ctrl+S', short: 'Save current search as a command' },
+                    { value: 'saved:', short: 'Browse saved commands in palette' },
+                    { value: 'Delete key', short: 'Delete highlighted saved command' }
+                ],
+                examples: [
+                    { query: 'saved:fetchlands', desc: 'Run the "fetchlands" saved search' },
+                    { query: 'saved:', desc: 'Browse all saved commands' }
+                ]
+            }
+        },
+
+        // ─── Search Syntax ────────────────────────────────────────────────
+
+        {
+            id: 'basic-syntax',
+            category: 'Search Syntax',
+            title: 'Basic Syntax',
+            icon: 'text-cursor-input',
+            summary: 'Card names, Pricefall bot notation, suffix shortcuts (* foil, & nonfoil, ~ etched).',
+            snippets: ['name|set|number|finish', 'Sol Ring*', 'Sheoldred (Showcase)', 'r:rare,mythic'],
+            keywords: ['basic', 'name', 'pricefall', 'notation', 'suffix', 'foil', 'nonfoil', 'etched', 'altfoil', 'finish', 'comma', 'multiple', 'syntax', 'search'],
+            content: {
+                description: 'Start typing a card name and an autocomplete dropdown will appear. You can also use the Pricefall bot notation: <code>name[|code[|number[|finish]]]</code>.<br><br>Human-readable tags are also supported — for example, appending <code>(Extended Art)</code> or <code>(Showcase)</code> to a card name will filter to those versions (does not work in regexp mode).<br><br>Use commas to supply multiple values for any filter. Finish suffixes can be appended directly to any search term:',
+                table: [
+                    { value: '&', short: 'Non-foil only' },
+                    { value: '*', short: 'Foil only' },
+                    { value: '~', short: 'Etched only' },
+                    { value: '`', short: 'Alt-foil (surge, ripple, galaxy, etc.)' }
+                ],
+                examples: [
+                    { query: 'Lightning Bolt|LEA', desc: 'Lightning Bolt from Alpha' },
+                    { query: 'Sol Ring*', desc: 'Foil Sol Rings only' },
+                    { query: 'Sheoldred (Showcase)', desc: 'Showcase versions of Sheoldred' },
+                    { query: 'r:rare,mythic', desc: 'Rare OR mythic cards' }
+                ]
+            }
+        },
+
+        {
+            id: 'editions',
+            category: 'Search Syntax',
+            title: 'Editions & Sets',
+            icon: 'library',
+            summary: 'Filter by set code (s:MKM), full name (s:"Aether Revolt"), or regexp (se:^MH).',
+            snippets: ['s:CODE', 's:"Set Name"', 'se:REGEXP', 'e:CODE'],
+            keywords: ['edition', 'set', 'expansion', 'code', 'name', 'scryfall', 'e:', 's:', 'se:', 'regex', 'regexp', 'filter'],
+            content: {
+                description: 'Filter cards by edition using the Scryfall notation <code>s:CODE</code> or the full edition name in quotes: <code>s:"Aether Revolt"</code>.<br><br>Regular expressions are supported with <code>se:REGEXP</code>. For compatibility, <code>e:CODE</code> (exact match) and <code>ee:REGEXP</code> (regexp) are also accepted.',
+                table: [
+                    { value: 's:CODE', short: 'Set by code (e.g. s:MKM)' },
+                    { value: 's:"Name"', short: 'Set by full name' },
+                    { value: 'se:REGEXP', short: 'Set code by regular expression' },
+                    { value: 'e:CODE', short: 'Compatibility alias for s:CODE' }
+                ],
+                examples: [
+                    { query: 's:MKM', desc: 'Cards from Murders at Karlov Manor' },
+                    { query: 's:"Aether Revolt"', desc: 'Using full set name' },
+                    { query: 'se:^MH', desc: 'Sets starting with "MH" (regex)' },
+                    { query: 'e:LEA', desc: 'Compatibility syntax for Alpha' }
+                ]
+            }
+        },
+
+        {
+            id: 'collector-numbers',
+            category: 'Search Syntax',
+            title: 'Collector Numbers',
+            icon: 'hash',
+            summary: 'Filter by number (cn:123), range (cn:1-50), comparison (cn>300), or per-set (cn:MKM:42).',
+            snippets: ['cn:123', 'cn:1-50', 'cn>300', 'cn:CODE:42', 'cne:REGEXP'],
+            keywords: ['collector', 'number', 'cn', 'cne', 'range', 'comparison', 'regex', 'regexp', '#', 'card number'],
+            content: {
+                description: 'Filter by collector number using <code>cn:NUMBER</code>. For plain numbers you can use comparison operators <code>cn&gt;NUMBER</code> and <code>cn&lt;NUMBER</code>, or a range <code>cn:NUMBER-NUMBER</code>.<br><br>Regular expressions are supported via <code>cne:REGEXP</code>.<br><br>To target a specific set while leaving other results untouched, prepend the set code: <code>cn:CODE:NUMBER</code>.',
+                table: [
+                    { value: 'cn:NUMBER', short: 'Exact collector number' },
+                    { value: 'cn:N-N', short: 'Range of collector numbers' },
+                    { value: 'cn>N / cn<N', short: 'Comparison operators' },
+                    { value: 'cn:CODE:N', short: 'Number within a specific set' },
+                    { value: 'cne:REGEXP', short: 'Collector number by regexp' }
+                ],
+                examples: [
+                    { query: 'cn:123', desc: 'Cards numbered 123' },
+                    { query: 'cn:1-50', desc: 'Cards numbered 1–50' },
+                    { query: 'cn>300', desc: 'Cards above #300' },
+                    { query: 'cn:MKM:42', desc: '#42 from MKM only' }
+                ]
+            }
+        },
+
+        {
+            id: 'finish',
+            category: 'Search Syntax',
+            title: 'Finish & Foils',
+            icon: 'sparkles',
+            summary: 'Filter foil treatments: f:foil, f:etched, f:nonfoil, is:altfoil.',
+            snippets: ['f:foil', 'f:etched', 'f:nonfoil', 'is:altfoil', 'Lightning Bolt*'],
+            keywords: ['finish', 'foil', 'etched', 'nonfoil', 'altfoil', 'surge', 'ripple', 'galaxy', 'treatment', 'f:', 'is:altfoil'],
+            content: {
+                description: 'Filter by finish with <code>f:VALUE</code>. Accepted values are <code>nonfoil</code>, <code>foil</code>, and <code>etched</code>, with shorthand <code>nf</code>, <code>f</code>, and <code>e</code>.<br><br>For special foil variants (Galaxy, Surge, Ripple, etc.) use <code>is:altfoil</code> as an additional filter.<br><br>Alternatively, use suffix notation directly on any query:',
+                table: [
+                    { value: '&', short: 'Non-foil only' },
+                    { value: '*', short: 'Foil only' },
+                    { value: '~', short: 'Etched only' },
+                    { value: '`', short: 'Alt-foil (surge, ripple, galaxy)' }
+                ],
+                examples: [
+                    { query: 'f:foil', desc: 'Foil versions only' },
+                    { query: 'f:e', desc: 'Etched foils (short form)' },
+                    { query: 'Lightning Bolt*', desc: 'Foil Lightning Bolts' },
+                    { query: 'Sol Ring&', desc: 'Non-foil Sol Rings' }
+                ]
+            }
+        },
+
+        {
+            id: 'colors',
+            category: 'Search Syntax',
+            title: 'Colors & Identity',
+            icon: 'palette',
+            summary: 'Filter by color (c:RG) or identity (ci:esper); supports guild, shard, and college names.',
+            snippets: ['c:WUBRG', 'ci:esper', 'c:azorius', 'c:colorless', 'c:multicolor'],
+            keywords: ['color', 'colour', 'identity', 'ci', 'c:', 'WUBRG', 'white', 'blue', 'black', 'red', 'green', 'colorless', 'multicolor', 'guild', 'shard', 'wedge', 'college', 'azorius', 'dimir', 'rakdos', 'gruul', 'selesnya', 'orzhov', 'izzet', 'golgari', 'boros', 'simic', 'bant', 'esper', 'grixis', 'jund', 'naya', 'abzan', 'jeskai', 'sultai', 'mardu', 'temur'],
+            content: {
+                description: 'Filter by color with <code>c:COLOR</code> and color identity with <code>ci:COLOR</code>. Use standard WUBRG letters, full color names, <code>C</code> for colorless, or <code>M</code> for multicolor.<br><br>Named groups are also supported:<br><strong>Guilds (2-color):</strong> azorius, dimir, rakdos, gruul, selesnya, orzhov, izzet, golgari, boros, simic<br><strong>Shards/Wedges (3-color):</strong> bant, esper, grixis, jund, naya, abzan, jeskai, sultai, mardu, temur<br><strong>Colleges (Strixhaven):</strong> silverquill, prismari, witherbloom, lorehold, quandrix<br><strong>Four-color:</strong> chaos, aggression, altruism, growth, artifice',
+                table: [
+                    { value: 'c:COLOR', short: 'Filter by card color' },
+                    { value: 'ci:COLOR', short: 'Filter by color identity' },
+                    { value: 'c:colorless', short: 'Colorless cards' },
+                    { value: 'c:M', short: 'Multicolor cards' }
+                ],
+                examples: [
+                    { query: 'c:rg', desc: 'Red and green cards' },
+                    { query: 'ci:esper', desc: 'Esper color identity (WUB)' },
+                    { query: 'c:quandrix', desc: 'Green/Blue (Strixhaven college)' },
+                    { query: 'c:colorless', desc: 'Colorless cards' }
+                ]
+            }
+        },
+
+        {
+            id: 'rarity',
+            category: 'Search Syntax',
+            title: 'Rarity',
+            icon: 'diamond',
+            summary: 'Filter by rarity (r:mythic, r:m) or use comparisons (r>=rare).',
+            snippets: ['r:mythic', 'r:m', 'r:rare', 'r>=rare', 'r<uncommon'],
+            keywords: ['rarity', 'r:', 'mythic', 'rare', 'uncommon', 'common', 'special', 'token', 'oversize', 'shorthand', 'comparison'],
+            content: {
+                description: 'Filter by rarity with <code>r:RARITY</code>. The first letter can be used as shorthand. Comparison operators <code>r&gt;RARITY</code> and <code>r&lt;RARITY</code> are also supported.',
+                table: [
+                    { value: 'mythic', short: 'm' },
+                    { value: 'rare', short: 'r' },
+                    { value: 'uncommon', short: 'u' },
+                    { value: 'common', short: 'c' },
+                    { value: 'special', short: 's' },
+                    { value: 'token', short: 't' },
+                    { value: 'oversize', short: 'o' }
+                ],
+                examples: [
+                    { query: 'r:mythic', desc: 'Mythic rares only' },
+                    { query: 'r:m', desc: 'Same using shorthand' },
+                    { query: 'r>=rare', desc: 'Rare and mythic' },
+                    { query: 'r:rare,mythic s:MKM', desc: 'Rares and mythics from MKM' }
+                ]
+            }
+        },
+
+        {
+            id: 'conditions',
+            category: 'Search Syntax',
+            title: 'Conditions',
+            icon: 'shield-check',
+            summary: 'Filter by card condition: cond:NM, condr: for retail, condb: for buylist.',
+            snippets: ['cond:NM', 'cond:SP', 'condr:MP', 'condb:NM', 'cond>SP'],
+            keywords: ['condition', 'cond', 'NM', 'SP', 'MP', 'HP', 'PO', 'near mint', 'slightly played', 'moderately played', 'heavily played', 'poor', 'retail', 'buylist', 'condr', 'condb'],
+            content: {
+                description: 'Filter by condition with <code>cond:COND</code>. Use <code>condr:</code> to apply the filter to retail prices only, or <code>condb:</code> for buylist prices only. Comparison operators are supported.',
+                table: [
+                    { value: 'NM', short: 'Near Mint' },
+                    { value: 'SP', short: 'Slightly Played' },
+                    { value: 'MP', short: 'Moderately Played' },
+                    { value: 'HP', short: 'Heavily Played' },
+                    { value: 'PO', short: 'Poor' }
+                ],
+                examples: [
+                    { query: 'cond:NM', desc: 'Near Mint only' },
+                    { query: 'condr:SP', desc: 'SP retail prices only' },
+                    { query: 'condb:MP', desc: 'MP buylist prices only' },
+                    { query: 'cond>SP', desc: 'Worse than SP (MP, HP, PO)' }
+                ]
+            }
+        },
+
+        {
+            id: 'types',
+            category: 'Search Syntax',
+            title: 'Card & Product Types',
+            icon: 'swords',
+            summary: 'Filter by type, subtype, or supertype (t:creature, t:goblin, t:booster).',
+            snippets: ['t:creature', 't:legendary', 't:goblin', 't:booster', 't:planeswalker'],
+            keywords: ['type', 'supertype', 'subtype', 'creature', 'instant', 'sorcery', 'enchantment', 'artifact', 'planeswalker', 'land', 'legendary', 'goblin', 'elf', 'wizard', 'booster', 'box', 'deck', 'sealed', 'product', 'redemption'],
+            content: {
+                description: 'Filter by card type with <code>t:VALUE</code>, accepting any valid supertype, type, or subtype. The same option also works for sealed products — you can search by category (booster, box, deck) or subtype (draft, collector, intro), or any fragment of the product name.',
+                table: [],
+                examples: [
+                    { query: 't:creature', desc: 'All creatures' },
+                    { query: 't:legendary', desc: 'Legendary permanents' },
+                    { query: 't:goblin', desc: 'Goblin creatures' },
+                    { query: 't:booster s:blb', desc: 'All booster products in BLB' },
+                    { query: 't:redemption', desc: 'All MTGO redemption products' }
+                ]
+            }
+        },
+
+        {
+            id: 'dates',
+            category: 'Search Syntax',
+            title: 'Release Dates',
+            icon: 'calendar',
+            summary: 'Filter by release date (date:2024, date>2023-01-01, year<2004, date:now).',
+            snippets: ['date:2024', 'date>2023-01-01', 'year<2004', 'date:now', 'date:MKM'],
+            keywords: ['date', 'year', 'release', 'when', 'old', 'new', 'vintage', 'modern', 'today', 'now', 'iso', 'format'],
+            content: {
+                description: 'Filter by release date with <code>date:VALUE</code>, <code>date&gt;VALUE</code>, or <code>date&lt;VALUE</code>. Use <code>year:VALUE</code> for year-only filtering. The value formats accepted are:',
+                table: [
+                    { value: 'YYYY-MM-DD', short: 'ISO date format' },
+                    { value: 'YYYY-MM', short: 'Year and month' },
+                    { value: 'YYYY', short: 'Year only' },
+                    { value: 'Set code', short: 'Same date as that set' },
+                    { value: 'now / today', short: 'Current date' }
+                ],
+                examples: [
+                    { query: 'date:2024', desc: 'Cards released in 2024' },
+                    { query: 'date>2023-01-01', desc: 'Released after Jan 1, 2023' },
+                    { query: 'date:MKM', desc: 'Same release date as MKM' },
+                    { query: 'year<2004', desc: 'Released before 2004' }
+                ]
+            }
+        },
+
+        {
+            id: 'properties',
+            category: 'Search Syntax',
+            title: 'Card Properties',
+            icon: 'tag',
+            summary: 'Filter by frame, language, or game properties (is:reserved, is:ea, not:foil).',
+            snippets: ['is:reserved', 'is:extendedart', 'is:showcase', 'is:borderless', 'not:foil', 'is:ea', 'is:sc'],
+            keywords: ['properties', 'is:', 'not:', 'reserved', 'token', 'oversize', 'fullart', 'extendedart', 'extended art', 'showcase', 'reskin', 'borderless', 'gold', 'retro', 'future', 'altfoil', 'japanese', 'phyrexian', 'wcd', 'commander', 'funny', 'gamechanger', 'ea', 'sc', 'bd', 'gc', 'jp', 'jpn', 'ph'],
+            content: {
+                description: 'Filter by card properties with <code>is:VALUE</code> or exclude with <code>not:VALUE</code> (equivalent to <code>-is:VALUE</code>).<br><br><strong>Generic:</strong> reserved, token, oversize, funny, wcd, commander, productless, gamechanger<br><strong>Frame:</strong> fullart, extendedart, showcase, reskin, borderless, gold, retro, future, foil, nonfoil, altfoil<br><strong>Language:</strong> japanese, phyrexian<br><br>Some values have shorthand aliases:',
+                table: [
+                    { value: 'ea', short: 'fullart / extended art' },
+                    { value: 'sc', short: 'showcase' },
+                    { value: 'bd', short: 'borderless' },
+                    { value: 'gc', short: 'gamechanger' },
+                    { value: 'jp / jpn', short: 'japanese' },
+                    { value: 'ph', short: 'phyrexian' }
+                ],
+                examples: [
+                    { query: 'is:reserved', desc: 'Reserved List cards' },
+                    { query: 'is:extendedart', desc: 'Extended art versions' },
+                    { query: 'is:showcase is:foil', desc: 'Foil showcase cards' },
+                    { query: 'not:foil', desc: 'Non-foil only' },
+                    { query: 'is:ea r:mythic', desc: 'Extended art mythics' }
+                ]
+            }
+        },
+
+        {
+            id: 'promos',
+            category: 'Search Syntax',
+            title: 'Promos & Variants',
+            icon: 'gift',
+            summary: 'Filter promos: is:promo, is:prerelease, is:buyabox, is:serialized.',
+            snippets: ['is:promo', 'is:prerelease', 'is:buyabox', 'is:serialized'],
+            keywords: ['promo', 'prerelease', 'buyabox', 'buy a box', 'serialized', 'variant', 'stamped', 'convention', 'fnm', 'wpn', 'gameday', 'judge', 'brawl', 'planeswalker deck'],
+            content: {
+                description: 'Filter promo cards with <code>is:VALUE</code>. Use <code>is:promo</code> to match any promo type, or a specific tag for targeted filtering. Multiple promo tags are available depending on the product.',
+                table: [],
+                examples: [
+                    { query: 'is:prerelease', desc: 'Prerelease promos' },
+                    { query: 'is:buyabox', desc: 'Buy-a-Box promos' },
+                    { query: 'is:serialized', desc: 'Serialized numbered cards' },
+                    { query: 'is:promo r:mythic', desc: 'Any mythic promo' }
+                ]
+            }
+        },
+
+        {
+            id: 'lands',
+            category: 'Search Syntax',
+            title: 'Land & Set Cycles',
+            icon: 'mountain',
+            summary: 'Filter land cycles (is:fetchland, is:dual) and special sets (is:power9, is:abu4h).',
+            snippets: ['is:fetchland', 'is:dual', 'is:shockland', 'is:power9', 'is:abu4h'],
+            keywords: ['land', 'cycle', 'fetchland', 'fetch', 'dual', 'shockland', 'shock', 'painland', 'pain', 'checkland', 'check', 'fastland', 'fast', 'filterland', 'surveilland', 'vergeland', 'power9', 'p9', 'abu4h', 'alpha', 'beta', 'unlimited'],
+            content: {
+                description: 'Filter by well-known land cycles and set groupings using <code>is:VALUE</code>:',
+                table: [
+                    { value: 'is:dual', short: 'Original dual lands' },
+                    { value: 'is:fetchland', short: 'Fetch lands' },
+                    { value: 'is:shockland', short: 'Shock lands' },
+                    { value: 'is:painland', short: 'Pain lands' },
+                    { value: 'is:checkland', short: 'Check lands' },
+                    { value: 'is:fastland', short: 'Fast lands' },
+                    { value: 'is:filterland', short: 'Filter lands' },
+                    { value: 'is:surveilland', short: 'Surveil lands' },
+                    { value: 'is:vergeland', short: 'Verge lands' },
+                    { value: 'is:power9 / is:p9', short: 'The Power Nine' },
+                    { value: 'is:abu4h', short: 'Alpha/Beta/Unlimited + first 4 expansions' }
+                ],
+                examples: [
+                    { query: 'is:fetchland', desc: 'All fetchlands' },
+                    { query: 'is:dual', desc: 'Original dual lands' },
+                    { query: 'is:power9', desc: 'The Power Nine cards' },
+                    { query: 'is:shockland f:foil', desc: 'Foil shocklands' }
+                ]
+            }
+        },
+
+        {
+            id: 'prices',
+            category: 'Search Syntax',
+            title: 'Price Filters',
+            icon: 'dollar-sign',
+            summary: 'Filter by price (price>10), buylist (buy_price>5), ratio (ratio>50), or cross-store (price>TCGLow).',
+            snippets: ['price>10', 'price<5', 'buy_price>5', 'ratio>50', 'price>TCGLow', 'arb_price', 'rev_price'],
+            keywords: ['price', 'buy_price', 'arb_price', 'rev_price', 'ratio', 'cost', 'value', 'retail', 'buylist', 'TCGLow', 'filter', 'comparison', 'desirability'],
+            content: {
+                description: 'Filter by retail price with <code>price&gt;VALUE</code> or <code>price&lt;VALUE</code>. Use <code>buy_price</code> to filter buylist prices. Filters can also reference a store\'s price — <code>price&gt;TCGLow</code> returns stores charging more than the TCG Low index for that card.<br><br>For cross-category comparisons: <code>arb_price</code> uses buylist price as a reference for retail results, and <code>rev_price</code> uses retail price as a reference for buylist results.<br><br><code>ratio&gt;VALUE</code> filters by buylist desirability percentage (max 64).',
+                table: [
+                    { value: 'price', short: 'Retail price filter' },
+                    { value: 'buy_price', short: 'Buylist price filter' },
+                    { value: 'arb_price', short: 'Retail results filtered by buylist price' },
+                    { value: 'rev_price', short: 'Buylist results filtered by retail price' },
+                    { value: 'ratio', short: 'Buylist desirability ratio (0–64)' }
+                ],
+                examples: [
+                    { query: 'price<10', desc: 'Cards selling under $10 retail' },
+                    { query: 'price>TCGLow', desc: 'Stores above TCG Low price' },
+                    { query: 'buy_price>5', desc: 'Buylists paying over $5' },
+                    { query: 'ratio>50', desc: 'High buylist demand cards' }
+                ]
+            }
+        },
+
+        {
+            id: 'stores',
+            category: 'Search Syntax',
+            title: 'Stores & Regions',
+            icon: 'store',
+            summary: 'Filter by store (store:TCG), region (region:eu), or skip categories (skip:index).',
+            snippets: ['store:TCG', 'store:only:CK', 'vendor:CK', 'seller:SCG', 'region:eu', 'skip:index', 'skip:retail'],
+            keywords: ['store', 'vendor', 'seller', 'region', 'skip', 'only', 'CK', 'TCG', 'SCG', 'MKM', 'us', 'eu', 'jp', 'index', 'retail', 'buylist', 'empty', 'filter'],
+            content: {
+                description: 'Filter by seller or vendor with <code>store:shorthand</code>, <code>seller:shorthand</code> (retail), or <code>vendor:shorthand</code> (buylist). These drop results where the store is absent. To show only that store, use <code>store:only:shorthand</code>.<br><br>Filter by region with <code>region:us</code>, <code>region:eu</code>, or <code>region:jp</code>.<br><br>The <code>skip:</code> filter hides entire result categories. Note: store filters leave index results visible — use <code>skip:index</code> to hide them.',
+                table: [
+                    { value: 'store:X', short: 'Include results from store X' },
+                    { value: 'store:only:X', short: 'Show only results from store X' },
+                    { value: 'seller:X', short: 'Retail-only store filter' },
+                    { value: 'vendor:X', short: 'Buylist-only store filter' },
+                    { value: 'region:us/eu/jp', short: 'Filter by store region' },
+                    { value: 'skip:retail', short: 'Hide all retail prices' },
+                    { value: 'skip:buylist', short: 'Hide all buylist prices' },
+                    { value: 'skip:index', short: 'Hide index/aggregate prices' },
+                    { value: 'skip:empty', short: 'Hide cards with no prices' }
+                ],
+                examples: [
+                    { query: 'store:TCG', desc: 'TCGplayer listings' },
+                    { query: 'store:only:CK', desc: 'Card Kingdom results only' },
+                    { query: 'vendor:CK', desc: 'Card Kingdom buylist' },
+                    { query: 'region:eu', desc: 'European stores only' },
+                    { query: 'skip:index', desc: 'Hide index/aggregate prices' }
+                ]
+            }
+        },
+
+        {
+            id: 'modes',
+            category: 'Search Syntax',
+            title: 'Search Modes',
+            icon: 'scan-search',
+            summary: 'Change matching behavior: sm:exact (default), sm:prefix, sm:any, sm:regexp, sm:scryfall.',
+            snippets: ['sm:exact', 'sm:prefix', 'sm:any', 'sm:regexp', 'sm:scryfall'],
+            keywords: ['mode', 'sm:', 'exact', 'prefix', 'any', 'regexp', 'regex', 'scryfall', 'match', 'contains', 'starts', 'pattern', 'forward'],
+            content: {
+                description: 'Change search matching behavior with <code>sm:VALUE</code>. The default mode is <code>exact</code> — only cards with that precise name are returned.<br><br>In <code>scryfall</code> mode, the query is forwarded to Scryfall. BAN card filters are disabled to avoid conflicts, but store and price filters still apply.',
+                table: [
+                    { value: 'exact', short: 'Exact name match (default)' },
+                    { value: 'prefix', short: 'Names starting with search term' },
+                    { value: 'any', short: 'Names containing search term' },
+                    { value: 'regexp', short: 'Regular expression (case sensitive)' },
+                    { value: 'scryfall', short: 'Forward query to Scryfall' }
+                ],
+                examples: [
+                    { query: 'Vesuva', desc: 'exact: only "Vesuva", not Vesuvan cards' },
+                    { query: 'sm:prefix Dragonlord', desc: 'prefix: cards starting with "Dragonlord"' },
+                    { query: 'sm:any Draco', desc: 'any: Draco and all cards containing "draco"' },
+                    { query: 'sm:regexp Cluestone$', desc: 'regexp: cards ending in "Cluestone"' },
+                    { query: 'sm:scryfall art:loot f:f', desc: 'scryfall: foil cards tagged "loot"' }
+                ]
+            }
+        },
+
+        {
+            id: 'sorting',
+            category: 'Search Syntax',
+            title: 'Sorting',
+            icon: 'arrow-up-down',
+            summary: 'Sort results by date (default), price, name, or collector number.',
+            snippets: ['sort:chrono', 'sort:retail', 'sort:buylist', 'sort:alpha', 'sort:number', 'sort:hybrid'],
+            keywords: ['sort', 'order', 'chrono', 'hybrid', 'alpha', 'alphabetical', 'number', 'retail', 'buylist', 'price', 'date', 'print', 'collector'],
+            content: {
+                description: 'Change the sort order of results with <code>sort:VALUE</code>. Note: when a sort is set via query, the sort UI dropdown is disabled.',
+                table: [
+                    { value: 'chrono', short: 'By print date (default)' },
+                    { value: 'hybrid', short: 'Alphabetical with sets grouped' },
+                    { value: 'alpha', short: 'Alphabetical order' },
+                    { value: 'number', short: 'By collector number' },
+                    { value: 'retail', short: 'By TCGplayer price' },
+                    { value: 'buylist', short: 'By Card Kingdom buylist price' }
+                ],
+                examples: [
+                    { query: 'sort:retail', desc: 'Highest TCG price first' },
+                    { query: 'r:mythic sort:retail', desc: 'Most expensive mythics first' },
+                    { query: 'is:fetchland sort:buylist', desc: 'Fetchlands by buylist value' }
+                ]
+            }
+        },
+
+        {
+            id: 'lists',
+            category: 'Search Syntax',
+            title: 'Special Lists',
+            icon: 'list-checks',
+            summary: 'Filter cards on curated lists: on:hotlist, on:tcgsyp, on:newspaper.',
+            snippets: ['on:hotlist', 'on:tcgsyp', 'on:newspaper'],
+            keywords: ['list', 'on:', 'hotlist', 'tcgsyp', 'syp', 'newspaper', 'spike', 'hot', 'curated', 'special', 'TCGplayer'],
+            content: {
+                description: 'Check if a card belongs to a curated list using <code>on:VALUE</code>:',
+                table: [
+                    { value: 'hotlist', short: 'Highest buylist prices over 3 months' },
+                    { value: 'tcgsyp', short: 'Present on the TCGplayer SYP list' },
+                    { value: 'newspaper', short: 'Found in a Newspaper Spike score' }
+                ],
+                examples: [
+                    { query: 'on:hotlist', desc: 'Cards on the buylist hot list' },
+                    { query: 'on:tcgsyp', desc: 'Cards available on TCGplayer SYP' },
+                    { query: 'on:newspaper r:mythic', desc: 'Newspaper spike mythics' }
+                ]
+            }
+        },
+
+        {
+            id: 'names',
+            category: 'Search Syntax',
+            title: 'Name Filters',
+            icon: 'type',
+            summary: 'Include or exclude cards by name (name:"X", -name:"Y") or filter by ID.',
+            snippets: ['name:"Lightning Bolt"', '-name:"Sol Ring"', 'namee:^The', 'id:12345'],
+            keywords: ['name', 'namee', 'id', 'include', 'exclude', 'filter', 'specific', 'regex', 'regexp', 'MTGBAN', 'MTGJSON', 'scryfall', 'TCGplayer', 'product ID'],
+            content: {
+                description: 'Filter by card name to include or exclude specific cards from a query using <code>name:NAME</code>. Enclose names with spaces in quotes or parentheses. Prefix with <code>-</code> to exclude.<br><br>Regular expressions are supported with <code>namee:REGEXP</code>.<br><br>Filter by internal card ID with <code>id:VALUE</code>, supporting MTGBAN, MTGJSON, Scryfall, and TCGplayer product IDs.',
+                table: [
+                    { value: 'name:"X"', short: 'Include only cards named X' },
+                    { value: '-name:"X"', short: 'Exclude cards named X' },
+                    { value: 'namee:REGEXP', short: 'Name filter using regular expression' },
+                    { value: 'id:VALUE', short: 'Filter by MTGBAN/MTGJSON/Scryfall/TCG ID' }
+                ],
+                examples: [
+                    { query: 'name:"Lightning Bolt"', desc: 'Exact name match' },
+                    { query: '-name:"Sol Ring"', desc: 'Exclude Sol Ring from results' },
+                    { query: 'namee:^The', desc: 'Names starting with "The"' },
+                    { query: 'id:12345', desc: 'By TCGplayer product ID' }
+                ]
+            }
+        },
+
+        // ─── Features ─────────────────────────────────────────────────────
+
+        {
+            id: 'feature-search',
+            category: 'Features',
+            title: 'Card & Sealed Search',
+            icon: 'search',
+            summary: 'Search prices across all stores, view historical charts, and follow affiliate links.',
+            snippets: [],
+            keywords: ['search', 'price', 'retail', 'buylist', 'chart', 'history', 'affiliate', 'store', 'sealed', 'product', 'condition', 'index'],
+            content: {
+                description: 'The main search page lets you find prices across all tracked stores and vendors for both single cards and sealed products. Results are split by retail and buylist, with condition breakdowns and index prices from aggregators like TCGplayer.<br><br>Click the chart icon (📊) on any card to load historical price data from major vendors. Use affiliate links in results to support BAN while making purchases.',
+                table: [],
+                examples: [
+                    { query: 'Lightning Bolt s:lea', desc: 'Alpha Lightning Bolt prices' },
+                    { query: 'r:mythic sort:retail skip:index', desc: 'Mythics by price, no index' },
+                    { query: 't:booster s:blb', desc: 'Bloomburrow booster products' }
+                ]
+            }
+        },
+
+        {
+            id: 'feature-newspaper',
+            category: 'Features',
+            title: 'Newspaper',
+            icon: 'newspaper',
+            summary: 'Daily Spike scores, buylist changes, seller count trends, SYP list, and archive.',
+            snippets: [],
+            keywords: ['newspaper', 'spike', 'score', 'buylist', 'change', 'trend', 'seller', 'count', 'SYP', 'archive', 'daily', 'movement', 'price change'],
+            content: {
+                description: 'The Newspaper page tracks daily market movements. It shows Spike scores (sudden price increases), buylist changes (vendors adjusting what they pay), and seller count trends (supply going up or down).<br><br>The SYP (Save Your Points) section lists TCGplayer store credit opportunities. An archive lets you browse historical issues.',
+                table: [],
+                examples: [
+                    { query: 'on:newspaper', desc: 'Cards currently in a Newspaper spike' },
+                    { query: 'on:newspaper r:mythic', desc: 'Spiking mythics' }
+                ]
+            }
+        },
+
+        {
+            id: 'feature-sleepers',
+            category: 'Features',
+            title: 'Sleepers',
+            icon: 'moon',
+            summary: 'Discover undervalued cards with bulk, reprint, mismatch, and gap analysis across tiers.',
+            snippets: [],
+            keywords: ['sleepers', 'bulk', 'reprint', 'mismatch', 'gap', 'hotlist', 'analysis', 'tier', 'rank', 'S', 'F', 'undervalued', 'opportunity', 'arbitrage'],
+            content: {
+                description: 'The Sleepers page surfaces cards that may be undervalued or overlooked. Analysis modes include:<br><br><strong>Bulk:</strong> Cards available for low prices across vendors<br><strong>Reprint:</strong> Cards with upcoming or recent reprints affecting price<br><strong>Mismatch:</strong> Cards priced inconsistently across stores<br><strong>Gap:</strong> Cards where buylist and retail prices diverge significantly<br><strong>Hotlist:</strong> High-demand cards based on sustained buylist interest<br><br>Cards are tiered S through F based on opportunity score.',
+                table: [],
+                examples: []
+            }
+        },
+
+        {
+            id: 'feature-upload',
+            category: 'Features',
+            title: 'Upload & Optimize',
+            icon: 'upload',
+            summary: 'Upload a collection (CSV, Excel, Moxfield, Deckbox) and optimize across buylist vendors.',
+            snippets: [],
+            keywords: ['upload', 'collection', 'CSV', 'excel', 'google sheets', 'moxfield', 'deckbox', 'buylist', 'optimize', 'export', 'CK', 'SCG', 'TCG', 'MKM', 'card kingdom', 'cardmarket'],
+            content: {
+                description: 'Upload your collection in CSV, Excel, Google Sheets, Moxfield, or Deckbox format. BAN will match your cards against all active buylists and calculate the optimal split across vendors to maximize return.<br><br>Export results in formats compatible with Card Kingdom, StarCityGames, TCGplayer, and Cardmarket.',
+                table: [],
+                examples: []
+            }
+        },
+
+        {
+            id: 'feature-arbitrage',
+            category: 'Features',
+            title: 'Arbitrage',
+            icon: 'trending-up',
+            summary: 'Find price gaps between retail and buylist; filter by condition, foil, rarity, and more.',
+            snippets: [],
+            keywords: ['arbitrage', 'arb', 'gap', 'price difference', 'retail', 'buylist', 'profit', 'flip', 'reverse', 'global', 'condition', 'foil', 'rarity', 'filter'],
+            content: {
+                description: 'The Arbitrage page identifies cards where there is a meaningful gap between what stores are selling for and what other vendors are buying at — potential flip opportunities.<br><br><strong>Standard mode:</strong> Compare retail prices to buylist prices across all vendors<br><strong>Reverse mode:</strong> Find buylists paying more than retail prices<br><strong>Global mode:</strong> Cross-store arbitrage including international vendors<br><br>Filter results by condition, foil treatment, rarity, and price thresholds.',
+                table: [],
+                examples: []
+            }
+        },
+
+        // ─── Tips & Tricks ────────────────────────────────────────────────
+
+        {
+            id: 'tips',
+            category: 'Tips & Tricks',
+            title: 'Power User Tips',
+            icon: 'lightbulb',
+            summary: 'Price refresh timing, historical charts, reprint finder, buylist ratios, and trade credit tooltips.',
+            snippets: [],
+            keywords: ['tips', 'tricks', 'power user', 'refresh', 'timing', 'history', 'chart', 'reprint', 'ratio', 'trade credit', 'tooltip', 'flavor name', 'condition', 'index', 'feedback'],
+            content: {
+                description: 'A few things to know to get the most out of BAN:<br><br><strong>Price refresh:</strong> Data is updated periodically throughout the day. The exact delay is randomized to prevent sniping.<br><br><strong>Historical data:</strong> Click the 📊 chart icon on any card to view price history from major vendors.<br><br><strong>Reprint finder:</strong> Click 📖 on a card to see every product containing any reprint of that card. Source products are also accessible via "Found in * products" links.<br><br><strong>Buylist ratios:</strong> The percentage shown on buylist results reflects vendor desirability — higher means they want it more. Only shown when the vendor also has retail stock at matching conditions.<br><br><strong>Trade credit:</strong> Hover over a buylist price to see the corresponding trade credit value, if available.<br><br><strong>Conditions:</strong> Inventory prices reflect stated conditions (accuracy depends on provider). Buylist prices are always NM. Sealed products are always in sealed/unopened condition. The Index condition is for trend data only — no quantities are tracked.<br><br><strong>Flavor names:</strong> Searching a flavor name returns only those specific art versions (unless disabled in preferences). This does not work for complex multi-filter queries.<br><br><strong>Feedback:</strong> Report issues in the #feedback channel on the BAN Discord with a URL or screenshot. Some errors originate from upstream providers.',
+                table: [],
+                examples: [
+                    { query: 'ratio>50 r:rare', desc: 'High-demand rares on buylists' },
+                    { query: 'is:reserved price>50', desc: 'Expensive reserved list cards' },
+                    { query: 'on:hotlist sort:buylist', desc: 'Hot list sorted by buylist value' }
+                ]
+            }
+        }
+
+    ]
+};

--- a/js/guide-data.js
+++ b/js/guide-data.js
@@ -17,11 +17,12 @@ window.__BAN_GUIDE = {
             content: {
                 description: 'The command palette gives you fast keyboard-driven access to search syntax help and site navigation. Open it with <code>Ctrl+K</code> (Windows/Linux) or <code>Cmd+K</code> (Mac), or by pressing <code>/</code> when no input field is focused.<br><br>Once open, you can switch modes using prefixes:<br><code>?</code> — inline syntax help<br><code>&gt;</code> — navigate to a page<br><code>saved:</code> — recall a saved search command',
                 table: [
-                    { value: 'Ctrl+K / Cmd+K', short: 'Open palette from anywhere' },
+                    { value: 'Ctrl+K / Cmd+K', short: 'Toggle palette open/closed from anywhere' },
                     { value: '/', short: 'Open palette when no input is focused' },
-                    { value: '?', short: 'Show inline syntax reference' },
-                    { value: '>', short: 'Navigate to a site page' },
-                    { value: 'saved:', short: 'Access saved search commands' }
+                    { value: '?', short: 'Help mode — show inline syntax reference (also: help: syntax:)' },
+                    { value: '>', short: 'Navigation mode — jump to a site page' },
+                    { value: 'saved:', short: 'Saved mode — access saved search commands' },
+                    { value: 'Shift+Enter', short: 'In help mode: navigate to full guide section' }
                 ],
                 examples: [
                     { query: '? rarity', desc: 'Show rarity syntax help inline' },
@@ -43,7 +44,7 @@ window.__BAN_GUIDE = {
                 description: 'Any search query can be saved as a named command for quick reuse. On a search results page, open the palette and select <strong>Save Current Search</strong>, or press <code>Ctrl+S</code> / <code>Cmd+S</code> while the palette is open. You will be prompted to name the command.<br><br>Saved commands appear in the palette by default and can be filtered with the <code>saved:</code> prefix. Hover over a saved command to reveal a delete button.',
                 table: [
                     { value: 'Save Current Search', short: 'Palette command (appears on search results pages)' },
-                    { value: 'Ctrl+S / Cmd+S', short: 'Save palette input as a command (while palette is open)' },
+                    { value: 'Ctrl+S / Cmd+S', short: 'Save the current page search as a command (while palette is open)' },
                     { value: 'saved:', short: 'Browse saved commands in palette' }
                 ],
                 examples: [

--- a/js/guide-data.js
+++ b/js/guide-data.js
@@ -1,0 +1,2 @@
+/* Guide Data — placeholder */
+window.__BAN_GUIDE = { sections: [] };

--- a/main.go
+++ b/main.go
@@ -848,6 +848,9 @@ func main() {
 	// when navigating to /home it should serve the home page
 	http.Handle("/", noSigning(http.HandlerFunc(Home)))
 
+	// Public guide page
+	http.Handle("/guide", noSigning(http.HandlerFunc(Guide)))
+
 	// Mobile/desktop view toggle
 	http.HandleFunc("/toggle-mobile", toggleMobileView)
 

--- a/mobile.go
+++ b/mobile.go
@@ -63,6 +63,7 @@ var mobileEnabledPages = []string{
 	"Newspaper",
 	"Sleepers",
 	"Admin",
+	"Guide",
 }
 
 // filterNavForMobile removes nav entries that don't have mobile templates.

--- a/templates/base-landing.html
+++ b/templates/base-landing.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" type="text/css" href="/css/main.css?hash={{.Hash}}">
     {{block "extra-css" .}}{{end}}
+    <link rel="stylesheet" type="text/css" href="/css/command-palette.css?hash={{.Hash}}">
 
     <link rel="apple-touch-icon" sizes="120x120" href="/img/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/img/favicon/favicon-32x32.png">
@@ -35,5 +36,14 @@
 {{block "content" .}}{{end}}
 
 {{block "extra-scripts" .}}{{end}}
+<script>
+window.__BAN_PALETTE = {
+    nav: [{{range .Nav}}{ name:"{{.Name}}", link:"{{.Link}}", icon:"{{.Short}}" },{{end}}],
+    hash: "{{.Hash}}",
+    user: "{{.BetaNav.Short}}"
+};
+</script>
+<script type="text/javascript" src="/js/guide-data.js?hash={{.Hash}}"></script>
+<script type="text/javascript" src="/js/command-palette.js?hash={{.Hash}}"></script>
 </body>
 </html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" type="text/css" href="/css/main.css?hash={{.Hash}}">
     {{block "extra-css" .}}{{end}}
+    <link rel="stylesheet" type="text/css" href="/css/command-palette.css?hash={{.Hash}}">
 
     <link rel="apple-touch-icon" sizes="120x120" href="/img/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/img/favicon/favicon-32x32.png">
@@ -35,5 +36,14 @@
 </div>
 
 {{block "extra-scripts" .}}{{end}}
+<script>
+window.__BAN_PALETTE = {
+    nav: [{{range .Nav}}{ name:"{{.Name}}", link:"{{.Link}}", icon:"{{.Short}}" },{{end}}],
+    hash: "{{.Hash}}",
+    user: "{{.BetaNav.Short}}"
+};
+</script>
+<script type="text/javascript" src="/js/guide-data.js?hash={{.Hash}}"></script>
+<script type="text/javascript" src="/js/command-palette.js?hash={{.Hash}}"></script>
 </body>
 </html>

--- a/templates/guide.html
+++ b/templates/guide.html
@@ -1,0 +1,6 @@
+{{define "content"}}
+<div style="padding: 2em; text-align: center;">
+    <h1>Guide</h1>
+    <p>Coming soon.</p>
+</div>
+{{end}}

--- a/templates/guide.html
+++ b/templates/guide.html
@@ -1,6 +1,281 @@
+{{define "extra-css"}}
+    <link rel="stylesheet" type="text/css" href="/css/guide.css?hash={{.Hash}}">
+{{end}}
+
+{{define "extra-head"}}
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+{{end}}
+
 {{define "content"}}
-<div style="padding: 2em; text-align: center;">
-    <h1>Guide</h1>
-    <p>Coming soon.</p>
+<div class="guide-container">
+    <nav class="guide-sidebar" id="guide-sidebar">
+        <div class="guide-sidebar-header">
+            <input class="guide-filter-input" id="guide-filter" type="text"
+                   placeholder="Filter sections..." autocomplete="off" />
+        </div>
+        <div class="guide-sidebar-nav" id="guide-sidebar-nav">
+            <!-- Built by JS -->
+        </div>
+    </nav>
+
+    <main class="guide-main" id="guide-main">
+        <div class="guide-hero">
+            <h1>MTGBAN Guide</h1>
+            <p class="guide-hero-sub">Search syntax, tools, and power user tips</p>
+            <div class="guide-hero-shortcut">
+                Press <kbd>Ctrl+K</kbd> or <kbd>Cmd+K</kbd> to open the command palette from any page
+            </div>
+        </div>
+        <div id="guide-sections">
+            <!-- Built by JS -->
+        </div>
+    </main>
 </div>
+
+<script>
+(function() {
+    var data = window.__BAN_GUIDE;
+    if (!data || !data.sections) return;
+
+    var sections = data.sections;
+    var sidebarNav = document.getElementById('guide-sidebar-nav');
+    var sectionsContainer = document.getElementById('guide-sections');
+
+    // Group sections by category in order
+    var categories = [];
+    var categoryMap = {};
+    for (var i = 0; i < sections.length; i++) {
+        var sec = sections[i];
+        if (!categoryMap[sec.category]) {
+            categoryMap[sec.category] = [];
+            categories.push(sec.category);
+        }
+        categoryMap[sec.category].push(sec);
+    }
+
+    // ── Build sidebar nav ──
+    for (var c = 0; c < categories.length; c++) {
+        var catName = categories[c];
+        var catHeader = document.createElement('div');
+        catHeader.className = 'guide-nav-category';
+        catHeader.setAttribute('data-category', catName);
+        catHeader.textContent = catName;
+        sidebarNav.appendChild(catHeader);
+
+        var catSections = categoryMap[catName];
+        for (var s = 0; s < catSections.length; s++) {
+            var item = catSections[s];
+            var link = document.createElement('a');
+            link.className = 'guide-nav-link';
+            link.href = '#' + item.id;
+            link.setAttribute('data-section', item.id);
+            link.setAttribute('data-category', catName);
+            link.innerHTML = '<i data-lucide="' + escapeAttr(item.icon) + '"></i>' +
+                '<span>' + escapeHtml(item.title) + '</span>';
+            sidebarNav.appendChild(link);
+        }
+    }
+
+    // ── Build main content ──
+    for (var c = 0; c < categories.length; c++) {
+        var catName = categories[c];
+
+        var divider = document.createElement('div');
+        divider.className = 'guide-category-divider';
+        divider.setAttribute('data-category', catName);
+        var h2 = document.createElement('h2');
+        h2.textContent = catName;
+        divider.appendChild(h2);
+        sectionsContainer.appendChild(divider);
+
+        var catSections = categoryMap[catName];
+        for (var s = 0; s < catSections.length; s++) {
+            var item = catSections[s];
+            var section = document.createElement('section');
+            section.className = 'guide-section';
+            section.id = item.id;
+            section.setAttribute('data-category', catName);
+            section.setAttribute('data-title', item.title);
+            section.setAttribute('data-summary', item.summary || '');
+            section.setAttribute('data-keywords', (item.keywords || []).join(' '));
+
+            var html = '';
+
+            // Header
+            html += '<div class="guide-section-header">';
+            html += '<i data-lucide="' + escapeAttr(item.icon) + '"></i>';
+            html += '<h3>' + escapeHtml(item.title) + '</h3>';
+            html += '</div>';
+
+            // Description (contains HTML — render as innerHTML)
+            if (item.content && item.content.description) {
+                html += '<div class="guide-section-desc">' + item.content.description + '</div>';
+            }
+
+            // Table
+            if (item.content && item.content.table && item.content.table.length > 0) {
+                html += '<table class="guide-table">';
+                html += '<thead><tr><th>Option</th><th>Description</th></tr></thead>';
+                html += '<tbody>';
+                for (var t = 0; t < item.content.table.length; t++) {
+                    var row = item.content.table[t];
+                    html += '<tr><td><code>' + escapeHtml(row.value) + '</code></td>';
+                    html += '<td>' + escapeHtml(row.short) + '</td></tr>';
+                }
+                html += '</tbody></table>';
+            }
+
+            // Examples
+            if (item.content && item.content.examples && item.content.examples.length > 0) {
+                html += '<div class="guide-examples">';
+                for (var e = 0; e < item.content.examples.length; e++) {
+                    var ex = item.content.examples[e];
+                    html += '<div class="guide-example">';
+                    html += '<a class="guide-example-query" href="/search?q=' + encodeURIComponent(ex.query) + '">' + escapeHtml(ex.query) + '</a>';
+                    html += '<span class="guide-example-desc">' + escapeHtml(ex.desc) + '</span>';
+                    html += '<button class="guide-example-copy" onclick="copySnippet(this, \'' + escapeJs(ex.query) + '\')" title="Copy to clipboard">';
+                    html += '<i data-lucide="copy"></i>';
+                    html += '</button>';
+                    html += '</div>';
+                }
+                html += '</div>';
+            }
+
+            section.innerHTML = html;
+            sectionsContainer.appendChild(section);
+        }
+    }
+
+    // ── Scroll spy ──
+    var navLinks = sidebarNav.querySelectorAll('.guide-nav-link');
+    var sectionEls = sectionsContainer.querySelectorAll('.guide-section');
+    var observer = new IntersectionObserver(function(entries) {
+        for (var i = 0; i < entries.length; i++) {
+            if (entries[i].isIntersecting) {
+                var id = entries[i].target.id;
+                for (var j = 0; j < navLinks.length; j++) {
+                    if (navLinks[j].getAttribute('data-section') === id) {
+                        navLinks[j].classList.add('active');
+                    } else {
+                        navLinks[j].classList.remove('active');
+                    }
+                }
+            }
+        }
+    }, { rootMargin: '-20% 0px -70% 0px' });
+
+    for (var i = 0; i < sectionEls.length; i++) {
+        observer.observe(sectionEls[i]);
+    }
+
+    // ── Filter ──
+    var filterInput = document.getElementById('guide-filter');
+    filterInput.addEventListener('input', function() {
+        var query = this.value.toLowerCase().trim();
+        var visibleCategories = {};
+
+        for (var i = 0; i < sectionEls.length; i++) {
+            var el = sectionEls[i];
+            var title = (el.getAttribute('data-title') || '').toLowerCase();
+            var summary = (el.getAttribute('data-summary') || '').toLowerCase();
+            var keywords = (el.getAttribute('data-keywords') || '').toLowerCase();
+            var cat = el.getAttribute('data-category');
+
+            var match = !query || title.indexOf(query) !== -1 ||
+                summary.indexOf(query) !== -1 || keywords.indexOf(query) !== -1;
+
+            if (match) {
+                el.classList.remove('hidden-by-filter');
+                visibleCategories[cat] = true;
+            } else {
+                el.classList.add('hidden-by-filter');
+            }
+        }
+
+        // Update sidebar links
+        for (var i = 0; i < navLinks.length; i++) {
+            var secId = navLinks[i].getAttribute('data-section');
+            var secEl = document.getElementById(secId);
+            if (secEl && secEl.classList.contains('hidden-by-filter')) {
+                navLinks[i].classList.add('hidden-by-filter');
+            } else {
+                navLinks[i].classList.remove('hidden-by-filter');
+            }
+        }
+
+        // Update category headers (sidebar + main)
+        var catHeaders = sidebarNav.querySelectorAll('.guide-nav-category');
+        for (var i = 0; i < catHeaders.length; i++) {
+            var cat = catHeaders[i].getAttribute('data-category');
+            if (visibleCategories[cat]) {
+                catHeaders[i].classList.remove('hidden-by-filter');
+            } else {
+                catHeaders[i].classList.add('hidden-by-filter');
+            }
+        }
+
+        var catDividers = sectionsContainer.querySelectorAll('.guide-category-divider');
+        for (var i = 0; i < catDividers.length; i++) {
+            var cat = catDividers[i].getAttribute('data-category');
+            if (visibleCategories[cat]) {
+                catDividers[i].classList.remove('hidden-by-filter');
+            } else {
+                catDividers[i].classList.add('hidden-by-filter');
+            }
+        }
+    });
+
+    // ── Anchor scroll ──
+    if (window.location.hash) {
+        var target = document.getElementById(window.location.hash.substring(1));
+        if (target) {
+            setTimeout(function() {
+                target.scrollIntoView({ behavior: 'smooth' });
+            }, 100);
+        }
+    }
+
+    // ── Lucide init ──
+    if (window.lucide) {
+        lucide.createIcons();
+    }
+
+    // ── Helpers ──
+    function escapeHtml(str) {
+        var div = document.createElement('div');
+        div.appendChild(document.createTextNode(str));
+        return div.innerHTML;
+    }
+
+    function escapeAttr(str) {
+        return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;')
+                  .replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    function escapeJs(str) {
+        return str.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/"/g, '\\"');
+    }
+})();
+
+function copySnippet(btn, text) {
+    if (navigator.clipboard) {
+        navigator.clipboard.writeText(text);
+    } else {
+        var ta = document.createElement('textarea');
+        ta.value = text;
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand('copy');
+        document.body.removeChild(ta);
+    }
+    var toast = document.getElementById('cp-toast');
+    if (toast) {
+        toast.textContent = 'Copied!';
+        toast.classList.add('show');
+        setTimeout(function() {
+            toast.classList.remove('show');
+        }, 1500);
+    }
+}
+</script>
 {{end}}

--- a/templates/guide.html
+++ b/templates/guide.html
@@ -38,9 +38,25 @@
     var data = window.__BAN_GUIDE;
     if (!data || !data.sections) return;
 
-    var sections = data.sections;
+    var allSections = data.sections;
     var sidebarNav = document.getElementById('guide-sidebar-nav');
     var sectionsContainer = document.getElementById('guide-sections');
+
+    // Build nav permission lookup from palette data
+    var navNames = {};
+    var palette = window.__BAN_PALETTE || {};
+    var navItems = palette.nav || [];
+    for (var n = 0; n < navItems.length; n++) {
+        navNames[navItems[n].name] = true;
+    }
+
+    // Filter sections by auth
+    var sections = [];
+    for (var i = 0; i < allSections.length; i++) {
+        var s = allSections[i];
+        if (s.requiresNav && !navNames[s.requiresNav]) continue;
+        sections.push(s);
+    }
 
     // Group sections by category in order
     var categories = [];

--- a/templates/guide.html
+++ b/templates/guide.html
@@ -3,6 +3,7 @@
 {{end}}
 
 {{define "extra-head"}}
+    <script type="text/javascript" src="/js/guide-data.js?hash={{.Hash}}"></script>
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
 {{end}}
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -10,6 +10,7 @@
 {{define "extra-head"}}
     <script type="text/javascript" src="/js/autocomplete.js?hash={{.Hash}}"></script>
     <script type="text/javascript" src="/js/fetchnames.js?hash={{.Hash}}"></script>
+    <script type="text/javascript" src="/js/recent-searches.js?hash={{.Hash}}"></script>
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
 {{end}}
 

--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -27,6 +27,9 @@
             <img src="/img/misc/discord.png" alt="Discord">
         </a>
 
+        <a class="ban-nav-ext" href="/guide" title="Guide">
+            <i data-lucide="help-circle" style="width:20px;height:20px;stroke:var(--greytext)"></i>
+        </a>
         <button class="ban-theme-toggle" id="theme-toggle" type="button" title="Toggle theme">
             <svg class="theme-icon theme-icon-sun" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#ffdd00" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/></svg>
             <svg class="theme-icon theme-icon-moon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#1a5ea6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.985 12.486a9 9 0 1 1-9.473-9.472c.405-.022.617.46.402.803a6 6 0 0 0 8.268 8.268c.344-.215.825-.004.803.401"/></svg>

--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -28,7 +28,7 @@
         </a>
 
         <a class="ban-nav-ext" href="/guide" title="Guide">
-            <i data-lucide="help-circle" style="width:20px;height:20px;stroke:var(--greytext)"></i>
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--greytext)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg>
         </a>
         <button class="ban-theme-toggle" id="theme-toggle" type="button" title="Toggle theme">
             <svg class="theme-icon theme-icon-sun" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#ffdd00" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/></svg>

--- a/templates/search.html
+++ b/templates/search.html
@@ -45,6 +45,7 @@
     <script type="text/javascript" src="/js/sealed.js?hash={{.Hash}}" defer></script>
     {{end}}
     <script type="text/javascript" src="/js/filtering.js?hash={{.Hash}}"></script>
+    <script type="text/javascript" src="/js/recent-searches.js?hash={{.Hash}}"></script>
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
 {{end}}
 


### PR DESCRIPTION
### Summary
- Keyboard-driven command palette for instant card search, page navigation, syntax help, and saved commands
- Interactive user guide page at /guide with searchable/filterable reference for all search syntax, tools, and features (searchable through the palette help menu)
- Help icon in navbar linking to guide

### Command Palette
- Opens from any page with `Ctrl+K` / `Cmd+K`, or with `/` when no input is focused
- Card name search
- Page navigation filtered by user permissions
- Recent searches integration
- Saved commands with `saved:` prefix; persist in localStorage. (structured for future server sync)
- Help mode (`?`) with inline syntax snippets and guide page deep links
- Navigation mode (`>`) for quick page jumping
- Theme toggle, random card, copy URL actions
- Desktop only - does not initialize on mobile

### Guide Page
- Public route, no auth required
- Guide sections are auth gated behind same logic that runs nav-bar access, so users won't see help or options for pages they cannot access
- Renders from shared guide-data.js (single source for palette help + guide content)
- Sticky sidebar with scroll spy and search/filter
- Covers all 18 search syntax categories, 5 feature pages, palette usage, and tips
- All examples are clickable/runnable

co-exists with Search page Syntax section (for now)
fixes #80 