### PR TITLE
timeseries: bound the connection pool and cancel chart queries on disconnect

### DIFF
--- a/api_chart.go
+++ b/api_chart.go
@@ -63,7 +63,7 @@ func ChartDataAPI(w http.ResponseWriter, r *http.Request) {
 	}
 
 	axisLabels := getDateAxisValues(earliest)
-	datasets := getDatasets(uuid, co.Sealed, axisLabels, userTier)
+	datasets := getDatasets(r.Context(), uuid, co.Sealed, axisLabels, userTier)
 
 	var apiDatasets []ChartAPIDataset
 	for _, ds := range datasets {

--- a/chart.go
+++ b/chart.go
@@ -63,7 +63,7 @@ func lookbackForTier(tier string) timeseries.Lookback {
 // language=nil, lookback) result set, so we fetch HGetAll exactly once and
 // fan the rows out to every per-dataset render rather than firing N
 // identical SQL queries (and discarding 15/16 of each result).
-func getDatasets(cardId string, sealed bool, keys []string, userTier string) []Dataset {
+func getDatasets(ctx context.Context, cardId string, sealed bool, keys []string, userTier string) []Dataset {
 	if PricesArchiveDB == nil {
 		return nil
 	}
@@ -90,7 +90,7 @@ func getDatasets(cardId string, sealed bool, keys []string, userTier string) []D
 		return nil
 	}
 
-	results, err := PricesArchiveDB.HGetAll(context.Background(), co.UUID, co.Foil, co.Etched, nil, lookbackForTier(userTier))
+	results, err := PricesArchiveDB.HGetAll(ctx, co.UUID, co.Foil, co.Etched, nil, lookbackForTier(userTier))
 	if err != nil {
 		log.Println(err)
 		return nil

--- a/search.go
+++ b/search.go
@@ -640,7 +640,7 @@ func Search(w http.ResponseWriter, r *http.Request) {
 			earliest, _ := PricesArchiveDB.GetEarliestDate(r.Context(), co.UUID, co.Foil, co.Etched, lb)
 
 			pageVars.AxisLabels = getDateAxisValues(earliest)
-			pageVars.Datasets = getDatasets(chartId, co.Sealed, pageVars.AxisLabels, userTier)
+			pageVars.Datasets = getDatasets(r.Context(), chartId, co.Sealed, pageVars.AxisLabels, userTier)
 			pageVars.Checkpoints = relevantCheckpoints(co.Name, earliest)
 			if len(pageVars.Datasets) == 0 {
 				pageVars.InfoMessage = "No chart data available"

--- a/timeseries/config.go
+++ b/timeseries/config.go
@@ -3,18 +3,22 @@ package timeseries
 import (
 	"database/sql"
 	"fmt"
+	"time"
 
 	_ "github.com/lib/pq"
 )
 
 type SqlConfig struct {
-	Host     string `json:"host"`
-	Port     int    `json:"port"`
-	User     string `json:"user"`
-	Password string `json:"password"`
-	DBName   string `json:"dbname"`
-	SSLMode  string `json:"sslmode"`
-	ReadOnly bool   `json:"readonly"`
+	Host                   string `json:"host"`
+	Port                   int    `json:"port"`
+	User                   string `json:"user"`
+	Password               string `json:"password"`
+	DBName                 string `json:"dbname"`
+	SSLMode                string `json:"sslmode"`
+	ReadOnly               bool   `json:"readonly"`
+	MaxOpenConns           int    `json:"max_open_conns"`
+	MaxIdleConns           int    `json:"max_idle_conns"`
+	ConnMaxLifetimeSeconds int    `json:"conn_max_lifetime_seconds"`
 }
 
 func (c SqlConfig) DSN() string {
@@ -40,6 +44,27 @@ func NewClient(cfg SqlConfig) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("timeseries: open: %w", err)
 	}
+
+	// Cap the pool so concurrent chart traffic can't exhaust Postgres's
+	// max_connections. Match idle to open so bursts don't churn through
+	// fresh TCP handshakes, and recycle periodically so stale conns
+	// behind load balancers / failovers get dropped. Defaults apply when
+	// the corresponding config field is zero.
+	maxOpen := cfg.MaxOpenConns
+	if maxOpen <= 0 {
+		maxOpen = 25
+	}
+	maxIdle := cfg.MaxIdleConns
+	if maxIdle <= 0 {
+		maxIdle = maxOpen
+	}
+	lifetime := time.Duration(cfg.ConnMaxLifetimeSeconds) * time.Second
+	if lifetime <= 0 {
+		lifetime = 30 * time.Minute
+	}
+	db.SetMaxOpenConns(maxOpen)
+	db.SetMaxIdleConns(maxIdle)
+	db.SetConnMaxLifetime(lifetime)
 
 	if err := db.Ping(); err != nil {
 		dbCloseErr := db.Close()


### PR DESCRIPTION
Two related fixes for chart traffic backing up against Postgres.

Connection pool: NewClient previously left the *sql.DB at its defaults (unlimited MaxOpenConns, 2 MaxIdleConns, no lifetime cap), so a burst of concurrent chart renders could open arbitrarily many connections, hit Postgres's max_connections ceiling, and stall every other caller until the pool drained. Now SetMaxOpenConns / SetMaxIdleConns / SetConnMaxLifetime are wired up and configurable via SqlConfig (max_open_conns, max_idle_conns, conn_max_lifetime_seconds), falling back to 25 / 25 / 30m when the field is zero. Matching idle to open avoids reopening conns on every burst; the lifetime cap recycles connections behind load balancers / failovers before they go silently dead.

Request context: getDatasets was calling HGetAll with context.Background(), so when a client disconnected mid-render (the exact 23:29 log pattern), the chart query kept running on the server, holding a pool slot and burning CPU for output nobody would read. Threading r.Context() through getDatasets from both call sites (api_chart.go, search.go) lets net/http cancel the query as soon as the client goes away.