### PR TITLE
CP3

### DIFF
--- a/css/command-palette.css
+++ b/css/command-palette.css
@@ -676,3 +676,9 @@
     min-width: 22px;
     text-align: center;
 }
+
+.cp-tab-hint {
+    font-size: 0.65rem;
+    padding: 1px 6px;
+    margin-top: 2px;
+}

--- a/css/command-palette.css
+++ b/css/command-palette.css
@@ -90,6 +90,11 @@
     color: #8b5cf6;
 }
 
+.cp-mode-indicator[data-mode="recent"] {
+    background: color-mix(in srgb, #14b8a6 15%, transparent);
+    color: #14b8a6;
+}
+
 /* Search input */
 .cp-input {
     flex: 1;

--- a/css/command-palette.css
+++ b/css/command-palette.css
@@ -623,57 +623,13 @@
     color: unset;
 }
 
-/* -- Hint card (default empty state) -------------------------------- */
-.cp-hint-card {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 16px 20px;
-    margin: 8px 12px 4px;
-    background: var(--surface-1, rgba(0, 0, 0, 0.04));
-    border: 1px dashed var(--border-moderate, rgba(0, 0, 0, 0.12));
-    border-radius: 10px;
-}
-
-.cp-hint-icon {
-    width: 32px;
-    height: 32px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-    color: var(--ainfo, #559eff);
-}
-
-.cp-hint-icon svg {
-    width: 22px;
-    height: 22px;
-}
-
-.cp-hint-body {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    min-width: 0;
-}
-
-.cp-hint-title {
-    font-size: 0.95rem;
-    font-weight: 600;
-    color: var(--normal, #111);
-}
-
-.cp-hint-subtitle {
-    font-size: 0.75rem;
-    color: var(--greytext, #888);
-}
-
 /* Shortcut row variant of cp-result */
 .cp-shortcut-row .cp-result-right kbd.cp-shortcut {
     font-size: 0.8rem;
     font-weight: 700;
     padding: 2px 8px;
     min-width: 22px;
+    justify-content: center;
     text-align: center;
 }
 

--- a/css/command-palette.css
+++ b/css/command-palette.css
@@ -622,3 +622,57 @@
 .cp-result.active .cp-result-icon[style*="color"] {
     color: unset;
 }
+
+/* -- Hint card (default empty state) -------------------------------- */
+.cp-hint-card {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 16px 20px;
+    margin: 8px 12px 4px;
+    background: var(--surface-1, rgba(0, 0, 0, 0.04));
+    border: 1px dashed var(--border-moderate, rgba(0, 0, 0, 0.12));
+    border-radius: 10px;
+}
+
+.cp-hint-icon {
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    color: var(--ainfo, #559eff);
+}
+
+.cp-hint-icon svg {
+    width: 22px;
+    height: 22px;
+}
+
+.cp-hint-body {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.cp-hint-title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--normal, #111);
+}
+
+.cp-hint-subtitle {
+    font-size: 0.75rem;
+    color: var(--greytext, #888);
+}
+
+/* Shortcut row variant of cp-result */
+.cp-shortcut-row .cp-result-right kbd.cp-shortcut {
+    font-size: 0.8rem;
+    font-weight: 700;
+    padding: 2px 8px;
+    min-width: 22px;
+    text-align: center;
+}

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -251,8 +251,10 @@
     // Footer
     var footer = document.createElement('div');
     footer.className = 'cp-footer';
-    footer.innerHTML = '<span><kbd>\u2191\u2193</kbd> Navigate</span>' +
-        '<span><kbd>Enter</kbd> Select</span>' +
+    footer.innerHTML =
+        '<span><kbd>\u2191\u2193</kbd> Navigate</span>' +
+        '<span class="cp-footer-action"><kbd>Enter</kbd> Select</span>' +
+        '<span class="cp-footer-tab" style="display:none"></span>' +
         '<span class="cp-footer-hint-delete" style="display:none"><kbd>Shift+Del</kbd> Remove</span>' +
         '<span><kbd>?</kbd> Help</span>' +
         '<span><kbd>Esc</kbd> Close</span>';
@@ -1051,6 +1053,7 @@
             }
         }
         updateDeleteHint();
+        updateFooterHints();
 
         // Render Lucide icons
         if (typeof lucide !== 'undefined' && lucide.createIcons) {
@@ -1096,6 +1099,7 @@
             resultItems[index]._userPicked = true;
         }
         updateDeleteHint();
+        updateFooterHints();
     }
 
     function updateDeleteHint() {
@@ -1104,6 +1108,86 @@
         var item = (activeIndex >= 0 && activeIndex < resultItems.length) ? resultItems[activeIndex] : null;
         var canDelete = item && (item.type === 'recent' || item.type === 'saved');
         hint.style.display = canDelete ? '' : 'none';
+    }
+
+    // Update the central footer slot based on the active result type.
+    // Mirrors the row-type - hint table in the spec.
+    function updateFooterHints() {
+        var actionEl = footer && footer.querySelector('.cp-footer-action');
+        var tabEl = footer && footer.querySelector('.cp-footer-tab');
+        if (!actionEl || !tabEl) return;
+
+        var item = (activeIndex >= 0 && activeIndex < resultItems.length) ? resultItems[activeIndex] : null;
+        if (!item) {
+            actionEl.innerHTML = '<kbd>Enter</kbd> Select';
+            tabEl.style.display = 'none';
+            tabEl.innerHTML = '';
+            return;
+        }
+
+        var actionHtml = '<kbd>Enter</kbd> Select';
+        var tabHtml = '';
+
+        switch (item.type) {
+            case 'shortcut':
+                actionHtml = '<kbd>Enter</kbd> Open';
+                break;
+            case 'nav':
+                actionHtml = '<kbd>Enter</kbd> Go to page';
+                if (item.navName && isParentNav(item.navName)) {
+                    tabHtml = '<kbd>Tab</kbd> Browse subpages';
+                }
+                break;
+            case 'nav-sub':
+                actionHtml = '<kbd>Enter</kbd> Open';
+                // Arbit/reverse/global filters (not sorts, not singletons) accept Tab to lock filter chip
+                if (item._parentChip && item._subView) {
+                    var pKey = navParentKeys[item._parentChip.navName];
+                    if (pKey && pKey !== 'newspaper' && pKey !== 'sleepers'
+                        && !isArbitSortValue(pKey, item._subView.value)) {
+                        tabHtml = '<kbd>Tab</kbd> Add filter';
+                    }
+                }
+                break;
+            case 'card':
+                actionHtml = '<kbd>Enter</kbd> Search';
+                tabHtml = '<kbd>Tab</kbd> Add card chip';
+                break;
+            case 'filter-candidate':
+                actionHtml = '<kbd>Enter</kbd> Search';
+                tabHtml = '<kbd>Tab</kbd> Lock filter';
+                break;
+            case 'recent':
+                actionHtml = '<kbd>Enter</kbd> Run';
+                break;
+            case 'saved':
+                actionHtml = '<kbd>Enter</kbd> Run';
+                tabHtml = '<kbd>Shift+Enter</kbd> Restore chips';
+                break;
+            case 'help':
+                if (item.isSyntax) {
+                    actionHtml = '<kbd>Enter</kbd> Copy snippet';
+                    tabHtml = '<kbd>Shift+Enter</kbd> Open guide';
+                } else {
+                    actionHtml = '<kbd>Enter</kbd> Open guide';
+                }
+                break;
+            case 'command':
+                actionHtml = '<kbd>Enter</kbd> Run';
+                break;
+            case 'search':
+                actionHtml = '<kbd>Enter</kbd> Search';
+                break;
+        }
+
+        actionEl.innerHTML = actionHtml;
+        if (tabHtml) {
+            tabEl.innerHTML = tabHtml;
+            tabEl.style.display = '';
+        } else {
+            tabEl.style.display = 'none';
+            tabEl.innerHTML = '';
+        }
     }
 
     function executeResult(shiftKey) {

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -680,24 +680,41 @@
 
     // ── Default results ──────────────────────────────────────────────
     function renderDefault() {
-        var items = [];
-        var recent = getRecentResults(null, 5);
-        var saved = getSavedResults(null);
-        var nav = getNavResults(null);
-
-        if (recent.length > 0) {
-            items.push({ type: 'header', title: 'Recent Searches' });
-            items = items.concat(recent);
-        }
-        if (saved.length > 0) {
-            items.push({ type: 'header', title: 'Saved Commands' });
-            items = items.concat(saved.slice(0, 3));
-        }
-        if (nav.length > 0) {
-            items.push({ type: 'header', title: 'Pages' });
-            items = items.concat(nav);
-        }
-
+        var items = [
+            { type: 'hint' },
+            {
+                type: 'shortcut',
+                title: 'Pages',
+                subtitle: 'Browse navigation and sub-pages',
+                icon: 'compass',
+                shortcut: '>',
+                action: function () { input.value = '>'; handleInput(); }
+            },
+            {
+                type: 'shortcut',
+                title: 'Help & syntax',
+                subtitle: 'Search reference and snippets',
+                icon: 'help-circle',
+                shortcut: '?',
+                action: function () { input.value = '?'; handleInput(); }
+            },
+            {
+                type: 'shortcut',
+                title: 'Saved',
+                subtitle: 'Your saved searches and commands',
+                icon: 'bookmark',
+                shortcut: '*',
+                action: function () { input.value = '*'; handleInput(); }
+            },
+            {
+                type: 'shortcut',
+                title: 'Recent',
+                subtitle: 'Your recent searches',
+                icon: 'clock',
+                shortcut: '<',
+                action: function () { input.value = '<'; handleInput(); }
+            }
+        ];
         renderResults(items);
     }
 
@@ -901,6 +918,35 @@
                 var headerIcon = categoryIconFor(item.title);
                 var iconHtml = headerIcon ? '<i data-lucide="' + headerIcon + '"></i>' : '';
                 html += '<div class="cp-category-header" data-category="' + escapeHtml(headerKey) + '">' + iconHtml + '<span>' + escapeHtml(item.title) + '</span></div>';
+                continue;
+            }
+
+            if (item.type === 'hint') {
+                html += '<div class="cp-hint-card">' +
+                    '<div class="cp-hint-icon"><i data-lucide="search"></i></div>' +
+                    '<div class="cp-hint-body">' +
+                        '<div class="cp-hint-title">Type to search</div>' +
+                        '<div class="cp-hint-subtitle">Cards, syntax - anything goes</div>' +
+                    '</div>' +
+                '</div>';
+                // Hint card is non-interactive: do not push to resultItems and do not increment idx
+                continue;
+            }
+
+            if (item.type === 'shortcut') {
+                var sActiveClass = idx === 0 ? ' active' : '';
+                html += '<div class="cp-result cp-shortcut-row' + sActiveClass + '" role="option" data-index="' + idx + '">';
+                html += '<div class="cp-result-icon"><i data-lucide="' + escapeHtml(item.icon) + '"></i></div>';
+                html += '<div class="cp-result-body">';
+                html += '<div class="cp-result-title">' + escapeHtml(item.title) + '</div>';
+                html += '<div class="cp-result-subtitle">' + escapeHtml(item.subtitle) + '</div>';
+                html += '</div>';
+                html += '<div class="cp-result-right">';
+                html += '<kbd class="cp-shortcut">' + escapeHtml(item.shortcut) + '</kbd>';
+                html += '</div>';
+                html += '</div>';
+                resultItems.push(item);
+                idx++;
                 continue;
             }
 

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -354,14 +354,20 @@
     function detectMode(val) {
         if (val.charAt(0) === '?' || /^(help:|syntax:)/i.test(val)) return 'help';
         if (val.charAt(0) === '>') return 'nav';
+        if (val.charAt(0) === '*') return 'saved';
+        if (val.charAt(0) === '<') return 'recent';
         if (/^saved:/i.test(val)) return 'saved';
+        if (/^recent:/i.test(val)) return 'recent';
         return 'search';
     }
 
     function stripPrefix(val) {
         if (/^(\?\s*|help:|syntax:|\?:)/i.test(val)) return val.replace(/^(\?\s*|help:|syntax:|\?:)/i, '').trim();
         if (val.charAt(0) === '>') return val.substring(1).trim();
+        if (val.charAt(0) === '*') return val.substring(1).trim();
+        if (val.charAt(0) === '<') return val.substring(1).trim();
         if (/^saved:/i.test(val)) return val.replace(/^saved:/i, '').trim();
+        if (/^recent:/i.test(val)) return val.replace(/^recent:/i, '').trim();
         return val;
     }
 

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -1019,6 +1019,10 @@
             if (badgeLabel) {
                 html += '<span class="cp-result-badge">' + escapeHtml(badgeLabel) + '</span>';
             }
+            // Parent-nav rows advertise Tab to browse sub-pages
+            if (item.type === 'nav' && item.navName && isParentNav(item.navName)) {
+                html += '<kbd class="cp-shortcut cp-tab-hint">Tab</kbd>';
+            }
             if (item.type === 'saved') {
                 html += '<button class="cp-result-delete" data-saved-id="' + escapeHtml(item.savedId) + '" title="Delete">';
                 html += '<i data-lucide="trash-2"></i>';

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -224,11 +224,12 @@
     chipContainer.setAttribute('role', 'group');
     chipContainer.setAttribute('aria-label', 'Search composition');
 
+    var DEFAULT_PLACEHOLDER = 'Type to search';
     var input = document.createElement('input');
     input.className = 'cp-input';
     input.id = 'cp-input';
     input.type = 'text';
-    input.placeholder = 'Search cards, commands, help...';
+    input.placeholder = DEFAULT_PLACEHOLDER;
     input.setAttribute('autocomplete', 'off');
     chipContainer.appendChild(input);
 
@@ -285,6 +286,7 @@
                 }
             }
             lastChipCount = now;
+            if (typeof updatePlaceholder === 'function') updatePlaceholder();
             if (!suppressChipOnChange && typeof handleInput === 'function') handleInput();
         });
     }
@@ -369,6 +371,51 @@
         if (/^saved:/i.test(val)) return val.replace(/^saved:/i, '').trim();
         if (/^recent:/i.test(val)) return val.replace(/^recent:/i, '').trim();
         return val;
+    }
+
+    // Update the input placeholder based on current mode/chip context.
+    // Detection order mirrors handleInput's dispatch order.
+    function updatePlaceholder() {
+        var raw = input.value;
+
+        // 1. Provider prefix detected
+        if (window.__palette_providers) {
+            var detected = window.__palette_providers.detectPrefix(raw);
+            if (detected) {
+                var provider = window.__palette_providers.getProvider(detected.prefix);
+                if (provider) {
+                    input.placeholder = 'Filter ' + (provider.name || 'options').toLowerCase() + '...';
+                    return;
+                }
+            }
+        }
+
+        // 2. Parent nav chip locked - sub-view mode
+        if (chips) {
+            var chipsList = chips.all();
+            for (var ci = chipsList.length - 1; ci >= 0; ci--) {
+                if (chipsList[ci].type === 'nav' && isParentNav(chipsList[ci].navName)) {
+                    input.placeholder = 'Filter ' + chipsList[ci].navName + ' sub-views...';
+                    return;
+                }
+            }
+        }
+
+        // 3. Mode prefix in input
+        var mode = detectMode(raw);
+        if (mode === 'nav')    { input.placeholder = 'Filter pages...'; return; }
+        if (mode === 'help')   { input.placeholder = 'Search help & syntax...'; return; }
+        if (mode === 'saved')  { input.placeholder = 'Filter saved searches...'; return; }
+        if (mode === 'recent') { input.placeholder = 'Filter recent searches...'; return; }
+
+        // 4. Chips present, no mode prefix
+        if (chips && chips.count() > 0) {
+            input.placeholder = 'Add filters or press Enter to search...';
+            return;
+        }
+
+        // 5. Default
+        input.placeholder = DEFAULT_PLACEHOLDER;
     }
 
     // ── Matching algorithm ───────────────────────────────────────────
@@ -1069,6 +1116,7 @@
     // ── Search dispatcher ────────────────────────────────────────────
     function handleInput() {
         var raw = input.value;
+        updatePlaceholder();
 
         // Check for filter prefix first - takes precedence over card/nav/help modes
         if (window.__palette_providers) {

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -1080,6 +1080,10 @@
             modeIndicator.textContent = 'SAVED';
             modeIndicator.setAttribute('data-mode', 'saved');
             modeIndicator.className = 'cp-mode-indicator active';
+        } else if (mode === 'recent') {
+            modeIndicator.textContent = 'RECENT';
+            modeIndicator.setAttribute('data-mode', 'recent');
+            modeIndicator.className = 'cp-mode-indicator active';
         } else {
             modeIndicator.textContent = '';
             modeIndicator.className = 'cp-mode-indicator';
@@ -1111,6 +1115,12 @@
             if (savedItems.length > 0) {
                 items.push({ type: 'header', title: 'Saved Commands' });
                 items = items.concat(savedItems);
+            }
+        } else if (mode === 'recent') {
+            var recentItems = getRecentResults(query, 50);
+            if (recentItems.length > 0) {
+                items.push({ type: 'header', title: 'Recent Searches' });
+                items = items.concat(recentItems);
             }
         } else {
             // Always offer direct search with full query (supports syntax like s:3ED)

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -224,7 +224,7 @@
     chipContainer.setAttribute('role', 'group');
     chipContainer.setAttribute('aria-label', 'Search composition');
 
-    var DEFAULT_PLACEHOLDER = 'Type to search';
+    var DEFAULT_PLACEHOLDER = 'Search...';
     var input = document.createElement('input');
     input.className = 'cp-input';
     input.id = 'cp-input';
@@ -730,7 +730,7 @@
     // ── Default results ──────────────────────────────────────────────
     function renderDefault() {
         var items = [
-            { type: 'hint' },
+            { type: 'header', title: 'Shortcuts' },
             {
                 type: 'shortcut',
                 title: 'Pages',
@@ -970,18 +970,6 @@
                 continue;
             }
 
-            if (item.type === 'hint') {
-                html += '<div class="cp-hint-card">' +
-                    '<div class="cp-hint-icon"><i data-lucide="search"></i></div>' +
-                    '<div class="cp-hint-body">' +
-                        '<div class="cp-hint-title">Type to search</div>' +
-                        '<div class="cp-hint-subtitle">Cards, syntax - anything goes</div>' +
-                    '</div>' +
-                '</div>';
-                // Hint card is non-interactive: do not push to resultItems and do not increment idx
-                continue;
-            }
-
             if (item.type === 'shortcut') {
                 var sActiveClass = idx === 0 ? ' active' : '';
                 html += '<div class="cp-result cp-shortcut-row' + sActiveClass + '" role="option" data-index="' + idx + '">';
@@ -1017,10 +1005,6 @@
             }
             html += '</div>';
             html += '<div class="cp-result-right">';
-            var badgeLabel = item.type === 'recent' ? 'Recent' : item.type === 'nav' ? 'Navigate' : item.type === 'card' ? 'Card' : item.type === 'command' ? 'Action' : item.type === 'saved' ? 'Saved' : item.type === 'syntax' ? 'Syntax' : item.type === 'help' ? item.badge || 'Help' : '';
-            if (badgeLabel) {
-                html += '<span class="cp-result-badge">' + escapeHtml(badgeLabel) + '</span>';
-            }
             // Parent-nav rows advertise Tab to browse sub-pages
             if (item.type === 'nav' && item.navName && isParentNav(item.navName)) {
                 html += '<kbd class="cp-shortcut cp-tab-hint">Tab</kbd>';

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -1139,21 +1139,12 @@
                 });
             }
 
-            // General search - combine sources
-            var recentItems = getRecentResults(query, 3);
+            // General search - combine sources (Recent and Saved live behind their own
+            // gated panels via < and * shortcuts, so omit them from the mixed view)
             var cmdItems = getStaticCommands(query);
-            var savedItems2 = getSavedResults(query);
             var cardItems = getCardResults(query, 5);
             var navItems2 = getNavResults(query);
 
-            if (recentItems.length > 0) {
-                items.push({ type: 'header', title: 'Recent Searches' });
-                items = items.concat(recentItems.slice(0, 3));
-            }
-            if (savedItems2.length > 0) {
-                items.push({ type: 'header', title: 'Saved Commands' });
-                items = items.concat(savedItems2.slice(0, 3));
-            }
             if (cmdItems.length > 0) {
                 items.push({ type: 'header', title: 'Commands' });
                 items = items.concat(cmdItems.slice(0, 3));

--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -1733,17 +1733,27 @@
                 fetchCardMeta(item.cardName);
                 locked = true;
             } else if (item.type === 'nav' && item.navName) {
-                suppressChipOnChange = true;
-                chips.add({
-                    type: 'nav',
-                    value: item.navLink || '',
-                    label: item.navName,
-                    icon: 'compass',
-                    navName: item.navName,
-                    navLink: item.navLink
-                });
-                suppressChipOnChange = false;
-                locked = true;
+                if (isParentNav(item.navName)) {
+                    // Parent nav (Newspaper, Sleepers, etc.) - lock as chip and reveal sub-views
+                    suppressChipOnChange = true;
+                    chips.add({
+                        type: 'nav',
+                        value: item.navLink || '',
+                        label: item.navName,
+                        icon: 'compass',
+                        navName: item.navName,
+                        navLink: item.navLink
+                    });
+                    suppressChipOnChange = false;
+                    locked = true;
+                } else {
+                    // Leaf nav (Search, Sets, Sealed, Upload, Home...) - no sub-pages.
+                    // Tab navigates immediately, identical to Enter. Avoids the leaky-NAV
+                    // bug where a locked leaf chip drops the user into general search.
+                    e.preventDefault();
+                    if (item.action) item.action();
+                    return;
+                }
             } else if (item.type === 'nav-sub' && item._subView && item._parentChip) {
                 var pKey = navParentKeys[item._parentChip.navName];
                 var urlParam;

--- a/palette.go
+++ b/palette.go
@@ -236,6 +236,16 @@ type PaletteArbitTargets struct {
 // paletteNewspaperTargetsJSON returns JSON for all newspaper page views.
 func paletteNewspaperTargetsJSON() template.JS {
 	out := []PaletteNavTarget{}
+	titleCounts := map[string]int{}
+
+	// First pass: count title occurrences so we know which need disambiguation.
+	for _, p := range NewspaperPages {
+		if p.Option == "" || p.Option == "options" {
+			continue
+		}
+		titleCounts[p.Title]++
+	}
+
 	for _, p := range NewspaperPages {
 		if p.Option == "" || p.Option == "options" {
 			continue
@@ -253,9 +263,18 @@ func paletteNewspaperTargetsJSON() template.JS {
 		case p.Option == "ensemble_forecast" || p.Option == "review":
 			group = "Analysis"
 		}
+
+		// Disambiguate duplicate titles by source.
+		// TCG-sourced options:  greatest_*, *_buylist, *_listings
+		// CK-sourced options:   buylist_*, stock_*, ck_buy*
+		label := p.Title
+		if titleCounts[p.Title] > 1 {
+			label = label + " " + paletteNewspaperSourceSuffix(p.Option)
+		}
+
 		out = append(out, PaletteNavTarget{
 			Value: p.Option,
-			Label: p.Title,
+			Label: label,
 			Group: group,
 		})
 	}
@@ -272,6 +291,23 @@ func paletteNewspaperTargetsJSON() template.JS {
 	})
 	data, _ := json.Marshal(out)
 	return template.JS(data)
+}
+
+// paletteNewspaperSourceSuffix returns "(TCG)" or "(CK)" based on the option key.
+// Falls back to "(<option>)" for novel keys so duplicates always render distinctly.
+func paletteNewspaperSourceSuffix(option string) string {
+	switch {
+	case strings.HasPrefix(option, "greatest_"),
+		strings.HasSuffix(option, "_buylist"),
+		strings.HasSuffix(option, "_listings"):
+		return "(TCG)"
+	case strings.HasPrefix(option, "buylist_"),
+		strings.HasPrefix(option, "stock_"),
+		strings.HasPrefix(option, "ck_buy"):
+		return "(CK)"
+	default:
+		return "(" + option + ")"
+	}
 }
 
 func paletteSleepersTargetsJSON() template.JS {

--- a/templates/base-landing.html
+++ b/templates/base-landing.html
@@ -53,6 +53,7 @@ window.__BAN_PALETTE_TARGETS = {
     global: {{palette_global_targets}}
 };
 </script>
+<script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
 <script type="text/javascript" src="/js/fetchnames.js?hash={{.Hash}}"></script>
 <script type="text/javascript" src="/js/palette-chips.js?hash={{.Hash}}"></script>
 <script type="text/javascript" src="/js/palette-providers.js?hash={{.Hash}}"></script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -57,6 +57,7 @@ window.__BAN_PALETTE_TARGETS = {
     global: {{palette_global_targets}}
 };
 </script>
+<script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
 <script type="text/javascript" src="/js/fetchnames.js?hash={{.Hash}}"></script>
 <script type="text/javascript" src="/js/palette-chips.js?hash={{.Hash}}"></script>
 <script type="text/javascript" src="/js/palette-providers.js?hash={{.Hash}}"></script>


### PR DESCRIPTION
- Declutters the palette default screen with a "Shortcuts" header and shortcut rows; gates Recent and Saved behind `<` and `*` 
- Makes Tab on parent-nav rows discoverable (right-rail `Tab` badge + dynamic footer hint) and fixes the leaky NAV state where Tab on a leaf nav silently dropped users into general search.
- Misc polish: context-aware input placeholder, drops redundant per-row type badges, disambiguates duplicate-titled newspaper sub-views with `(TCG)`/`(CK)` suffixes, and loads Lucide in the base template so palette icons render on every page.