### PR TITLE
mobile/chart: add date range picker to drawer

### DIFF
--- a/api_chart.go
+++ b/api_chart.go
@@ -3,14 +3,17 @@ package main
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mtgban/go-mtgban/mtgmatcher"
 )
 
 type ChartAPIResponse struct {
-	AxisLabels []string          `json:"axisLabels"`
-	Datasets   []ChartAPIDataset `json:"datasets"`
+	MaxLookbackDays int               `json:"maxLookbackDays"`
+	AxisLabels      []string          `json:"axisLabels"`
+	Datasets        []ChartAPIDataset `json:"datasets"`
 }
 
 type ChartAPIDataset struct {
@@ -42,7 +45,21 @@ func ChartDataAPI(w http.ResponseWriter, r *http.Request) {
 	userTier := GetParamFromSig(sig, "UserTier")
 
 	lb := lookbackForTier(userTier)
+	maxDays := lb.Days()
+
 	earliest, _ := PricesArchiveDB.GetEarliestDate(r.Context(), co.UUID, co.Foil, co.Etched, lb)
+
+	if rangeStr := r.FormValue("range"); rangeStr != "" {
+		if days, err := strconv.Atoi(rangeStr); err == nil && days > 0 {
+			if days > maxDays {
+				days = maxDays
+			}
+			cutoff := time.Now().AddDate(0, 0, -days)
+			if cutoff.After(earliest) {
+				earliest = cutoff
+			}
+		}
+	}
 
 	axisLabels := getDateAxisValues(earliest)
 	datasets := getDatasets(uuid, co.Sealed, axisLabels, userTier)
@@ -60,8 +77,9 @@ func ChartDataAPI(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := ChartAPIResponse{
-		AxisLabels: axisLabels,
-		Datasets:   apiDatasets,
+		MaxLookbackDays: maxDays,
+		AxisLabels:      axisLabels,
+		Datasets:        apiDatasets,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/css/search-mobile.css
+++ b/css/search-mobile.css
@@ -1330,6 +1330,25 @@
     flex-shrink: 0;
 }
 
+.m-chart-range {
+    font-size: 0.7rem;
+    font-weight: 600;
+    padding: 0.25em 0.6em;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: none;
+    color: var(--text);
+    cursor: pointer;
+    min-height: auto !important;
+    flex-shrink: 0;
+    margin-right: 0.4em;
+}
+
+.m-chart-range:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+
 .m-chart-container {
     flex: 1;
     position: relative;

--- a/css/search-mobile.css
+++ b/css/search-mobile.css
@@ -1331,6 +1331,15 @@
 }
 
 .m-chart-range {
+    position: relative;
+    flex-shrink: 0;
+    margin-right: 0.4em;
+}
+
+.m-chart-range-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3em;
     font-size: 0.7rem;
     font-weight: 600;
     padding: 0.25em 0.6em;
@@ -1340,13 +1349,71 @@
     color: var(--text);
     cursor: pointer;
     min-height: auto !important;
-    flex-shrink: 0;
-    margin-right: 0.4em;
 }
 
-.m-chart-range:disabled {
+.m-chart-range-btn:disabled {
     opacity: 0.5;
     cursor: default;
+}
+
+.m-chart-range-caret {
+    font-size: 0.85em;
+    line-height: 1;
+    opacity: 0.7;
+}
+
+.m-chart-range-menu {
+    position: absolute;
+    top: calc(100% + 0.3em);
+    right: 0;
+    margin: 0;
+    padding: 0.25em 0;
+    list-style: none;
+    min-width: 6em;
+    background: rgba(30, 30, 50, 0.98);
+    backdrop-filter: blur(20px) saturate(1.5);
+    -webkit-backdrop-filter: blur(20px) saturate(1.5);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 6px;
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.5);
+    z-index: 10;
+    display: none;
+}
+
+.m-chart-range.open .m-chart-range-menu {
+    display: block;
+}
+
+.m-chart-range-opt {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.2em;
+    padding: 0.5em 0.8em;
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: var(--text);
+    cursor: pointer;
+}
+
+.m-chart-range-opt.is-active {
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.m-chart-range-opt.is-locked {
+    color: rgba(255, 255, 255, 0.45);
+    cursor: default;
+}
+
+.m-chart-range-opt:not(.is-locked):active {
+    background: rgba(255, 255, 255, 0.12);
+}
+
+.m-chart-range-lock {
+    font-size: 0.85em;
+    min-width: 1em;
+    text-align: right;
+    flex-shrink: 0;
 }
 
 .m-chart-container {

--- a/js/mobile-chart.js
+++ b/js/mobile-chart.js
@@ -1,8 +1,39 @@
 // Mobile Chart - price history in a bottom drawer with pinch/pan/zoom
 (function() {
     var currentChart = null;
+    var currentCardId = null;
+    var currentMaxLoaded = 0;
+    var prefetchPromise = null;
     var libsLoaded = false;
     var libsLoading = false;
+
+    function pickInitialRange() {
+        var saved = parseInt(localStorage.getItem('chartDateRange'));
+        if (isNaN(saved) || saved <= 0) saved = 180;
+        var sel = document.getElementById('m-chart-range');
+        if (!sel) return saved;
+        var bestEnabled = 30;
+        var matched = false;
+        for (var i = 0; i < sel.options.length; i++) {
+            var opt = sel.options[i];
+            if (opt.disabled) continue;
+            var v = parseInt(opt.value);
+            if (v <= saved && v > bestEnabled) bestEnabled = v;
+            if (v === saved) matched = true;
+        }
+        return matched ? saved : bestEnabled;
+    }
+
+    function applyRangeFilter(range) {
+        if (!currentChart) return;
+        var labels = currentChart.data.labels;
+        if (!labels || range === 0 || range >= labels.length) {
+            currentChart.options.scales.x.min = undefined;
+        } else {
+            currentChart.options.scales.x.min = labels[range - 1];
+        }
+        currentChart.update();
+    }
 
     function loadChartLibs(callback) {
         if (libsLoaded) { callback(); return; }
@@ -235,6 +266,7 @@
         var canvas = document.getElementById('m-chart-canvas');
         var resetBtn = document.getElementById('m-chart-reset');
         var legendEl = document.getElementById('m-chart-legend');
+        var rangeSel = document.getElementById('m-chart-range');
 
         nameEl.textContent = cardName;
         loading.style.display = 'block';
@@ -242,6 +274,7 @@
         if (legendEl) legendEl.innerHTML = '';
         canvas.style.display = 'none';
         resetBtn.style.display = 'none';
+        if (rangeSel) rangeSel.disabled = true;
         overlay.classList.add('open');
         drawer.classList.add('open');
 
@@ -249,11 +282,18 @@
             currentChart.destroy();
             currentChart = null;
         }
+        currentCardId = cardId;
+        currentMaxLoaded = 0;
+        prefetchPromise = null;
+
+        var initialRange = pickInitialRange();
+        if (rangeSel) rangeSel.value = String(initialRange);
 
         loadChartLibs(function() {
-            fetch('/api/chart/' + encodeURIComponent(cardId))
+            fetch('/api/chart/' + encodeURIComponent(cardId) + '?range=' + initialRange)
                 .then(function(r) { return r.json(); })
                 .then(function(data) {
+                    if (currentCardId !== cardId) return;
                     loading.style.display = 'none';
                     if (!data.datasets || data.datasets.length === 0) {
                         loading.style.display = 'block';
@@ -264,6 +304,8 @@
                     resetBtn.style.display = 'inline-block';
                     currentChart = createChart(canvas.getContext('2d'), data);
                     renderChartLegend(data.datasets, currentChart);
+                    currentMaxLoaded = initialRange;
+                    if (rangeSel) rangeSel.disabled = false;
                 })
                 .catch(function(err) {
                     loading.style.display = 'block';
@@ -281,4 +323,28 @@
     window.resetChartZoom = function() {
         if (currentChart) currentChart.resetZoom();
     };
+
+    window.changeChartRange = function(range) {
+        if (isNaN(range) || range <= 0) return;
+        localStorage.setItem('chartDateRange', String(range));
+        if (currentChart) currentChart.resetZoom();
+        if (range <= currentMaxLoaded) {
+            applyRangeFilter(range);
+        }
+    };
+
+    function wireRangePicker() {
+        var sel = document.getElementById('m-chart-range');
+        if (!sel) return;
+        sel.addEventListener('change', function() {
+            var v = parseInt(this.value);
+            window.changeChartRange(v);
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', wireRangePicker);
+    } else {
+        wireRangePicker();
+    }
 })();

--- a/js/mobile-chart.js
+++ b/js/mobile-chart.js
@@ -35,6 +35,31 @@
         currentChart.update();
     }
 
+    function prefetchFullRange(cardId, fullRange) {
+        prefetchPromise = fetch('/api/chart/' + encodeURIComponent(cardId) + '?range=' + fullRange)
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                if (currentCardId !== cardId || !currentChart) return;
+                if (!data || !data.datasets) return;
+                currentChart.data.labels = data.axisLabels;
+                data.datasets.forEach(function(ds, i) {
+                    if (currentChart.data.datasets[i]) {
+                        currentChart.data.datasets[i].data = ds.data.map(function(v) {
+                            var n = parseFloat(v);
+                            return isNaN(n) ? null : n;
+                        });
+                    }
+                });
+                currentChart.update('none');
+                currentMaxLoaded = fullRange;
+            })
+            .catch(function(err) {
+                console.error('chart prefetch failed', err);
+                prefetchPromise = null;
+            });
+        return prefetchPromise;
+    }
+
     function loadChartLibs(callback) {
         if (libsLoaded) { callback(); return; }
         if (libsLoading) {
@@ -306,6 +331,9 @@
                     renderChartLegend(data.datasets, currentChart);
                     currentMaxLoaded = initialRange;
                     if (rangeSel) rangeSel.disabled = false;
+                    if (data.maxLookbackDays && data.maxLookbackDays > initialRange) {
+                        prefetchFullRange(cardId, data.maxLookbackDays);
+                    }
                 })
                 .catch(function(err) {
                     loading.style.display = 'block';
@@ -328,9 +356,32 @@
         if (isNaN(range) || range <= 0) return;
         localStorage.setItem('chartDateRange', String(range));
         if (currentChart) currentChart.resetZoom();
+
         if (range <= currentMaxLoaded) {
             applyRangeFilter(range);
+            return;
         }
+
+        var rangeSel = document.getElementById('m-chart-range');
+        var cardId = currentCardId;
+        if (rangeSel) rangeSel.disabled = true;
+
+        var p = prefetchPromise;
+        if (!p) {
+            // Prefetch was never started or failed - fire one now.
+            // Fall back to `range` itself as the upper bound; this is a best-effort
+            // expansion since we no longer know maxLookbackDays in this scope.
+            p = prefetchFullRange(cardId, range);
+        }
+
+        p.then(function() {
+            if (currentCardId !== cardId) return;
+            applyRangeFilter(range);
+        }).catch(function() {
+            // Swallow - the catch in prefetchFullRange already logged.
+        }).then(function() {
+            if (currentCardId === cardId && rangeSel) rangeSel.disabled = false;
+        });
     };
 
     function wireRangePicker() {

--- a/js/mobile-chart.js
+++ b/js/mobile-chart.js
@@ -10,18 +10,44 @@
     function pickInitialRange() {
         var saved = parseInt(localStorage.getItem('chartDateRange'));
         if (isNaN(saved) || saved <= 0) saved = 180;
-        var sel = document.getElementById('m-chart-range');
-        if (!sel) return saved;
+        var menu = document.getElementById('m-chart-range-menu');
+        if (!menu) return saved;
+        var opts = menu.querySelectorAll('.m-chart-range-opt');
         var bestEnabled = 30;
         var matched = false;
-        for (var i = 0; i < sel.options.length; i++) {
-            var opt = sel.options[i];
-            if (opt.disabled) continue;
-            var v = parseInt(opt.value);
+        for (var i = 0; i < opts.length; i++) {
+            var opt = opts[i];
+            if (opt.classList.contains('is-locked')) continue;
+            var v = parseInt(opt.getAttribute('data-value'));
             if (v <= saved && v > bestEnabled) bestEnabled = v;
             if (v === saved) matched = true;
         }
         return matched ? saved : bestEnabled;
+    }
+
+    function setRangePickerValue(v) {
+        var btn = document.getElementById('m-chart-range-btn');
+        var menu = document.getElementById('m-chart-range-menu');
+        if (!btn || !menu) return;
+        var label = btn.querySelector('.m-chart-range-label');
+        var opts = menu.querySelectorAll('.m-chart-range-opt');
+        for (var i = 0; i < opts.length; i++) {
+            var opt = opts[i];
+            if (parseInt(opt.getAttribute('data-value')) === v) {
+                opt.classList.add('is-active');
+                var text = opt.querySelector('.m-chart-range-text');
+                if (label && text) label.textContent = text.textContent;
+            } else {
+                opt.classList.remove('is-active');
+            }
+        }
+    }
+
+    function setRangePickerDisabled(disabled) {
+        var btn = document.getElementById('m-chart-range-btn');
+        var wrapper = document.getElementById('m-chart-range');
+        if (btn) btn.disabled = disabled;
+        if (disabled && wrapper) wrapper.classList.remove('open');
     }
 
     function applyRangeFilter(range) {
@@ -291,15 +317,13 @@
         var canvas = document.getElementById('m-chart-canvas');
         var resetBtn = document.getElementById('m-chart-reset');
         var legendEl = document.getElementById('m-chart-legend');
-        var rangeSel = document.getElementById('m-chart-range');
-
         nameEl.textContent = cardName;
         loading.style.display = 'block';
         loading.textContent = 'Loading chart...';
         if (legendEl) legendEl.innerHTML = '';
         canvas.style.display = 'none';
         resetBtn.style.display = 'none';
-        if (rangeSel) rangeSel.disabled = true;
+        setRangePickerDisabled(true);
         overlay.classList.add('open');
         drawer.classList.add('open');
 
@@ -312,7 +336,7 @@
         prefetchPromise = null;
 
         var initialRange = pickInitialRange();
-        if (rangeSel) rangeSel.value = String(initialRange);
+        setRangePickerValue(initialRange);
 
         loadChartLibs(function() {
             fetch('/api/chart/' + encodeURIComponent(cardId) + '?range=' + initialRange)
@@ -330,7 +354,7 @@
                     currentChart = createChart(canvas.getContext('2d'), data);
                     renderChartLegend(data.datasets, currentChart);
                     currentMaxLoaded = initialRange;
-                    if (rangeSel) rangeSel.disabled = false;
+                    setRangePickerDisabled(false);
                     if (data.maxLookbackDays && data.maxLookbackDays > initialRange) {
                         prefetchFullRange(cardId, data.maxLookbackDays);
                     }
@@ -355,6 +379,7 @@
     window.changeChartRange = function(range) {
         if (isNaN(range) || range <= 0) return;
         localStorage.setItem('chartDateRange', String(range));
+        setRangePickerValue(range);
         if (currentChart) currentChart.resetZoom();
 
         if (range <= currentMaxLoaded) {
@@ -362,9 +387,8 @@
             return;
         }
 
-        var rangeSel = document.getElementById('m-chart-range');
         var cardId = currentCardId;
-        if (rangeSel) rangeSel.disabled = true;
+        setRangePickerDisabled(true);
 
         var p = prefetchPromise;
         if (!p) {
@@ -380,16 +404,34 @@
         }).catch(function() {
             // Swallow - the catch in prefetchFullRange already logged.
         }).then(function() {
-            if (currentCardId === cardId && rangeSel) rangeSel.disabled = false;
+            if (currentCardId === cardId) setRangePickerDisabled(false);
         });
     };
 
     function wireRangePicker() {
-        var sel = document.getElementById('m-chart-range');
-        if (!sel) return;
-        sel.addEventListener('change', function() {
-            var v = parseInt(this.value);
+        var wrapper = document.getElementById('m-chart-range');
+        var btn = document.getElementById('m-chart-range-btn');
+        var menu = document.getElementById('m-chart-range-menu');
+        if (!wrapper || !btn || !menu) return;
+
+        btn.addEventListener('click', function(e) {
+            if (btn.disabled) return;
+            e.stopPropagation();
+            wrapper.classList.toggle('open');
+        });
+
+        menu.addEventListener('click', function(e) {
+            var opt = e.target.closest('.m-chart-range-opt');
+            if (!opt || !menu.contains(opt)) return;
+            if (opt.classList.contains('is-locked')) return;
+            var v = parseInt(opt.getAttribute('data-value'));
+            if (isNaN(v)) return;
+            wrapper.classList.remove('open');
             window.changeChartRange(v);
+        });
+
+        document.addEventListener('click', function(e) {
+            if (!wrapper.contains(e.target)) wrapper.classList.remove('open');
         });
     }
 

--- a/templates/mobile/search.html
+++ b/templates/mobile/search.html
@@ -603,6 +603,15 @@
         <div class="m-drawer-handle" onclick="hideChartDrawer()"><span></span></div>
         <div class="m-chart-header">
             <span class="m-chart-name" id="m-chart-name"></span>
+            <select class="m-chart-range" id="m-chart-range" disabled>
+                <option value="30">1mo</option>
+                <option value="90"   {{if lt $.MaxLookbackDays 90}}   disabled{{end}}>3mo{{if lt $.MaxLookbackDays 90}} 🔒{{end}}</option>
+                <option value="180"  {{if ge $.MaxLookbackDays 180}}  selected{{end}}{{if lt $.MaxLookbackDays 180}} disabled{{end}}>6mo{{if lt $.MaxLookbackDays 180}} 🔒{{end}}</option>
+                <option value="365"  {{if lt $.MaxLookbackDays 365}}  disabled{{end}}>1yr{{if lt $.MaxLookbackDays 365}} 🔒{{end}}</option>
+                <option value="730"  {{if lt $.MaxLookbackDays 730}}  disabled{{end}}>2yr{{if lt $.MaxLookbackDays 730}} 🔒{{end}}</option>
+                <option value="1825" {{if lt $.MaxLookbackDays 1825}} disabled{{end}}>5yr{{if lt $.MaxLookbackDays 1825}} 🔒{{end}}</option>
+                <option value="3650" {{if lt $.MaxLookbackDays 3650}} disabled{{end}}>10yr{{if lt $.MaxLookbackDays 3650}} 🔒{{end}}</option>
+            </select>
             <button class="m-chart-reset" id="m-chart-reset" onclick="resetChartZoom()">Reset Zoom</button>
         </div>
         <div class="m-chart-container">

--- a/templates/mobile/search.html
+++ b/templates/mobile/search.html
@@ -603,15 +603,42 @@
         <div class="m-drawer-handle" onclick="hideChartDrawer()"><span></span></div>
         <div class="m-chart-header">
             <span class="m-chart-name" id="m-chart-name"></span>
-            <select class="m-chart-range" id="m-chart-range" disabled>
-                <option value="30">1mo</option>
-                <option value="90"   {{if lt $.MaxLookbackDays 90}}   disabled{{end}}>3mo{{if lt $.MaxLookbackDays 90}} 🔒{{end}}</option>
-                <option value="180"  {{if ge $.MaxLookbackDays 180}}  selected{{end}}{{if lt $.MaxLookbackDays 180}} disabled{{end}}>6mo{{if lt $.MaxLookbackDays 180}} 🔒{{end}}</option>
-                <option value="365"  {{if lt $.MaxLookbackDays 365}}  disabled{{end}}>1yr{{if lt $.MaxLookbackDays 365}} 🔒{{end}}</option>
-                <option value="730"  {{if lt $.MaxLookbackDays 730}}  disabled{{end}}>2yr{{if lt $.MaxLookbackDays 730}} 🔒{{end}}</option>
-                <option value="1825" {{if lt $.MaxLookbackDays 1825}} disabled{{end}}>5yr{{if lt $.MaxLookbackDays 1825}} 🔒{{end}}</option>
-                <option value="3650" {{if lt $.MaxLookbackDays 3650}} disabled{{end}}>10yr{{if lt $.MaxLookbackDays 3650}} 🔒{{end}}</option>
-            </select>
+            <div class="m-chart-range" id="m-chart-range">
+                <button type="button" class="m-chart-range-btn" id="m-chart-range-btn" disabled>
+                    <span class="m-chart-range-label">6mo</span>
+                    <span class="m-chart-range-caret" aria-hidden="true">▾</span>
+                </button>
+                <ul class="m-chart-range-menu" id="m-chart-range-menu" role="listbox">
+                    <li class="m-chart-range-opt" data-value="30" role="option">
+                        <span class="m-chart-range-text">1mo</span>
+                        <span class="m-chart-range-lock" aria-hidden="true"></span>
+                    </li>
+                    <li class="m-chart-range-opt{{if lt $.MaxLookbackDays 90}} is-locked{{end}}" data-value="90" role="option"{{if lt $.MaxLookbackDays 90}} aria-disabled="true"{{end}}>
+                        <span class="m-chart-range-text">3mo</span>
+                        <span class="m-chart-range-lock" aria-hidden="true">{{if lt $.MaxLookbackDays 90}}🔒{{end}}</span>
+                    </li>
+                    <li class="m-chart-range-opt{{if lt $.MaxLookbackDays 180}} is-locked{{end}}" data-value="180" role="option"{{if lt $.MaxLookbackDays 180}} aria-disabled="true"{{end}}>
+                        <span class="m-chart-range-text">6mo</span>
+                        <span class="m-chart-range-lock" aria-hidden="true">{{if lt $.MaxLookbackDays 180}}🔒{{end}}</span>
+                    </li>
+                    <li class="m-chart-range-opt{{if lt $.MaxLookbackDays 365}} is-locked{{end}}" data-value="365" role="option"{{if lt $.MaxLookbackDays 365}} aria-disabled="true"{{end}}>
+                        <span class="m-chart-range-text">1yr</span>
+                        <span class="m-chart-range-lock" aria-hidden="true">{{if lt $.MaxLookbackDays 365}}🔒{{end}}</span>
+                    </li>
+                    <li class="m-chart-range-opt{{if lt $.MaxLookbackDays 730}} is-locked{{end}}" data-value="730" role="option"{{if lt $.MaxLookbackDays 730}} aria-disabled="true"{{end}}>
+                        <span class="m-chart-range-text">2yr</span>
+                        <span class="m-chart-range-lock" aria-hidden="true">{{if lt $.MaxLookbackDays 730}}🔒{{end}}</span>
+                    </li>
+                    <li class="m-chart-range-opt{{if lt $.MaxLookbackDays 1825}} is-locked{{end}}" data-value="1825" role="option"{{if lt $.MaxLookbackDays 1825}} aria-disabled="true"{{end}}>
+                        <span class="m-chart-range-text">5yr</span>
+                        <span class="m-chart-range-lock" aria-hidden="true">{{if lt $.MaxLookbackDays 1825}}🔒{{end}}</span>
+                    </li>
+                    <li class="m-chart-range-opt{{if lt $.MaxLookbackDays 3650}} is-locked{{end}}" data-value="3650" role="option"{{if lt $.MaxLookbackDays 3650}} aria-disabled="true"{{end}}>
+                        <span class="m-chart-range-text">10yr</span>
+                        <span class="m-chart-range-lock" aria-hidden="true">{{if lt $.MaxLookbackDays 3650}}🔒{{end}}</span>
+                    </li>
+                </ul>
+            </div>
             <button class="m-chart-reset" id="m-chart-reset" onclick="resetChartZoom()">Reset Zoom</button>
         </div>
         <div class="m-chart-container">


### PR DESCRIPTION
Uses two-stage fetching for fast first paint:
- Stage 1: load the saved range (default 6mo) for first paint
- Stage 2: prefetch the user's tier-max range in the background
- Picker changes within loaded data filter in-place via scales.x.min
- Picker changes beyond loaded data await the prefetch