### PR TITLE
Mobile favorites pane polish

### DIFF
--- a/css/search-mobile.css
+++ b/css/search-mobile.css
@@ -1153,8 +1153,13 @@
     gap: 0.4em;
 }
 
-.m-fav-item-top .m-badge {
+/* Chip slot is always rendered (may be empty) and pushed to the right edge of the
+   top row, so the pin button that follows it is anchored consistently. */
+.m-fav-item-top .m-fav-chips {
     margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3em;
 }
 
 .m-fav-thumb {
@@ -2248,24 +2253,37 @@
     border: 0;
     color: var(--greytext, #888);
     cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
 .m-fav-pin.pinned { color: var(--accent, #5b8def); }
 
 .m-fav-sort {
-    display: flex;
-    gap: 0.35em;
-    padding: 0.3em 0.6em 0.6em;
-    flex-wrap: wrap;
+    display: inline-flex;
+    align-items: center;
+    gap: 0;
+    margin-right: 0.15em;
 }
 .m-fav-sort .fav-sort-pill {
-    padding: 0.4em 0.6em;
-    background: var(--surface-2, rgba(255,255,255,0.04));
-    border: 1px solid var(--border-subtle, rgba(255,255,255,0.08));
-    border-radius: 0.35em;
-    color: var(--greytext, #888);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.15em;
+    padding: 0.3em 0.4em;
+    background: none;
+    border: none;
+    color: var(--greytext);
+    cursor: pointer;
     font: inherit;
+    line-height: 1;
+    min-height: auto;
+}
+.m-fav-sort .fav-sort-pill:active {
+    color: var(--dodgerblue);
 }
 .m-fav-sort .fav-sort-pill.active {
-    color: var(--accent, #5b8def);
-    border-color: var(--accent-border, rgba(91,141,239,0.35));
+    color: var(--dodgerblue);
 }
+.m-fav-sort .fav-sort-pill i,
+.m-fav-sort .fav-sort-pill svg { width: 16px; height: 16px; }

--- a/css/search.css
+++ b/css/search.css
@@ -2204,4 +2204,5 @@
     color: var(--accent, #5b8def);
     border-color: var(--accent-border, rgba(91,141,239,0.35));
 }
-.fav-sort-pill i { width: 12px; height: 12px; }
+.fav-sort-pill i,
+.fav-sort-pill svg { width: 12px; height: 12px; }

--- a/js/favorites.js
+++ b/js/favorites.js
@@ -251,11 +251,11 @@
             html += '<div class="m-fav-header">';
             html += '<span class="m-fav-title">Favorites</span>';
             html += '<span class="m-fav-actions">';
+            html += '<span class="m-fav-sort">' + sortPillsHtml() + '</span>';
             html += '<button class="m-fav-refresh" onclick="window.manualRefreshFavorites()" title="Refresh prices"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M3 21v-5h5"/></svg></button>';
             html += '<button class="m-fav-clear" onclick="window.clearFavorites()">Clear</button>';
             html += '</span>';
             html += '</div>';
-            html += '<div class="m-fav-sort">' + sortPillsHtml() + '</div>';
             html += '<div class="m-fav-list">';
 
             favs.forEach(function(f) {
@@ -267,8 +267,10 @@
                 html += '<div class="m-fav-item-top">';
                 html += '<span class="m-fav-name">' + escapeHtml(f.name) + '</span>';
                 html += '<span class="m-fav-set">' + escapeHtml(f.set) + (f.number ? ' #' + escapeHtml(f.number) : '') + '</span>';
+                html += '<span class="m-fav-chips">';
                 if (f.finishTag) html += '<span class="m-badge ' + (f.finishClass || 'foil') + '">' + escapeHtml(f.finishTag) + '</span>';
                 if (f.treatments) f.treatments.forEach(function(tag) { html += '<span class="m-badge treatment">' + escapeHtml(tag) + '</span>'; });
+                html += '</span>';
                 html += '<button class="m-fav-pin' + (f.pinned ? ' pinned' : '') + '" data-id="' + escapeAttr(f.id) + '" onclick="event.preventDefault(); event.stopPropagation(); window.toggleFavoritePin(this.dataset.id, event)" title="' + (f.pinned ? 'Unpin' : 'Pin to top') + '"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="' + (f.pinned ? 'currentColor' : 'none') + '" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 17v5"/><path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z"/></svg></button>';
                 html += '</div>';
                 html += '<div class="m-fav-item-prices">';


### PR DESCRIPTION
Follow-up fixes after the consolidated PR landed:

- Sort pills moved inline into the mobile favorites pane header alongside Refresh/Clear (was a separate row that pushed the list down)
- Mobile sort pills restyled to match the Refresh icon (transparent, no border, dodgerblue when active) instead of the bordered desktop pill style
- Pin button anchored to the top right of every favorite tile via a consistent chip-slot DOM container (.m-fav-chips) that always renders, even when there are no finish/treatment chips
- Sort pill icon sizing (16px mobile / 12px desktop) now also targets the lucide-replaced SVG, not just the placeholder <i>

<img width="641" height="1421" alt="image" src="https://github.com/user-attachments/assets/583d5669-6d5b-44bc-ba4d-a07142b9551e" />
