### PR TITLE
Mobile stuff

### DIFF
--- a/css/search-mobile.css
+++ b/css/search-mobile.css
@@ -1250,6 +1250,84 @@
     height: 18px;
 }
 
+/* Per-card actions kebab + dropdown menu */
+.m-actions-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0.5em;
+    color: var(--greytext);
+    min-height: auto !important;
+    display: flex;
+    align-items: center;
+    position: relative;
+    transition: transform 0.1s ease, background-color 0.1s ease;
+}
+
+.m-actions-btn::before {
+    content: '';
+    position: absolute;
+    inset: -4px;
+}
+
+.m-actions-btn:active {
+    background: rgba(255, 255, 255, 0.1);
+    transform: scale(0.85);
+}
+
+.m-actions-btn i,
+.m-actions-btn svg {
+    width: 18px;
+    height: 18px;
+}
+
+.m-actions-menu {
+    position: fixed;
+    z-index: 600;
+    background: var(--surface-2);
+    border: 1px solid var(--border-subtle);
+    border-radius: 0.6em;
+    padding: 0.35em 0;
+    min-width: 13em;
+    max-width: calc(100vw - 1em);
+    display: none;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+}
+
+.m-actions-menu.open {
+    display: block;
+}
+
+.m-actions-item {
+    display: flex;
+    align-items: center;
+    gap: 0.7em;
+    padding: 0.75em 0.95em;
+    color: var(--text);
+    font-size: 0.9rem;
+    text-decoration: none;
+    background: none;
+    border: none;
+    width: 100%;
+    text-align: left;
+    cursor: pointer;
+    box-sizing: border-box;
+    font-family: inherit;
+}
+
+.m-actions-item:active {
+    background: var(--surface-3);
+}
+
+.m-actions-item i,
+.m-actions-item svg,
+.m-actions-item img {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+    object-fit: contain;
+}
+
 /* Chart drawer */
 .m-chart-drawer {
     position: fixed;

--- a/js/mobile-chart.js
+++ b/js/mobile-chart.js
@@ -7,6 +7,23 @@
     var libsLoaded = false;
     var libsLoading = false;
 
+    var HIDDEN_COOKIE = 'MobileChartHidden';
+
+    function readHiddenVendors() {
+        var match = document.cookie.match(new RegExp('(?:^|; )' + HIDDEN_COOKIE + '=([^;]*)'));
+        if (!match) return [];
+        try {
+            return decodeURIComponent(match[1]).split(',').filter(Boolean);
+        } catch (e) {
+            return [];
+        }
+    }
+
+    function writeHiddenVendors(names) {
+        var maxAge = 60 * 60 * 24 * 365 * 5;
+        document.cookie = HIDDEN_COOKIE + '=' + encodeURIComponent(names.join(',')) + '; path=/; max-age=' + maxAge + '; SameSite=Lax';
+    }
+
     function pickInitialRange() {
         var saved = parseInt(localStorage.getItem('chartDateRange'));
         if (isNaN(saved) || saved <= 0) saved = 180;
@@ -352,6 +369,18 @@
                     canvas.style.display = 'block';
                     resetBtn.style.display = 'inline-block';
                     currentChart = createChart(canvas.getContext('2d'), data);
+
+                    // Restore previously hidden vendors (global preference across cards)
+                    var hidden = readHiddenVendors();
+                    if (hidden.length) {
+                        data.datasets.forEach(function(ds, i) {
+                            if (hidden.indexOf(ds.name) !== -1) {
+                                currentChart.setDatasetVisibility(i, false);
+                            }
+                        });
+                        currentChart.update('none');
+                    }
+
                     renderChartLegend(data.datasets, currentChart);
                     currentMaxLoaded = initialRange;
                     setRangePickerDisabled(false);
@@ -368,6 +397,13 @@
     };
 
     window.hideChartDrawer = function() {
+        if (currentChart) {
+            var hidden = [];
+            currentChart.data.datasets.forEach(function(ds, i) {
+                if (!currentChart.isDatasetVisible(i)) hidden.push(ds.label);
+            });
+            writeHiddenVendors(hidden);
+        }
         document.getElementById('m-chart-overlay').classList.remove('open');
         document.getElementById('m-chart-drawer').classList.remove('open');
     };

--- a/main.go
+++ b/main.go
@@ -102,6 +102,7 @@ type PageVars struct {
 	GlobalMode     bool
 	ReverseMode    bool
 	DefaultTab     string
+	DefaultView    string
 
 	Page               string
 	Subtitle           string

--- a/search.go
+++ b/search.go
@@ -160,6 +160,7 @@ func Search(w http.ResponseWriter, r *http.Request) {
 
 	pageVars.SearchBest = (readCookie(r, "SearchListingPriority") != "stores")
 	pageVars.DefaultTab = readCookie(r, "SearchDefaultTab")
+	pageVars.DefaultView = readCookie(r, "SearchDefaultView")
 
 	// Load whether a user can download CSV and validate the query parameter
 	canDownloadCSV, _ := strconv.ParseBool(GetParamFromSig(sig, "SearchDownloadCSV"))

--- a/templates/mobile/search.html
+++ b/templates/mobile/search.html
@@ -232,31 +232,37 @@
             {{$hasBuyers := (index $.FoundVendors $cardId)}}
             {{$defaultBuyers := or (eq $.DefaultTab "buyers") (eq $.SearchSort "buylist")}}
 
-            {{/* Condition pills - default to NM, hidden for sealed products */}}
+            {{/* Resolve the active condition view for this card: user preference, falling back to NM if unavailable. */}}
+            {{$sellerConds := (index $.FoundSellers $cardId)}}
+            {{$vendorConds := (index $.FoundVendors $cardId)}}
+            {{$defView := $.DefaultView}}
+            {{if eq $defView ""}}{{$defView = "NM"}}{{end}}
+            {{$hasDefault := false}}
+            {{if $sellerConds}}{{if (index $sellerConds $defView)}}{{$hasDefault = true}}{{end}}{{end}}
+            {{if $vendorConds}}{{if (index $vendorConds $defView)}}{{$hasDefault = true}}{{end}}{{end}}
+            {{if not $hasDefault}}{{$defView = "NM"}}{{end}}
+
+            {{/* Condition pills - default driven by user preference, hidden for sealed products */}}
             {{if not $card.Sealed}}
             <div class="m-cond-pills" data-card="{{$cardId}}">
                 <span class="m-cond-pills-left">
                 {{range $conditions := $.CondKeys}}
                     {{if ne $conditions "INDEX"}}
-                        {{$sellerConds := (index $.FoundSellers $cardId)}}
-                        {{$vendorConds := (index $.FoundVendors $cardId)}}
                         {{$hasCond := false}}
                         {{if $sellerConds}}{{if (index $sellerConds $conditions)}}{{$hasCond = true}}{{end}}{{end}}
                         {{if $vendorConds}}{{if (index $vendorConds $conditions)}}{{$hasCond = true}}{{end}}{{end}}
                         {{if $hasCond}}
-                            <button class="m-cond-pill{{if eq $conditions "NM"}} active{{end}}" data-cond="{{$conditions}}" data-card="{{$cardId}}">{{$conditions}}</button>
+                            <button class="m-cond-pill{{if eq $conditions $defView}} active{{end}}" data-cond="{{$conditions}}" data-card="{{$cardId}}">{{$conditions}}</button>
                         {{end}}
                     {{end}}
                 {{end}}
                 </span>
                 {{$hasIndex := false}}
-                {{$sellerConds := (index $.FoundSellers $cardId)}}
-                {{$vendorConds := (index $.FoundVendors $cardId)}}
                 {{if $sellerConds}}{{if (index $sellerConds "INDEX")}}{{$hasIndex = true}}{{end}}{{end}}
                 {{if $vendorConds}}{{if (index $vendorConds "INDEX")}}{{$hasIndex = true}}{{end}}{{end}}
                 {{if $hasIndex}}
                 <span class="m-cond-pills-right">
-                    <button class="m-cond-pill" data-cond="INDEX" data-card="{{$cardId}}">Index</button>
+                    <button class="m-cond-pill{{if eq $defView "INDEX"}} active{{end}}" data-cond="INDEX" data-card="{{$cardId}}">Index</button>
                 </span>
                 {{end}}
             </div>
@@ -279,7 +285,7 @@
                     {{$entries := (index $condsEntry $conditions)}}
                     {{if $entries}}
                         {{if eq $conditions "INDEX"}}
-                        <div class="m-cond-group" data-cond="INDEX" data-card="{{$cardId}}">
+                        <div class="m-cond-group{{if eq $defView "INDEX"}} active{{end}}" data-cond="INDEX" data-card="{{$cardId}}">
                             {{range $ei, $entry := $entries}}
                                 {{if $entry.Locked}}
                                 <div class="m-vendor-row m-vendor-locked">
@@ -300,7 +306,7 @@
                             {{end}}
                         </div>
                         {{else}}
-                        <div class="m-cond-group{{if eq $conditions "NM"}} active{{end}}" data-cond="{{$conditions}}" data-card="{{$cardId}}">
+                        <div class="m-cond-group{{if eq $conditions $defView}} active{{end}}" data-cond="{{$conditions}}" data-card="{{$cardId}}">
                             {{range $ei, $entry := $entries}}
                                 {{if $entry.Locked}}
                                 <div class="m-vendor-row m-vendor-locked">
@@ -360,7 +366,7 @@
                     {{$entries := (index $condsEntry $conditions)}}
                     {{if $entries}}
                         {{if eq $conditions "INDEX"}}
-                        <div class="m-cond-group" data-cond="INDEX" data-card="{{$cardId}}">
+                        <div class="m-cond-group{{if eq $defView "INDEX"}} active{{end}}" data-cond="INDEX" data-card="{{$cardId}}">
                             {{range $ei, $entry := $entries}}
                                 {{if $entry.Locked}}
                                 <div class="m-vendor-row m-vendor-locked">
@@ -381,7 +387,7 @@
                             {{end}}
                         </div>
                         {{else}}
-                        <div class="m-cond-group{{if eq $conditions "NM"}} active{{end}}" data-cond="{{$conditions}}" data-card="{{$cardId}}">
+                        <div class="m-cond-group{{if eq $conditions $defView}} active{{end}}" data-cond="{{$conditions}}" data-card="{{$cardId}}">
                             {{range $ei, $entry := $entries}}
                                 {{if $entry.Locked}}
                                 <div class="m-vendor-row m-vendor-locked">
@@ -510,6 +516,19 @@
                 <div class="m-settings-pills" id="m-set-default-tab">
                     <button type="button" class="m-settings-pill active" data-val="sellers">Sellers</button>
                     <button type="button" class="m-settings-pill" data-val="buyers">Buyers</button>
+                </div>
+            </div>
+
+            {{/* Default View - which condition (or Index) is initially active in result cards */}}
+            <div class="m-settings-section">
+                <div class="m-settings-label">Default View</div>
+                <div class="m-settings-pills" id="m-set-default-view">
+                    <button type="button" class="m-settings-pill active" data-val="NM">NM</button>
+                    <button type="button" class="m-settings-pill" data-val="SP">SP</button>
+                    <button type="button" class="m-settings-pill" data-val="MP">MP</button>
+                    <button type="button" class="m-settings-pill" data-val="HP">HP</button>
+                    <button type="button" class="m-settings-pill" data-val="PO">PO</button>
+                    <button type="button" class="m-settings-pill" data-val="INDEX">Index</button>
                 </div>
             </div>
 
@@ -867,33 +886,22 @@ function hideCardDrawer() {
         });
     });
 
-    // Condition pill switching
+    // Condition pill switching - all pills (including Index) are mutually exclusive
     document.querySelectorAll('.m-cond-pill').forEach(function(pill) {
         pill.addEventListener('click', function() {
-            var cardId = this.getAttribute('data-card');
             var cond = this.getAttribute('data-cond');
             var card = this.closest('.m-card');
 
-            if (cond === 'INDEX') {
-                // Index pill toggles independently
-                this.classList.toggle('active');
-                card.querySelectorAll('.m-cond-group[data-cond="INDEX"]').forEach(function(g) {
-                    g.classList.toggle('active');
-                });
-            } else {
-                // Condition pills are mutually exclusive
-                this.closest('.m-cond-pills').querySelectorAll('.m-cond-pills-left .m-cond-pill').forEach(function(p) { p.classList.remove('active'); });
-                this.classList.add('active');
+            this.closest('.m-cond-pills').querySelectorAll('.m-cond-pill').forEach(function(p) { p.classList.remove('active'); });
+            this.classList.add('active');
 
-                card.querySelectorAll('.m-cond-group').forEach(function(g) {
-                    if (g.getAttribute('data-cond') === 'INDEX') return;
-                    if (g.getAttribute('data-cond') === cond) {
-                        g.classList.add('active');
-                    } else {
-                        g.classList.remove('active');
-                    }
-                });
-            }
+            card.querySelectorAll('.m-cond-group').forEach(function(g) {
+                if (g.getAttribute('data-cond') === cond) {
+                    g.classList.add('active');
+                } else {
+                    g.classList.remove('active');
+                }
+            });
 
             recalcBestBadges(card);
         });
@@ -1003,6 +1011,15 @@ function loadSettings() {
         });
     }
 
+    // Default View
+    var view = getCookie('SearchDefaultView');
+    if (view) {
+        var group = document.getElementById('m-set-default-view');
+        group.querySelectorAll('.m-settings-pill').forEach(function(p) {
+            p.classList.toggle('active', p.getAttribute('data-val') === view);
+        });
+    }
+
     // Listing Priority
     var lp = getCookie('SearchListingPriority');
     if (lp) {
@@ -1051,6 +1068,10 @@ function saveSettings() {
     // Default Tab
     var tabPill = document.querySelector('#m-set-default-tab .m-settings-pill.active');
     setCookie('SearchDefaultTab', tabPill ? tabPill.getAttribute('data-val') : 'sellers', 1000);
+
+    // Default View
+    var viewPill = document.querySelector('#m-set-default-view .m-settings-pill.active');
+    setCookie('SearchDefaultView', viewPill ? viewPill.getAttribute('data-val') : 'NM', 1000);
 
     // Listing Priority
     var lpPill = document.querySelector('#m-set-listing-priority .m-settings-pill.active');

--- a/templates/mobile/search.html
+++ b/templates/mobile/search.html
@@ -22,6 +22,7 @@
     <script type="text/javascript" src="/js/recent-searches.js?hash={{.Hash}}"></script>
     <script type="text/javascript" src="/js/favorites.js?hash={{.Hash}}"></script>
     <script type="text/javascript" src="/js/cookies.js?hash={{.Hash}}"></script>
+    <script type="text/javascript" src="/js/copy2clip.js?hash={{.Hash}}"></script>
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
 {{end}}
 
@@ -225,7 +226,55 @@
                     {{if $card.Reserved}}<span class="m-badge rl">RL</span>{{end}}
                     <button class="m-fav-btn fav-btn" data-card-id="{{$cardId}}" onclick="event.stopPropagation(); toggleFavorite(this);" title="Add to favorites"><i data-lucide="star"></i></button>
                     {{if not $.DisableChart}}<button class="m-chart-btn" onclick="event.stopPropagation(); showChartDrawer('{{$cardId}}', {{$card.Sealed}}, '{{$card.Name}}');" title="Price history"><i data-lucide="chart-line"></i></button>{{end}}
+                    <button class="m-actions-btn" onclick="event.stopPropagation(); toggleActionsMenu(this);" title="More actions"><i data-lucide="more-vertical"></i></button>
                 </div>
+            </div>
+            <div class="m-actions-menu" data-card="{{$cardId}}">
+                {{if $card.Sealed}}
+                    {{if $card.Booster}}
+                        <a class="m-actions-item" href='/search?q=unpack:"{{$card.Name}}"' onclick="closeActionsMenus()">
+                            <i data-lucide="gift"></i><span>Simulate booster pack</span>
+                        </a>
+                    {{end}}
+                    {{if $card.HasDeck}}
+                        <a class="m-actions-item" href="/api/tcgplayer/decklist/{{$card.UUID}}" onclick="closeActionsMenus()">
+                            <img src="/img/misc/decklist.png" alt=""><span>TCGplayer decklist</span>
+                        </a>
+                        <a class="m-actions-item" href="/api/cardmarket/decklist/{{$card.UUID}}" onclick="closeActionsMenus()">
+                            <img src="/img/misc/decklist-mkm.png" alt=""><span>Cardmarket decklist</span>
+                        </a>
+                    {{end}}
+                    <a class="m-actions-item" href='/search?q={{if $card.Booster}}contents{{else}}decklist{{end}}:"{{$card.Name}}"' onclick="closeActionsMenus()">
+                        <i data-lucide="search"></i><span>Search contents</span>
+                    </a>
+                {{else if $.HasAvailable}}
+                    <a class="m-actions-item" href='/sealed?q=container:"{{$card.Name}}"' onclick="closeActionsMenus()">
+                        <i data-lucide="package"></i><span>Find in sealed products</span>
+                    </a>
+                {{end}}
+                <button type="button" class="m-actions-item" onclick="event.stopPropagation(); copyAndBlink(this, '{{$card.Name}}'); closeActionsMenus();">
+                    <i data-lucide="clipboard-copy"></i><span>Copy card name</span>
+                </button>
+                {{if not $card.Sealed}}
+                    <a class="m-actions-item" href="{{$card.DeckboxURL}}" target="_blank" rel="noopener" onclick="closeActionsMenus()">
+                        <img src="/img/logo/deckbox.webp" alt=""><span>Open on Deckbox</span>
+                    </a>
+                {{end}}
+                {{if $card.CKRestockURL}}
+                    <a class="m-actions-item" href="{{$card.CKRestockURL}}" target="_blank" rel="noopener" onclick="closeActionsMenus()">
+                        <i data-lucide="bell"></i><span>CardKingdom restock notice</span>
+                    </a>
+                {{end}}
+                {{if $card.ScryfallURL}}
+                    <a class="m-actions-item" href="{{$card.ScryfallURL}}" target="_blank" rel="noopener" onclick="closeActionsMenus()">
+                        <img src="/img/logo/scryfall.svg" alt=""><span>Open on Scryfall</span>
+                    </a>
+                {{end}}
+                {{if $card.TCGId}}
+                    <a class="m-actions-item" href="https://store.tcgplayer.com/admin/product/manage/{{$card.TCGId}}" target="_blank" rel="noopener" onclick="closeActionsMenus()">
+                        <img src="/img/logo/tcgapp.png" alt=""><span>TCGplayer inventory</span>
+                    </a>
+                {{end}}
             </div>
 
             {{$hasSellers := (index $.FoundSellers $cardId)}}
@@ -854,6 +903,35 @@ function applyFilters() {
     // Navigate
     window.location.href = '?q=' + encodeURIComponent(query);
 }
+
+// Per-card actions menu
+function toggleActionsMenu(btn) {
+    var card = btn.closest('.m-card');
+    var menu = card.querySelector('.m-actions-menu');
+    if (!menu) return;
+    var wasOpen = menu.classList.contains('open');
+    closeActionsMenus();
+    if (!wasOpen) {
+        var rect = btn.getBoundingClientRect();
+        menu.style.top = (rect.bottom + 4) + 'px';
+        menu.style.right = Math.max(8, window.innerWidth - rect.right) + 'px';
+        menu.classList.add('open');
+    }
+}
+
+function closeActionsMenus() {
+    document.querySelectorAll('.m-actions-menu.open').forEach(function(m) {
+        m.classList.remove('open');
+    });
+}
+
+document.addEventListener('click', function(e) {
+    if (!e.target.closest('.m-actions-menu') && !e.target.closest('.m-actions-btn')) {
+        closeActionsMenus();
+    }
+});
+window.addEventListener('scroll', closeActionsMenus, { passive: true });
+window.addEventListener('resize', closeActionsMenus);
 
 // Card image drawer
 function showCardDrawer(imgUrl, name) {


### PR DESCRIPTION
fixes #162 
<img width="541" height="441" alt="image" src="https://github.com/user-attachments/assets/8706d98a-6c4b-4be4-8f0f-493762f4c862" />

fixes #131 
<img width="546" height="650" alt="image" src="https://github.com/user-attachments/assets/50640520-bc5b-44c6-8335-4a9cd6f6e84a" />
<img width="526" height="329" alt="image" src="https://github.com/user-attachments/assets/cc5b2061-c297-4e9f-bfd4-23bd893d16e6" />

saves active vendor lines for charts on close/reopen instead of defaulting to all vendors