### PR TITLE
CP2 polish

### DIFF
--- a/css/command-palette.css
+++ b/css/command-palette.css
@@ -501,14 +501,11 @@
     border: 0;
 }
 
-/* Keyrune set symbols rendered inside result icons */
+/* Keyrune set symbols rendered inside result icons - follow current text color */
 .cp-result-icon .ss {
     font-size: 16px;
     line-height: 1;
-    color: var(--greytext, #888);
-}
-.cp-result.active .cp-result-icon .ss {
-    color: var(--ainfo, #559eff);
+    color: var(--normal, #111);
 }
 
 /* Preserve inline icon colors (e.g., rarity pips) over active-state override */

--- a/css/command-palette.css
+++ b/css/command-palette.css
@@ -145,13 +145,16 @@
 
 /* Category header */
 .cp-category-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
     padding: 6px 16px 4px;
     margin-top: 4px;
     font-size: 0.65rem;
     font-weight: 600;
     letter-spacing: 0.08em;
     text-transform: uppercase;
-    color: var(--greytext, #888);
+    color: #FFBF00;
     user-select: none;
     border-top: 1px solid var(--border-subtle, rgba(0, 0, 0, 0.06));
 }
@@ -161,29 +164,10 @@
     margin-top: 0;
 }
 
-.cp-category-header {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-}
-
 .cp-category-header svg {
     width: 12px;
     height: 12px;
     opacity: 0.8;
-}
-
-.cp-category-header[data-category="recent"],
-.cp-category-header[data-category="commands"] {
-    color: #FFBF00;
-}
-
-.cp-category-header[data-category="saved"] {
-    color: #8b5cf6;
-}
-
-.cp-category-header[data-category="cards"] {
-    color: var(--ainfo, #559eff);
 }
 
 /* Result row */

--- a/css/command-palette.css
+++ b/css/command-palette.css
@@ -411,10 +411,10 @@
 .cp-chip {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
-    padding: 2px 4px 2px 8px;
+    gap: 6px;
+    padding: 3px 8px;
     font-size: 0.8rem;
-    line-height: 1.4;
+    line-height: 1.2;
     background: var(--surface-2, rgba(0, 0, 0, 0.06));
     border: 1px solid var(--border-subtle, rgba(0, 0, 0, 0.06));
     border-radius: 999px;
@@ -450,21 +450,24 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 16px;
+    width: 0;
     height: 16px;
     padding: 0;
-    margin-left: 2px;
+    margin-left: 0;
     border: none;
     border-radius: 50%;
     background: transparent;
     color: inherit;
     cursor: pointer;
     opacity: 0;
-    transition: opacity 0.1s, background 0.1s;
+    overflow: hidden;
+    transition: opacity 0.1s, background 0.1s, width 0.12s, margin-left 0.12s;
 }
 .cp-chip:hover .cp-chip-delete,
 .cp-chip.active .cp-chip-delete {
     opacity: 0.7;
+    width: 16px;
+    margin-left: 2px;
 }
 .cp-chip-delete:hover {
     opacity: 1 !important;
@@ -496,4 +499,19 @@
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
     border: 0;
+}
+
+/* Keyrune set symbols rendered inside result icons */
+.cp-result-icon .ss {
+    font-size: 16px;
+    line-height: 1;
+    color: var(--greytext, #888);
+}
+.cp-result.active .cp-result-icon .ss {
+    color: var(--ainfo, #559eff);
+}
+
+/* Preserve inline icon colors (e.g., rarity pips) over active-state override */
+.cp-result.active .cp-result-icon[style*="color"] {
+    color: unset;
 }

--- a/css/command-palette.css
+++ b/css/command-palette.css
@@ -182,8 +182,8 @@
 
 /* Result icon */
 .cp-result-icon {
-    width: 20px;
-    height: 20px;
+    width: 24px;
+    height: 24px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -192,8 +192,8 @@
 }
 
 .cp-result-icon svg {
-    width: 16px;
-    height: 16px;
+    width: 20px;
+    height: 20px;
 }
 
 .cp-result.active .cp-result-icon {
@@ -503,7 +503,7 @@
 
 /* Keyrune set symbols rendered inside result icons - follow current text color */
 .cp-result-icon .ss {
-    font-size: 16px;
+    font-size: 20px;
     line-height: 1;
     color: var(--normal, #111);
 }

--- a/css/command-palette.css
+++ b/css/command-palette.css
@@ -161,6 +161,31 @@
     margin-top: 0;
 }
 
+.cp-category-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.cp-category-header svg {
+    width: 12px;
+    height: 12px;
+    opacity: 0.8;
+}
+
+.cp-category-header[data-category="recent"],
+.cp-category-header[data-category="commands"] {
+    color: #FFBF00;
+}
+
+.cp-category-header[data-category="saved"] {
+    color: #8b5cf6;
+}
+
+.cp-category-header[data-category="cards"] {
+    color: var(--ainfo, #559eff);
+}
+
 /* Result row */
 .cp-result {
     display: flex;
@@ -335,7 +360,9 @@
     border: 1px solid var(--green, #4caf50);
     border-radius: 8px;
     z-index: 600;
-    transition: right 300ms ease;
+    opacity: 0;
+    transform: scale(0.96);
+    transition: right 300ms ease, opacity 220ms ease, transform 220ms ease;
     white-space: nowrap;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
     pointer-events: none;
@@ -348,6 +375,8 @@
 
 .cp-toast.show {
     right: 1em;
+    opacity: 1;
+    transform: scale(1);
 }
 
 /* ── 8. Save Sub-input ──────────────────────────────────── */

--- a/css/command-palette.css
+++ b/css/command-palette.css
@@ -397,6 +397,110 @@
     color: var(--greytext, #888);
 }
 
+/* ── 8a. Save Search Modal ───────────────────────────────── */
+.cp-save-modal-backdrop {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.4);
+    backdrop-filter: blur(2px);
+    -webkit-backdrop-filter: blur(2px);
+    z-index: 10;
+    opacity: 0;
+    transition: opacity 120ms ease-out;
+    pointer-events: none;
+}
+
+.cp-save-modal-backdrop.open {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.cp-save-modal {
+    width: 92%;
+    max-width: 420px;
+    background: var(--background, #fff);
+    border: 1px solid var(--border-moderate, rgba(0, 0, 0, 0.12));
+    border-radius: 12px;
+    box-shadow: 0 20px 48px rgba(0, 0, 0, 0.45);
+    padding: 16px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    min-height: 140px;
+    transform: translateY(4px);
+    transition: transform 140ms ease-out;
+}
+
+.cp-save-modal-backdrop.open .cp-save-modal {
+    transform: translateY(0);
+}
+
+.cp-save-modal-title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--normal, #111);
+    margin: 0;
+}
+
+.cp-save-modal-preview {
+    font-size: 0.78rem;
+    color: var(--greytext, #888);
+    background: var(--surface-1, rgba(0, 0, 0, 0.04));
+    border: 1px solid var(--border-subtle, rgba(0, 0, 0, 0.08));
+    border-radius: 6px;
+    padding: 6px 8px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.cp-save-modal-input {
+    width: 100%;
+    padding: 8px 10px;
+    background: var(--surface-1, rgba(0, 0, 0, 0.04));
+    border: 1px solid var(--border-moderate, rgba(0, 0, 0, 0.12));
+    border-radius: 6px;
+    outline: none;
+    font: inherit;
+    font-size: 0.9rem;
+    color: var(--normal, #111);
+    box-sizing: border-box;
+}
+
+.cp-save-modal-input:focus {
+    border-color: var(--ainfo, #559eff);
+}
+
+.cp-save-modal-input::placeholder {
+    color: var(--greytext, #888);
+}
+
+.cp-save-modal-hint {
+    display: flex;
+    justify-content: center;
+    gap: 14px;
+    font-size: 0.7rem;
+    color: var(--greytext, #888);
+    margin-top: 2px;
+}
+
+.cp-save-modal-hint kbd {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 5px;
+    background: var(--surface-2, rgba(0, 0, 0, 0.06));
+    border: 1px solid var(--border-subtle, rgba(0, 0, 0, 0.08));
+    border-radius: 4px;
+    font-size: 0.65rem;
+    font-family: inherit;
+    margin-right: 3px;
+    color: var(--normal, #111);
+}
+
 /* ── 9. Chip Container ──────────────────────────────────── */
 .cp-chip-container {
     flex: 1;

--- a/css/command-palette.css
+++ b/css/command-palette.css
@@ -363,40 +363,6 @@
     transform: scale(1);
 }
 
-/* ── 8. Save Sub-input ──────────────────────────────────── */
-.cp-save-row {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: 8px;
-    padding: 10px 16px;
-    border-top: 1px solid var(--border-subtle, rgba(0, 0, 0, 0.08));
-    background: var(--surface-1, rgba(0, 0, 0, 0.04));
-    flex-shrink: 0;
-}
-
-.cp-save-label {
-    font-size: 0.8rem;
-    color: var(--greytext, #888);
-    white-space: nowrap;
-    flex-shrink: 0;
-}
-
-.cp-save-input {
-    flex: 1;
-    border: none;
-    outline: none;
-    background: transparent;
-    font: inherit;
-    font-size: 0.9rem;
-    color: var(--normal, #111);
-    min-width: 0;
-}
-
-.cp-save-input::placeholder {
-    color: var(--greytext, #888);
-}
-
 /* ── 8a. Save Search Modal ───────────────────────────────── */
 .cp-save-modal-backdrop {
     position: absolute;

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -976,6 +976,11 @@
             els[index].scrollIntoView({ block: 'nearest' });
         }
         activeIndex = index;
+        // Flag the item as explicitly picked by the user so Enter executes it
+        // rather than the chip-composition fallback.
+        if (index >= 0 && index < resultItems.length && resultItems[index]) {
+            resultItems[index]._userPicked = true;
+        }
         updateDeleteHint();
     }
 
@@ -1479,36 +1484,29 @@
 
         // Enter
         if (key === 'Enter' || code === 13) {
-            // D3: parent-only chip (or parent + nav-sub chips) + empty input + no highlighted result → navigate
-            if (chips && chips.count() > 0 && input.value.trim() === '' && activeIndex < 0) {
-                var chipsNow = chips.all();
-                var firstNav = chipsNow[0];
-                var onlyParentAndSubs = firstNav && firstNav.type === 'nav' && isParentNav(firstNav.navName);
-                if (onlyParentAndSubs) {
-                    var allMatchingSubs = true;
-                    var pKeyE = navParentKeys[firstNav.navName];
-                    for (var ek = 1; ek < chipsNow.length; ek++) {
-                        if (chipsNow[ek].type !== 'nav-sub' || chipsNow[ek]._parentKey !== pKeyE) {
-                            allMatchingSubs = false;
-                            break;
-                        }
-                    }
-                    if (allMatchingSubs) {
-                        e.preventDefault();
-                        if (chipsNow.length === 1) {
-                            // Only parent chip: navigate to base URL
-                            window.location.href = firstNav.navLink;
-                            return;
-                        }
-                        // Parent + sub chips: compose params
-                        var baseE = (firstNav.navLink || '').split('?')[0];
-                        var paramsE = [];
-                        for (var ep = 1; ep < chipsNow.length; ep++) {
-                            if (chipsNow[ep]._urlParam) paramsE.push(chipsNow[ep]._urlParam);
-                        }
-                        window.location.href = baseE + (paramsE.length > 0 ? '?' + paramsE.join('&') : '');
+            // Chips locked + empty input: default to executing the composed query
+            // rather than whatever default-view result happens to be highlighted.
+            // If the user wants to pick a default-view item instead, they can arrow
+            // to it first (that changes activeIndex to a user-selected value, not
+            // the auto-select-first-result).
+            if (chips && chips.count() > 0 && input.value.trim() === '') {
+                var activeItem = (activeIndex >= 0 && activeIndex < resultItems.length)
+                    ? resultItems[activeIndex] : null;
+                // Only fall through to executeResult when the active item was explicitly
+                // arrowed-to (userPickedResult flag), otherwise treat Enter as "run chips".
+                if (!activeItem || !activeItem._userPicked) {
+                    e.preventDefault();
+                    var navUrl = chipsNavURL(chips.all());
+                    if (navUrl) {
+                        window.location.href = navUrl;
                         return;
                     }
+                    var composed = chips.composedQuery();
+                    if (composed) {
+                        recordRecentSearch(composed);
+                        window.location.href = '/search?q=' + encodeURIComponent(composed);
+                    }
+                    return;
                 }
             }
 

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -173,6 +173,32 @@
         return div.innerHTML;
     }
 
+    function categoryKeyFor(title) {
+        var t = (title || '').toLowerCase();
+        if (t.indexOf('recent') >= 0) return 'recent';
+        if (t.indexOf('saved') >= 0) return 'saved';
+        if (t.indexOf('page') >= 0 || t.indexOf('navigate') >= 0) return 'pages';
+        if (t.indexOf('card') >= 0) return 'cards';
+        if (t.indexOf('command') >= 0 || t.indexOf('action') >= 0) return 'commands';
+        if (t.indexOf('help') >= 0) return 'help';
+        if (t.indexOf('syntax') >= 0) return 'syntax';
+        return 'other';
+    }
+
+    function categoryIconFor(title) {
+        var key = categoryKeyFor(title);
+        var map = {
+            recent: 'clock',
+            saved: 'bookmark',
+            pages: 'compass',
+            cards: 'search',
+            commands: 'zap',
+            help: 'help-circle',
+            syntax: 'code'
+        };
+        return map[key] || null;
+    }
+
     // ── DOM creation ─────────────────────────────────────────────────
     var overlay = document.createElement('div');
     overlay.className = 'cp-overlay';
@@ -864,7 +890,10 @@
         for (var i = 0; i < items.length; i++) {
             var item = items[i];
             if (item.type === 'header') {
-                html += '<div class="cp-category-header">' + escapeHtml(item.title) + '</div>';
+                var headerKey = categoryKeyFor(item.title);
+                var headerIcon = categoryIconFor(item.title);
+                var iconHtml = headerIcon ? '<i data-lucide="' + headerIcon + '"></i>' : '';
+                html += '<div class="cp-category-header" data-category="' + escapeHtml(headerKey) + '">' + iconHtml + '<span>' + escapeHtml(item.title) + '</span></div>';
                 continue;
             }
 

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -933,8 +933,18 @@
 
         resultsEl.innerHTML = html;
 
-        if (idx > 0) {
+        // Auto-select the first result UNLESS chips are locked and input is empty.
+        // In that case, Enter should run the chip composition, not a default item.
+        var skipAutoSelect = chips && chips.count() > 0 && input && input.value.trim() === '';
+        if (idx > 0 && !skipAutoSelect) {
             activeIndex = 0;
+        } else {
+            activeIndex = -1;
+            // Clear any lingering .active class on result rows
+            var activeEls = resultsEl.querySelectorAll('.cp-result.active');
+            for (var ai = 0; ai < activeEls.length; ai++) {
+                activeEls[ai].classList.remove('active');
+            }
         }
         updateDeleteHint();
 

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -1326,7 +1326,7 @@
         handleInput();
     }
 
-    // Delete without confirmation — used by Shift+Delete keyboard shortcut.
+    // Delete without confirmation - used by Shift+Delete keyboard shortcut.
     function deleteSavedCommandSilent(savedId) {
         var saved = getJSON(SAVED_KEY);
         var target = null;

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -727,7 +727,7 @@
     }
 
     function buildProviderItem(prefix, provider, candidate) {
-        return {
+        var item = {
             type: 'filter-candidate',
             title: candidate.label,
             subtitle: candidate.sublabel || '',
@@ -756,6 +756,14 @@
                 }
             }
         };
+        if (candidate.keyrune) {
+            var kr = String(candidate.keyrune).toLowerCase().replace(/[^a-z0-9]/g, '');
+            item.iconHtml = '<i class="ss ss-' + kr + '"></i>';
+        }
+        if (candidate.iconColor) {
+            item.iconStyle = 'color: ' + candidate.iconColor;
+        }
+        return item;
     }
 
     // ── Sub-view rendering (parent nav chip locked) ──────────────────
@@ -863,7 +871,12 @@
             var activeClass = idx === 0 ? ' active' : '';
             var disabledClass = item.disabled ? ' disabled' : '';
             html += '<div class="cp-result' + activeClass + disabledClass + '" role="option" data-index="' + idx + '"' + (item.disabled ? ' aria-disabled="true"' : '') + '>';
-            html += '<div class="cp-result-icon"><i data-lucide="' + escapeHtml(item.icon || 'search') + '"></i></div>';
+            if (item.iconHtml) {
+                html += '<div class="cp-result-icon">' + item.iconHtml + '</div>';
+            } else {
+                var iconStyleAttr = item.iconStyle ? ' style="' + escapeHtml(item.iconStyle) + '"' : '';
+                html += '<div class="cp-result-icon"' + iconStyleAttr + '><i data-lucide="' + escapeHtml(item.icon || 'search') + '"></i></div>';
+            }
             html += '<div class="cp-result-body">';
             html += '<div class="cp-result-title">' + escapeHtml(item.title) + '</div>';
             if (item.snippets) {

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -127,6 +127,7 @@
     var RECENT_KEY = 'mtgban_recent_searches';
     var SAVED_KEY = 'mtgban_saved_commands';
     var MAX_SAVED = 50;
+    var saveModalOpen = false;
     var MAX_NAME = 60;
 
     function getJSON(key) {
@@ -337,7 +338,7 @@
         isOpen = false;
         overlay.classList.remove('open');
         document.body.style.overflow = '';
-        removeSaveRow();
+        removeSaveModal();
         if (previousFocus) {
             previousFocus.focus();
             previousFocus = null;
@@ -508,7 +509,7 @@
                 name: 'Save Current Search',
                 icon: 'bookmark-plus',
                 keywords: ['save', 'bookmark', 'store', 'command'],
-                action: function() { showSaveRow(); }
+                action: function() { showSaveModal(); }
             });
         }
 
@@ -1186,14 +1187,13 @@
     });
 
     // ── Saved commands ───────────────────────────────────────────────
-    function showSaveRow() {
-        removeSaveRow();
+    function showSaveModal() {
+        removeSaveModal();
 
         var queryToSave;
         if (chips && chips.count() > 0) {
             queryToSave = chips.composedQuery();
         } else {
-            // V1 behavior: fall back to page searchbox value
             var searchInput = document.getElementById('searchbox');
             queryToSave = searchInput ? searchInput.value.trim() : '';
         }
@@ -1202,45 +1202,99 @@
             return;
         }
 
-        var row = document.createElement('div');
-        row.className = 'cp-save-row';
-        row.id = 'cp-save-row';
+        // Backdrop - scopes to the palette overlay (absolute, not fixed)
+        var backdrop = document.createElement('div');
+        backdrop.className = 'cp-save-modal-backdrop';
+        backdrop.id = 'cp-save-modal-backdrop';
 
-        var label = document.createElement('span');
-        label.className = 'cp-save-label';
-        label.textContent = 'Name:';
+        // Modal card
+        var modal = document.createElement('div');
+        modal.className = 'cp-save-modal';
+        modal.setAttribute('role', 'dialog');
+        modal.setAttribute('aria-modal', 'true');
+        modal.setAttribute('aria-labelledby', 'cp-save-modal-title');
+
+        var titleEl = document.createElement('div');
+        titleEl.className = 'cp-save-modal-title';
+        titleEl.id = 'cp-save-modal-title';
+        titleEl.textContent = 'Save search';
+
+        var previewEl = document.createElement('div');
+        previewEl.className = 'cp-save-modal-preview';
+        previewEl.textContent = queryToSave;
+        previewEl.title = queryToSave;
 
         var saveInput = document.createElement('input');
-        saveInput.className = 'cp-save-input';
-        saveInput.id = 'cp-save-input';
-        saveInput.placeholder = 'Enter a name for this search...';
+        saveInput.className = 'cp-save-modal-input';
+        saveInput.id = 'cp-save-modal-input';
+        saveInput.type = 'text';
+        saveInput.placeholder = 'Enter a name...';
         saveInput.maxLength = MAX_NAME;
+        saveInput.setAttribute('autocomplete', 'off');
 
-        row.appendChild(label);
-        row.appendChild(saveInput);
-        dialog.appendChild(row);
+        var hintEl = document.createElement('div');
+        hintEl.className = 'cp-save-modal-hint';
+        hintEl.innerHTML = '<span><kbd>Enter</kbd> Save</span>' +
+            '<span><kbd>Esc</kbd> Cancel</span>';
+
+        modal.appendChild(titleEl);
+        modal.appendChild(previewEl);
+        modal.appendChild(saveInput);
+        modal.appendChild(hintEl);
+        backdrop.appendChild(modal);
+        overlay.appendChild(backdrop);
+
+        // Trigger opening transition on next frame
+        requestAnimationFrame(function() {
+            backdrop.classList.add('open');
+        });
+
+        saveModalOpen = true;
         saveInput.focus();
 
         var pendingConflict = null;
 
+        function enterNamingState() {
+            pendingConflict = null;
+            titleEl.textContent = 'Save search';
+            previewEl.textContent = queryToSave;
+            previewEl.title = queryToSave;
+            saveInput.value = '';
+            saveInput.placeholder = 'Enter a name...';
+            saveInput.maxLength = MAX_NAME;
+            hintEl.innerHTML = '<span><kbd>Enter</kbd> Save</span>' +
+                '<span><kbd>Esc</kbd> Cancel</span>';
+        }
+
+        function enterConflictState(name, existing) {
+            pendingConflict = { name: name, query: queryToSave };
+            titleEl.textContent = 'Overwrite saved search?';
+            previewEl.textContent = '"' + name + '" already exists with: ' + existing.query;
+            previewEl.title = existing.query;
+            saveInput.value = '';
+            saveInput.placeholder = 'y / n';
+            saveInput.maxLength = 3;
+            hintEl.innerHTML = '<span><kbd>Y</kbd> Overwrite</span>' +
+                '<span><kbd>N</kbd> / <kbd>Esc</kbd> Cancel</span>';
+        }
+
+        // Keep all keyboard handling local to the modal input
         saveInput.addEventListener('keydown', function(e) {
+            // Stop propagation so the palette's document-level keydown
+            // handlers do not react to typing inside the modal.
+            e.stopPropagation();
+
             if (e.key === 'Enter' || e.keyCode === 13) {
                 e.preventDefault();
 
-                // If awaiting overwrite confirmation
                 if (pendingConflict) {
                     var answer = saveInput.value.trim().toLowerCase();
                     if (answer === 'y' || answer === 'yes') {
                         saveCommand(pendingConflict.name, pendingConflict.query, true);
-                        removeSaveRow();
+                        removeSaveModal();
                         input.focus();
                     } else {
-                        // Cancel - go back to name input
-                        pendingConflict = null;
-                        label.textContent = 'Name:';
-                        saveInput.value = '';
-                        saveInput.placeholder = 'Enter a name for this search...';
-                        saveInput.maxLength = MAX_NAME;
+                        enterNamingState();
                     }
                     return;
                 }
@@ -1252,27 +1306,31 @@
                 }
                 var conflict = saveCommand(name, queryToSave, false);
                 if (conflict) {
-                    // Show confirmation prompt in the save row
-                    pendingConflict = { name: name, query: queryToSave };
-                    label.textContent = '"' + name + '" exists with: ' + conflict.existing.query + ' - Overwrite?';
-                    saveInput.value = '';
-                    saveInput.placeholder = 'y / n';
-                    saveInput.maxLength = 3;
+                    enterConflictState(name, conflict.existing);
                 } else {
-                    removeSaveRow();
+                    removeSaveModal();
                     input.focus();
                 }
             } else if (e.key === 'Escape' || e.keyCode === 27) {
                 e.preventDefault();
-                removeSaveRow();
+                removeSaveModal();
+                input.focus();
+            }
+        });
+
+        // Click outside the modal card (on the backdrop) closes the modal
+        backdrop.addEventListener('click', function(e) {
+            if (e.target === backdrop) {
+                removeSaveModal();
                 input.focus();
             }
         });
     }
 
-    function removeSaveRow() {
-        var row = document.getElementById('cp-save-row');
-        if (row) row.parentNode.removeChild(row);
+    function removeSaveModal() {
+        saveModalOpen = false;
+        var bd = document.getElementById('cp-save-modal-backdrop');
+        if (bd && bd.parentNode) bd.parentNode.removeChild(bd);
     }
 
     // Returns null if saved, or a conflict object if confirmation needed
@@ -1535,7 +1593,7 @@
         // Ctrl/Cmd+S - save current search
         if ((e.ctrlKey || e.metaKey) && (key === 's' || code === 83)) {
             e.preventDefault();
-            showSaveRow();
+            showSaveModal();
             return;
         }
 
@@ -1739,8 +1797,8 @@
     dialog.addEventListener('keydown', function(e) {
         if ((e.key === 'Escape' || e.keyCode === 27) && e.target.id !== 'cp-input') {
             e.preventDefault();
-            if (document.getElementById('cp-save-row')) {
-                removeSaveRow();
+            if (saveModalOpen) {
+                removeSaveModal();
                 input.focus();
             } else {
                 closePalette();

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -1275,7 +1275,7 @@
             saveInput.placeholder = 'y / n';
             saveInput.maxLength = 3;
             hintEl.innerHTML = '<span><kbd>Y</kbd> Overwrite</span>' +
-                '<span><kbd>N</kbd> / <kbd>Esc</kbd> Cancel</span>';
+                '<span><kbd>Esc</kbd> Cancel</span>';
         }
 
         // Keep all keyboard handling local to the modal input
@@ -1315,6 +1315,8 @@
                 e.preventDefault();
                 removeSaveModal();
                 input.focus();
+            } else if (e.key === 'Tab' || e.keyCode === 9) {
+                e.preventDefault();
             }
         });
 

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -1217,25 +1217,18 @@
         var titleEl = document.createElement('div');
         titleEl.className = 'cp-save-modal-title';
         titleEl.id = 'cp-save-modal-title';
-        titleEl.textContent = 'Save search';
 
         var previewEl = document.createElement('div');
         previewEl.className = 'cp-save-modal-preview';
-        previewEl.textContent = queryToSave;
-        previewEl.title = queryToSave;
 
         var saveInput = document.createElement('input');
         saveInput.className = 'cp-save-modal-input';
         saveInput.id = 'cp-save-modal-input';
         saveInput.type = 'text';
-        saveInput.placeholder = 'Enter a name...';
-        saveInput.maxLength = MAX_NAME;
         saveInput.setAttribute('autocomplete', 'off');
 
         var hintEl = document.createElement('div');
         hintEl.className = 'cp-save-modal-hint';
-        hintEl.innerHTML = '<span><kbd>Enter</kbd> Save</span>' +
-            '<span><kbd>Esc</kbd> Cancel</span>';
 
         modal.appendChild(titleEl);
         modal.appendChild(previewEl);
@@ -1250,7 +1243,6 @@
         });
 
         saveModalOpen = true;
-        saveInput.focus();
 
         var pendingConflict = null;
 
@@ -1277,6 +1269,9 @@
             hintEl.innerHTML = '<span><kbd>Y</kbd> Overwrite</span>' +
                 '<span><kbd>Esc</kbd> Cancel</span>';
         }
+
+        enterNamingState();
+        saveInput.focus();
 
         // Keep all keyboard handling local to the modal input
         saveInput.addEventListener('keydown', function(e) {

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -1458,6 +1458,8 @@
 
     // ── Keyboard: global ─────────────────────────────────────────────
     document.addEventListener('keydown', function(e) {
+        if (saveModalOpen) return;
+
         // Ctrl/Cmd+K to toggle
         if ((e.ctrlKey || e.metaKey) && (e.key === 'k' || e.keyCode === 75)) {
             e.preventDefault();
@@ -1484,6 +1486,7 @@
 
     // ── Focus trap on dialog level ─────────────────────────────────────
     dialog.addEventListener('keydown', function(e) {
+        if (saveModalOpen) return;
         if ((e.key === 'Tab' || e.keyCode === 9) && e.target !== input) {
             e.preventDefault();
             input.focus();
@@ -1492,6 +1495,8 @@
 
     // ── Keyboard: internal (palette open) ────────────────────────────
     input.addEventListener('keydown', function(e) {
+        if (saveModalOpen) return;
+
         var key = e.key || '';
         var code = e.keyCode || 0;
 

--- a/js/palette-providers.js
+++ b/js/palette-providers.js
@@ -63,13 +63,13 @@
         icon: 'diamond',
         getCandidates: function (query, ctx) {
             var base = [
-                { value: 'mythic', label: 'Mythic', sublabel: 'm' },
-                { value: 'rare', label: 'Rare', sublabel: 'r' },
-                { value: 'uncommon', label: 'Uncommon', sublabel: 'u' },
-                { value: 'common', label: 'Common', sublabel: 'c' },
-                { value: 'special', label: 'Special', sublabel: 's' },
-                { value: 'token', label: 'Token', sublabel: 't' },
-                { value: 'oversize', label: 'Oversize', sublabel: 'o' }
+                { value: 'mythic', label: 'Mythic', sublabel: 'm', iconColor: '#f59e0b' },
+                { value: 'rare', label: 'Rare', sublabel: 'r', iconColor: '#d4af37' },
+                { value: 'uncommon', label: 'Uncommon', sublabel: 'u', iconColor: '#c0c0c0' },
+                { value: 'common', label: 'Common', sublabel: 'c', iconColor: '#555' },
+                { value: 'special', label: 'Special', sublabel: 's', iconColor: '#8b5cf6' },
+                { value: 'token', label: 'Token', sublabel: 't', iconColor: '#888' },
+                { value: 'oversize', label: 'Oversize', sublabel: 'o', iconColor: '#888' }
             ];
             if (ctx && ctx.cardMeta && ctx.cardMeta.rarities && ctx.cardMeta.rarities.length > 0) {
                 var allowed = {};
@@ -89,9 +89,9 @@
         icon: 'sparkles',
         getCandidates: function (query) {
             var base = [
-                { value: 'foil', label: 'Foil' },
-                { value: 'nonfoil', label: 'Non-foil' },
-                { value: 'etched', label: 'Etched' }
+                { value: 'foil', label: 'Foil', iconColor: '#d4af37' },
+                { value: 'nonfoil', label: 'Non-foil', iconColor: '#888' },
+                { value: 'etched', label: 'Etched', iconColor: '#06b6d4' }
             ];
             return filterEntries(base, query);
         }
@@ -372,7 +372,8 @@
                 opts.push({
                     value: s.code,
                     label: s.name,
-                    sublabel: s.code + (s.released ? ' \xb7 ' + s.released.substring(0, 4) : '')
+                    sublabel: s.code + (s.released ? ' \xb7 ' + s.released.substring(0, 4) : ''),
+                    keyrune: s.keyrune || ''
                 });
             }
             if (ctx && ctx.cardMeta && ctx.cardMeta.printings) {

--- a/templates/base-landing.html
+++ b/templates/base-landing.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" type="text/css" href="/css/main.css?hash={{.Hash}}">
     {{block "extra-css" .}}{{end}}
     <link rel="stylesheet" type="text/css" href="/css/command-palette.css?hash={{.Hash}}">
+    <link href="//cdn.jsdelivr.net/npm/keyrune@latest/css/keyrune.css" rel="stylesheet" type="text/css">
 
     <link rel="apple-touch-icon" sizes="120x120" href="/img/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/img/favicon/favicon-32x32.png">

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" type="text/css" href="/css/main.css?hash={{.Hash}}">
     {{block "extra-css" .}}{{end}}
     <link rel="stylesheet" type="text/css" href="/css/command-palette.css?hash={{.Hash}}">
+    <link href="//cdn.jsdelivr.net/npm/keyrune@latest/css/keyrune.css" rel="stylesheet" type="text/css">
 
     <link rel="apple-touch-icon" sizes="120x120" href="/img/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/img/favicon/favicon-32x32.png">


### PR DESCRIPTION
- Keyrune set symbols render in the s:/e: dropdown
- Rarity color pips: mythic/rare/uncommon/common/special all tinted
- Finish dropdown icons tinted by type
- Chip tightening: symmetric padding, tighter line-height, delete button collapses at rest
- Toast fades + scales on both entry and exit
- Enter with chips locked + empty input runs the composed chip query instead of the auto-highlighted default result
- Default view no longer auto-highlights the first row when chips are locked