### PR TITLE
joblog: insert "running" row at job start, tighten heartbeat to 10s

### DIFF
--- a/joblog/joblog.go
+++ b/joblog/joblog.go
@@ -149,11 +149,18 @@ func (r *Runner) RunJob(name string, fn func()) {
 
 // RunJobErr is the error-returning sibling of RunJob; the returned error
 // (if any) is recorded as the run's status/error_msg.
+//
+// A row is inserted with status="running" before fn executes and updated to
+// its terminal status when fn returns. If the process dies mid-run the row
+// stays as "running", which is the breadcrumb that distinguishes "never
+// started" from "started but never finished".
 func (r *Runner) RunJobErr(name string, fn func() error) {
 	start := time.Now()
 	before := takeMemSnapshot()
 	log.Printf("job %q: start (heap=%dMB goroutines=%d numgc=%d)",
 		name, before.HeapAlloc>>20, before.Goroutines, before.NumGC)
+
+	runID := r.recordJobStart(name, "job", start, before)
 
 	var (
 		runErr     error
@@ -193,7 +200,7 @@ func (r *Runner) RunJobErr(name string, fn func() error) {
 		after.NumGC-before.NumGC,
 	)
 
-	r.recordJobRun(name, "job", status, start, &dur, before, after, runErr, panicMsg, panicStack)
+	r.recordJobFinish(runID, name, "job", status, start, dur, before, after, runErr, panicMsg, panicStack)
 }
 
 // StartHeartbeat spawns a goroutine that records a periodic snapshot of
@@ -214,19 +221,96 @@ func (r *Runner) StartHeartbeat(interval time.Duration) {
 		defer ticker.Stop()
 		for range ticker.C {
 			snap := takeMemSnapshot()
-			r.recordJobRun("heartbeat", "heartbeat", "tick", time.Now(), nil, snap, snap, nil, "", "")
+			r.recordHeartbeat(snap)
 		}
 	}()
 }
 
-// recordJobRun is the single funnel for both job and heartbeat inserts. It
-// swallows its own errors (a logging-system failure must not kill the caller)
-// and always emits a local log line so we keep a breadcrumb even if the DB
-// write fails.
-func (r *Runner) recordJobRun(name, kind, status string, start time.Time, dur *time.Duration, before, after memSnapshot, runErr error, panicMsg, panicStack string) {
+// recordJobStart inserts a job_runs row with status="running" and only the
+// "before" snapshot populated. Returns the row id (0 when no DB or on error)
+// so the matching recordJobFinish can update the same row. Errors are logged
+// but never surfaced — a logging-system failure must not kill the caller.
+func (r *Runner) recordJobStart(name, kind string, start time.Time, before memSnapshot) int64 {
+	if !r.canWrite() {
+		return 0
+	}
 	run := JobRun{
 		Host:        r.host,
 		BuildCommit: r.buildCommit,
+		JobName:     name,
+		Kind:        kind,
+		Status:      "running",
+		StartedAt:   start,
+	}
+	heapBefore := before.HeapAlloc
+	heapSysBefore := before.HeapSys
+	gorBefore := before.Goroutines
+	gcBefore := before.NumGC
+	pauseBefore := before.PauseTotalNs
+	run.HeapAllocBefore = &heapBefore
+	run.HeapSysBefore = &heapSysBefore
+	run.GoroutinesBefore = &gorBefore
+	run.NumGCBefore = &gcBefore
+	run.PauseTotalNsBefore = &pauseBefore
+	if before.SysMemKnown {
+		used := before.SysMemUsed
+		total := before.SysMemTotal
+		run.SysMemUsedBytes = &used
+		run.SysMemTotalBytes = &total
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	id, err := r.insertJobRunReturningID(ctx, run)
+	if err != nil {
+		log.Printf("job %q: failed to record start: %v", name, err)
+		return 0
+	}
+	return id
+}
+
+// recordJobFinish closes out a job. When runID > 0 it updates the row
+// previously inserted by recordJobStart; otherwise it falls back to a fresh
+// INSERT so the run is still recorded if the start write failed.
+func (r *Runner) recordJobFinish(runID int64, name, kind, status string, start time.Time, dur time.Duration, before, after memSnapshot, runErr error, panicMsg, panicStack string) {
+	if !r.canWrite() {
+		return
+	}
+	run := buildJobRun(r.host, r.buildCommit, name, kind, status, start, &dur, before, after, runErr, panicMsg, panicStack)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if runID > 0 {
+		if err := r.updateJobRun(ctx, runID, run); err != nil {
+			log.Printf("job %q: failed to record finish: %v", name, err)
+		}
+		return
+	}
+	if err := r.insertJobRun(ctx, run); err != nil {
+		log.Printf("job %q: failed to record run: %v", name, err)
+	}
+}
+
+// recordHeartbeat writes a single self-contained tick row. Heartbeats don't
+// have a start/finish pairing so they use a plain insert.
+func (r *Runner) recordHeartbeat(snap memSnapshot) {
+	if !r.canWrite() {
+		return
+	}
+	run := buildJobRun(r.host, r.buildCommit, "heartbeat", "heartbeat", "tick", time.Now(), nil, snap, snap, nil, "", "")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := r.insertJobRun(ctx, run); err != nil {
+		log.Printf("heartbeat: failed to record: %v", err)
+	}
+}
+
+// buildJobRun assembles a JobRun from snapshots and outcome fields. Shared by
+// the finish and heartbeat paths.
+func buildJobRun(host, buildCommit, name, kind, status string, start time.Time, dur *time.Duration, before, after memSnapshot, runErr error, panicMsg, panicStack string) JobRun {
+	run := JobRun{
+		Host:        host,
+		BuildCommit: buildCommit,
 		JobName:     name,
 		Kind:        kind,
 		Status:      status,
@@ -282,15 +366,7 @@ func (r *Runner) recordJobRun(name, kind, status string, start time.Time, dur *t
 			run.PanicStack = &panicStack
 		}
 	}
-
-	if !r.canWrite() {
-		return
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	if err := r.insertJobRun(ctx, run); err != nil {
-		log.Printf("job %q: failed to record run: %v", name, err)
-	}
+	return run
 }
 
 func toErrorString(v any) string {

--- a/joblog/schema.go
+++ b/joblog/schema.go
@@ -16,7 +16,7 @@ type JobRun struct {
 	BuildCommit string
 	JobName     string
 	Kind        string // "job" or "heartbeat"
-	Status      string // "success", "error", "panic", "tick"
+	Status      string // "running", "success", "error", "panic", "tick"
 	StartedAt   time.Time
 	FinishedAt  *time.Time
 	DurationMs  *int64
@@ -109,29 +109,80 @@ func (r *Runner) insertJobRun(ctx context.Context, run JobRun) error {
 	if !r.canWrite() {
 		return nil
 	}
+	_, err := r.db.ExecContext(ctx, insertJobRunSQL, jobRunArgs(run)...)
+	return err
+}
+
+// insertJobRunReturningID writes a job_runs row and returns the new id, so a
+// "running" row can later be updated in place by recordJobFinish.
+func (r *Runner) insertJobRunReturningID(ctx context.Context, run JobRun) (int64, error) {
+	if !r.canWrite() {
+		return 0, nil
+	}
+	var id int64
+	err := r.db.QueryRowContext(ctx, insertJobRunSQL+" RETURNING id", jobRunArgs(run)...).Scan(&id)
+	return id, err
+}
+
+// updateJobRun rewrites the terminal-state fields on an existing job_runs row.
+// Used to close out a row previously inserted with status="running".
+func (r *Runner) updateJobRun(ctx context.Context, id int64, run JobRun) error {
+	if !r.canWrite() {
+		return nil
+	}
 	const q = `
-		INSERT INTO job_runs (
-			host, build_commit, job_name, kind, status,
-			started_at, finished_at, duration_ms,
-			error_msg, panic_stack,
-			heap_alloc_before, heap_alloc_after,
-			heap_sys_before, heap_sys_after,
-			goroutines_before, goroutines_after,
-			num_gc_before, num_gc_after,
-			pause_total_ns_before, pause_total_ns_after,
-			sys_mem_used_bytes, sys_mem_total_bytes
-		) VALUES (
-			$1,$2,$3,$4,$5,
-			$6,$7,$8,
-			$9,$10,
-			$11,$12,
-			$13,$14,
-			$15,$16,
-			$17,$18,
-			$19,$20,
-			$21,$22
-		)`
+		UPDATE job_runs SET
+			status = $1,
+			finished_at = $2,
+			duration_ms = $3,
+			error_msg = $4,
+			panic_stack = $5,
+			heap_alloc_after = $6,
+			heap_sys_after = $7,
+			goroutines_after = $8,
+			num_gc_after = $9,
+			pause_total_ns_after = $10,
+			sys_mem_used_bytes = COALESCE($11, sys_mem_used_bytes),
+			sys_mem_total_bytes = COALESCE($12, sys_mem_total_bytes)
+		WHERE id = $13`
 	_, err := r.db.ExecContext(ctx, q,
+		run.Status,
+		nullTime(run.FinishedAt), nullInt64Ptr(run.DurationMs),
+		nullStrPtr(run.ErrorMsg), nullStrPtr(run.PanicStack),
+		nullInt64Ptr(run.HeapAllocAfter), nullInt64Ptr(run.HeapSysAfter),
+		nullIntPtr(run.GoroutinesAfter), nullInt64Ptr(run.NumGCAfter),
+		nullInt64Ptr(run.PauseTotalNsAfter),
+		nullInt64Ptr(run.SysMemUsedBytes), nullInt64Ptr(run.SysMemTotalBytes),
+		id,
+	)
+	return err
+}
+
+const insertJobRunSQL = `
+	INSERT INTO job_runs (
+		host, build_commit, job_name, kind, status,
+		started_at, finished_at, duration_ms,
+		error_msg, panic_stack,
+		heap_alloc_before, heap_alloc_after,
+		heap_sys_before, heap_sys_after,
+		goroutines_before, goroutines_after,
+		num_gc_before, num_gc_after,
+		pause_total_ns_before, pause_total_ns_after,
+		sys_mem_used_bytes, sys_mem_total_bytes
+	) VALUES (
+		$1,$2,$3,$4,$5,
+		$6,$7,$8,
+		$9,$10,
+		$11,$12,
+		$13,$14,
+		$15,$16,
+		$17,$18,
+		$19,$20,
+		$21,$22
+	)`
+
+func jobRunArgs(run JobRun) []any {
+	return []any{
 		run.Host, nullStr(run.BuildCommit), run.JobName, run.Kind, run.Status,
 		run.StartedAt, nullTime(run.FinishedAt), nullInt64Ptr(run.DurationMs),
 		nullStrPtr(run.ErrorMsg), nullStrPtr(run.PanicStack),
@@ -141,8 +192,7 @@ func (r *Runner) insertJobRun(ctx context.Context, run JobRun) error {
 		nullInt64Ptr(run.NumGCBefore), nullInt64Ptr(run.NumGCAfter),
 		nullInt64Ptr(run.PauseTotalNsBefore), nullInt64Ptr(run.PauseTotalNsAfter),
 		nullInt64Ptr(run.SysMemUsedBytes), nullInt64Ptr(run.SysMemTotalBytes),
-	)
-	return err
+	}
 }
 
 // insertLogLines writes a batch of log lines in a single multi-value INSERT.

--- a/joblog/schema.sql
+++ b/joblog/schema.sql
@@ -9,7 +9,7 @@ create table if not exists job_runs (
     build_commit             text,
     job_name                 text not null,
     kind                     text not null,            -- 'job' | 'heartbeat'
-    status                   text not null,            -- 'success' | 'error' | 'panic' | 'tick'
+    status                   text not null,            -- 'running' | 'success' | 'error' | 'panic' | 'tick'
     started_at               timestamptz not null,
     finished_at              timestamptz,
     duration_ms              bigint,

--- a/main.go
+++ b/main.go
@@ -917,7 +917,7 @@ func main() {
 
 	// Periodic memory/goroutine snapshots into job_runs so we have data
 	// points between cron firings to spot creeping resource use.
-	JobLog.StartHeartbeat(5 * time.Minute)
+	JobLog.StartHeartbeat(10 * time.Second)
 
 	if !DevMode {
 		// Set up new refreshes as needed


### PR DESCRIPTION
RunJobErr now inserts a job_runs row with status="running" before fn executes and updates that row on completion, so a process that dies mid-job leaves a visible row instead of nothing. Heartbeat cadence drops from 5m to 10s so the last-known-alive timestamp is much closer to any crash.