### PR TITLE
fix: publish shared globals via atomic.Pointer to stop heap-corruption races

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -62,9 +62,9 @@ func Admin(w http.ResponseWriter, r *http.Request) {
 		pageVars.Nav = filterNavForMobile(pageVars.Nav)
 	}
 
-	pageVars.LastUpdate = LastDatastoreUpdate
-	pageVars.LastNews = LastNewspaperUpdate
-	pageVars.LastStash = LastStashUpdate
+	pageVars.LastUpdate = GetLastDatastoreUpdate()
+	pageVars.LastNews = GetLastNewspaperUpdate()
+	pageVars.LastStash = GetLastStashUpdate()
 
 	var gaScrapers []string
 	for _, state := range []string{"in_progress", "queued"} {
@@ -239,7 +239,7 @@ func Admin(w http.ResponseWriter, r *http.Request) {
 		v.Set("msg", "Moving data to timeseries in the background...")
 		doReboot = true
 
-		if StashingInProgress {
+		if IsStashingInProgress() {
 			v.Set("msg", "Stashing is already in progress")
 		} else {
 			go JobLog.RunJob("admin.stashInTimeseries", stashInTimeseries)
@@ -364,7 +364,7 @@ func Admin(w http.ResponseWriter, r *http.Request) {
 
 	// -- Dashboard: Retail Scrapers --
 	var sellerTable [][]string
-	for _, seller := range Sellers {
+	for _, seller := range GetSellers() {
 		key := "UNKNOWN"
 		for name, scrapersConfig := range Config.ScraperConfig.Config {
 			if slices.Contains(scrapersConfig["retail"], seller.Info().Shorthand) {
@@ -415,7 +415,7 @@ func Admin(w http.ResponseWriter, r *http.Request) {
 
 	// -- Dashboard: Buylist Scrapers --
 	var vendorTable [][]string
-	for _, vendor := range Vendors {
+	for _, vendor := range GetVendors() {
 		key := "UNKNOWN"
 		for name, scrapersConfig := range Config.ScraperConfig.Config {
 			if slices.Contains(scrapersConfig["buylist"], vendor.Info().Shorthand) {
@@ -534,7 +534,7 @@ func Admin(w http.ResponseWriter, r *http.Request) {
 	pageVars.LatestHash = BuildCommit
 	pageVars.CurrentTime = time.Now()
 
-	pageVars.DisableChart = StashingInProgress
+	pageVars.DisableChart = IsStashingInProgress()
 
 	render(w, "admin.html", pageVars)
 }

--- a/api.go
+++ b/api.go
@@ -730,7 +730,7 @@ func SearchAPI(w http.ResponseWriter, r *http.Request) {
 	// Retrieve prices
 	if isRetail && canRetail {
 		var enabledStores []string
-		for _, seller := range Sellers {
+		for _, seller := range GetSellers() {
 			if seller != nil && !slices.Contains(blocklistRetail, seller.Info().Shorthand) {
 				enabledStores = append(enabledStores, seller.Info().Shorthand)
 			}
@@ -745,7 +745,7 @@ func SearchAPI(w http.ResponseWriter, r *http.Request) {
 	}
 	if isBuylist && canBuylist {
 		var enabledStores []string
-		for _, vendor := range Vendors {
+		for _, vendor := range GetVendors() {
 			if vendor != nil && !slices.Contains(blocklistBuylist, vendor.Info().Shorthand) {
 				enabledStores = append(enabledStores, vendor.Info().Shorthand)
 			}

--- a/api_banprice.go
+++ b/api_banprice.go
@@ -124,13 +124,13 @@ func PriceAPI(w http.ResponseWriter, r *http.Request) {
 	var enabledStores []string
 	switch storesOpt {
 	case "ALL_ACCESS":
-		for _, seller := range Sellers {
+		for _, seller := range GetSellers() {
 			shorthand := seller.Info().Shorthand
 			if !slices.Contains(Config.SearchRetailBlockList, shorthand) && !slices.Contains(enabledStores, shorthand) {
 				enabledStores = append(enabledStores, shorthand)
 			}
 		}
-		for _, vendor := range Vendors {
+		for _, vendor := range GetVendors() {
 			shorthand := vendor.Info().Shorthand
 			if !slices.Contains(Config.SearchBuylistBlockList, shorthand) &&
 				!slices.Contains(enabledStores, shorthand) {
@@ -138,13 +138,13 @@ func PriceAPI(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	case "DEV_ACCESS":
-		for _, seller := range Sellers {
+		for _, seller := range GetSellers() {
 			shorthand := seller.Info().Shorthand
 			if !slices.Contains(enabledStores, shorthand) {
 				enabledStores = append(enabledStores, shorthand)
 			}
 		}
-		for _, vendor := range Vendors {
+		for _, vendor := range GetVendors() {
 			shorthand := vendor.Info().Shorthand
 			if !slices.Contains(enabledStores, shorthand) {
 				enabledStores = append(enabledStores, shorthand)
@@ -160,7 +160,7 @@ func PriceAPI(w http.ResponseWriter, r *http.Request) {
 		filter := r.FormValue("filter")
 		if filter == "singles" {
 			var filtered []string
-			for _, seller := range Sellers {
+			for _, seller := range GetSellers() {
 				if (seller.Info().SealedMode && filter == "singles") || (!seller.Info().SealedMode && filter == "sealed") {
 					continue
 				}
@@ -169,7 +169,7 @@ func PriceAPI(w http.ResponseWriter, r *http.Request) {
 					filtered = append(filtered, shorthand)
 				}
 			}
-			for _, vendor := range Vendors {
+			for _, vendor := range GetVendors() {
 				if (vendor.Info().SealedMode && filter == "singles") || (!vendor.Info().SealedMode && filter == "sealed") {
 					continue
 				}
@@ -407,7 +407,7 @@ func getIdFunc(mode string) func(co *mtgmatcher.CardObject) string {
 
 func getSellerPrices(mode string, enabledStores []string, filterByEdition string, filterByHash []string, filterByFinish string, qty, conds, sealed bool, tagName string) map[string]map[string]*BanPrice {
 	out := map[string]map[string]*BanPrice{}
-	for _, seller := range Sellers {
+	for _, seller := range GetSellers() {
 		// Only keep the right product type
 		if (!sealed && seller.Info().SealedMode) ||
 			(sealed && !seller.Info().SealedMode) {
@@ -558,7 +558,7 @@ func processEntry[T mtgban.GenericEntry](out map[string]map[string]*BanPrice, en
 
 func getVendorPrices(mode string, enabledStores []string, filterByEdition string, filterByHash []string, filterByFinish string, qty, conds, sealed bool, tagName string) map[string]map[string]*BanPrice {
 	out := map[string]map[string]*BanPrice{}
-	for _, vendor := range Vendors {
+	for _, vendor := range GetVendors() {
 		// Only keep the right product type
 		if (!sealed && vendor.Info().SealedMode) ||
 			(sealed && !vendor.Info().SealedMode) {
@@ -778,7 +778,7 @@ func SimplePrice2CSV(w *csv.Writer, pm map[string]map[string]*BanPrice, uploaded
 			}
 
 			// Determine whether scraper is an index and should appear regardless of conditions
-			for _, scraper := range Sellers {
+			for _, scraper := range GetSellers() {
 				if scraper.Info().Shorthand != scraperKey {
 					continue
 				}
@@ -786,7 +786,7 @@ func SimplePrice2CSV(w *csv.Writer, pm map[string]map[string]*BanPrice, uploaded
 					isIndex = append(isIndex, scraperKey)
 				}
 			}
-			for _, scraper := range Vendors {
+			for _, scraper := range GetVendors() {
 				if scraper.Info().Shorthand != scraperKey {
 					continue
 				}

--- a/api_prices.go
+++ b/api_prices.go
@@ -45,7 +45,7 @@ func BatchPricesAPI(w http.ResponseWriter, r *http.Request) {
 		// Find best NM sell price (lowest)
 		var bestSellPrice float64
 		var bestSellName string
-		for _, seller := range Sellers {
+		for _, seller := range GetSellers() {
 			if slices.Contains(blocklistRetail, seller.Info().Shorthand) {
 				continue
 			}
@@ -79,7 +79,7 @@ func BatchPricesAPI(w http.ResponseWriter, r *http.Request) {
 		// Find best NM buy price (highest buylist)
 		var bestBuyPrice float64
 		var bestBuyName string
-		for _, vendor := range Vendors {
+		for _, vendor := range GetVendors() {
 			if slices.Contains(blocklistBuylist, vendor.Info().Shorthand) {
 				continue
 			}

--- a/arbit.go
+++ b/arbit.go
@@ -337,7 +337,7 @@ func arbit(w http.ResponseWriter, r *http.Request, reverse bool) {
 	allowlistSellersOpt := GetParamFromSig(sig, "ArbitEnabled")
 
 	if allowlistSellersOpt == "ALL" || (DevMode && !SigCheck) {
-		for _, seller := range Sellers {
+		for _, seller := range GetSellers() {
 			if seller.Info().MetadataOnly {
 				continue
 			}
@@ -362,14 +362,14 @@ func arbit(w http.ResponseWriter, r *http.Request, reverse bool) {
 	// Populate vendor keys for the settings modal (shown on every page load)
 	var vendorKeys []string
 	if reverse {
-		for _, seller := range Sellers {
+		for _, seller := range GetSellers() {
 			if slices.Contains(blocklistVendors, seller.Info().Shorthand) {
 				continue
 			}
 			vendorKeys = append(vendorKeys, seller.Info().Shorthand)
 		}
 	} else {
-		for _, vendor := range Vendors {
+		for _, vendor := range GetVendors() {
 			if slices.Contains(blocklistVendors, vendor.Info().Shorthand) {
 				continue
 			}
@@ -425,7 +425,7 @@ func Global(w http.ResponseWriter, r *http.Request) {
 
 	// The "menu" section, the reference
 	var allowlistSellers []string
-	for _, seller := range Sellers {
+	for _, seller := range GetSellers() {
 		if anyEnabled {
 			// This is the list of allowed global sellers, minus the ones blocked from search
 			if slices.Contains(Config.GlobalAllowList, seller.Info().Shorthand) {
@@ -445,7 +445,7 @@ func Global(w http.ResponseWriter, r *http.Request) {
 
 	// The "Jump to" section, the probe
 	var blocklistVendors []string
-	for _, seller := range Sellers {
+	for _, seller := range GetSellers() {
 		if slices.Contains(Config.GlobalProbeList, seller.Info().Shorthand) {
 			continue
 		}
@@ -454,7 +454,7 @@ func Global(w http.ResponseWriter, r *http.Request) {
 
 	// Populate vendor keys for the settings modal (shown on every page load)
 	var globalVendorKeys []string
-	for _, vendor := range Vendors {
+	for _, vendor := range GetVendors() {
 		if slices.Contains(blocklistVendors, vendor.Info().Shorthand) {
 			continue
 		}
@@ -518,7 +518,7 @@ func scraperCompare(w http.ResponseWriter, r *http.Request, pageVars PageVars, a
 					break
 				}
 
-				for _, vendor := range Vendors {
+				for _, vendor := range GetVendors() {
 					if vendor.Info().Shorthand == v[0] {
 						source = vendor
 						break
@@ -531,7 +531,7 @@ func scraperCompare(w http.ResponseWriter, r *http.Request, pageVars PageVars, a
 					break
 				}
 
-				for _, seller := range Sellers {
+				for _, seller := range GetSellers() {
 					if seller.Info().Shorthand == v[0] {
 						source = seller
 						break
@@ -577,14 +577,14 @@ func scraperCompare(w http.ResponseWriter, r *http.Request, pageVars PageVars, a
 	// Set up menu bar, by selecting which scrapers should be selectable as source
 	var menuScrapers []mtgban.Scraper
 	if pageVars.ReverseMode {
-		for _, vendor := range Vendors {
+		for _, vendor := range GetVendors() {
 			if slices.Contains(blocklistVendors, vendor.Info().Shorthand) {
 				continue
 			}
 			menuScrapers = append(menuScrapers, vendor)
 		}
 	} else {
-		for _, seller := range Sellers {
+		for _, seller := range GetSellers() {
 			if !slices.Contains(allowlistSellers, seller.Info().Shorthand) {
 				continue
 			}
@@ -718,7 +718,7 @@ func scraperCompare(w http.ResponseWriter, r *http.Request, pageVars PageVars, a
 	// The pool of scrapers that source will be compared against
 	var scrapers []mtgban.Scraper
 	if pageVars.GlobalMode || pageVars.ReverseMode {
-		for _, seller := range Sellers {
+		for _, seller := range GetSellers() {
 			// Skip unactionable sellers
 			if seller.Info().SealedMode && seller.Info().MetadataOnly {
 				continue
@@ -732,7 +732,7 @@ func scraperCompare(w http.ResponseWriter, r *http.Request, pageVars PageVars, a
 			scrapers = append(scrapers, seller)
 		}
 	} else {
-		for _, vendor := range Vendors {
+		for _, vendor := range GetVendors() {
 			if source.Info().SealedMode != vendor.Info().SealedMode {
 				continue
 			}

--- a/auth.go
+++ b/auth.go
@@ -294,7 +294,7 @@ func enforceAPISigning(next http.Handler) http.Handler {
 			return
 		}
 
-		if len(Sellers) == 0 || len(Vendors) == 0 {
+		if len(GetSellers()) == 0 || len(GetVendors()) == 0 {
 			http.Error(w, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
 			return
 		}

--- a/chart.go
+++ b/chart.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"slices"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/mtgban/go-mtgban/mtgmatcher"
@@ -174,9 +175,25 @@ func getRow(accumulated map[string]*timeseries.PriceRow, uuid string, isFoil boo
 	return row
 }
 
-var StashingInProgress bool
+// stashingInProgress gates concurrent invocations of stashInTimeseries
+// (cron + admin button). Use IsStashingInProgress to read.
+var stashingInProgress atomic.Bool
+
+// IsStashingInProgress reports whether a timeseries stash is currently
+// running. Safe to call from any goroutine.
+func IsStashingInProgress() bool {
+	return stashingInProgress.Load()
+}
 
 func stashInTimeseries() {
+	// Only one stash may run at a time. The cron fires every 12h and the
+	// admin button can fire at any moment; CompareAndSwap is the real gate.
+	if !stashingInProgress.CompareAndSwap(false, true) {
+		log.Println("stashInTimeseries: another stash is already running, skipping")
+		return
+	}
+	defer stashingInProgress.Store(false)
+
 	if PricesArchiveDB == nil {
 		log.Println("PricesArchiveDB not initialized, skipping stash")
 		return
@@ -184,13 +201,12 @@ func stashInTimeseries() {
 
 	start := time.Now()
 	ServerNotify("timeseries", "Taking snapshot...")
-	StashingInProgress = true
 
 	// Accumulate all prices into a single row per (date, uuid, foil, etched).
 	accumulated := map[string]*timeseries.PriceRow{}
 
 	// Collect retail prices from sellers
-	for _, seller := range Sellers {
+	for _, seller := range GetSellers() {
 		for _, config := range Config.TimeseriesConfig.Datasets {
 			if !slices.Contains(config.Retail, seller.Info().Shorthand) {
 				continue
@@ -225,7 +241,7 @@ func stashInTimeseries() {
 	}
 
 	// Collect buylist prices from vendors
-	for _, vendor := range Vendors {
+	for _, vendor := range GetVendors() {
 		for _, config := range Config.TimeseriesConfig.Datasets {
 			if !slices.Contains(config.Buylist, vendor.Info().Shorthand) {
 				continue
@@ -265,8 +281,7 @@ func stashInTimeseries() {
 		ServerNotify("timeseries", fmt.Sprintf("batch upsert error: %s", err))
 	}
 
-	LastStashUpdate = time.Now()
-	StashingInProgress = false
+	SetLastStashUpdate(time.Now())
 	msg := fmt.Sprintf("Snapshot completed in %s: %d upserted, %d errors", time.Since(start), upserted, errCount)
 	ServerNotify("timeseries", msg)
 }

--- a/checkpoints.go
+++ b/checkpoints.go
@@ -264,7 +264,8 @@ func curatedCheckpoints(cardName string, earliest time.Time) []ChartCheckpoint {
 // distinct card release date so the marker lands where the card actually
 // appeared, rather than collapsing every drop onto SLD's original 2019 date.
 func setCheckpointsFromEditions(cardName string, earliest time.Time, printingSet map[string]bool) []ChartCheckpoint {
-	if SealedEditionsList == nil {
+	sealedList := GetEditions().SealedEditionsList
+	if sealedList == nil {
 		return nil
 	}
 	now := time.Now()
@@ -283,7 +284,7 @@ func setCheckpointsFromEditions(cardName string, earliest time.Time, printingSet
 	}
 	bestRelease := map[string]releasePick{}
 
-	for _, entries := range SealedEditionsList {
+	for _, entries := range sealedList {
 		for _, e := range entries {
 			if e.Code == "" || seen[e.Code] {
 				continue

--- a/discord.go
+++ b/discord.go
@@ -459,7 +459,7 @@ func checkForLinks(mGuildID, mContent string) (string, string) {
 // message is created on any channel that the authenticated bot has access to.
 func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 	// Ignore requests if starting up
-	if len(Sellers) == 0 || len(Vendors) == 0 {
+	if len(GetSellers()) == 0 || len(GetVendors()) == 0 {
 		return
 	}
 

--- a/load.go
+++ b/load.go
@@ -9,6 +9,8 @@ import (
 	"path"
 	"slices"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/mtgban/go-mtgban/mtgban"
 	"github.com/mtgban/simplecloud"
@@ -16,11 +18,38 @@ import (
 
 var DataBucket simplecloud.Reader
 
-// Slice containing all the loaded retail data
-var Sellers []mtgban.Seller
+// Snapshots of the loaded retail and buylist data. Held behind atomic.Pointer
+// so readers always observe a fully-constructed, immutable slice and writers
+// publish via a single atomic store. Mutating the slice returned by
+// GetSellers/GetVendors is a bug — treat it as read-only.
+var (
+	sellersPtr atomic.Pointer[[]mtgban.Seller]
+	vendorsPtr atomic.Pointer[[]mtgban.Vendor]
 
-// Slice containing all the loaded buylist data
-var Vendors []mtgban.Vendor
+	// Serializes writers so concurrent updateSellers/updateVendors calls
+	// don't lose each other's changes during the read-modify-publish cycle.
+	scrapersWriteMu sync.Mutex
+)
+
+// GetSellers returns the current sellers snapshot. The returned slice is
+// shared and MUST NOT be modified by callers.
+func GetSellers() []mtgban.Seller {
+	p := sellersPtr.Load()
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+// GetVendors returns the current vendors snapshot. The returned slice is
+// shared and MUST NOT be modified by callers.
+func GetVendors() []mtgban.Vendor {
+	p := vendorsPtr.Load()
+	if p == nil {
+		return nil
+	}
+	return *p
+}
 
 type ScraperConfig struct {
 	BucketAccessKey  string `json:"bucket_access_key"`
@@ -109,117 +138,121 @@ func loadScraper(bucket simplecloud.Reader, base, game, name, kind, shorthand, f
 }
 
 func updateSellers(scraper mtgban.Scraper) {
+	seller := scraper.(mtgban.Seller)
+
+	scrapersWriteMu.Lock()
+	defer scrapersWriteMu.Unlock()
+
+	current := GetSellers()
+
 	sellerIndex := -1
-	for i, seller := range Sellers {
-		if seller.Info().Shorthand == scraper.Info().Shorthand {
+	for i, s := range current {
+		if s.Info().Shorthand == seller.Info().Shorthand {
 			sellerIndex = i
 			break
 		}
 	}
 
-	err := updateSellerAtPosition(scraper.(mtgban.Seller), sellerIndex)
+	next, err := buildNextSellers(current, seller, sellerIndex)
 	if err != nil {
 		msg := fmt.Sprintf("seller %s %s - %s", scraper.Info().Name, scraper.Info().Shorthand, err.Error())
 		ServerNotify("refresh", msg, true)
 		return
 	}
+	sellersPtr.Store(&next)
 
 	msg := fmt.Sprintf("%s inventory updated at position %d", scraper.Info().Shorthand, sellerIndex)
 	ServerNotify("refresh", msg)
-
-	return
 }
 
-func updateSellerAtPosition(seller mtgban.Seller, i int) error {
-	// Save seller in global array
+func buildNextSellers(current []mtgban.Seller, seller mtgban.Seller, i int) ([]mtgban.Seller, error) {
 	if i < 0 {
-		Sellers = append(Sellers, seller)
+		next := make([]mtgban.Seller, len(current)+1)
+		copy(next, current)
+		next[len(current)] = seller
 
-		// Keep slices sorted
-		slices.SortFunc(Sellers, func(a, b mtgban.Seller) int {
+		slices.SortFunc(next, func(a, b mtgban.Seller) int {
 			ret := strings.Compare(a.Info().Name, b.Info().Name)
 			if ret == 0 {
 				ret = strings.Compare(a.Info().Shorthand, b.Info().Shorthand)
 			}
 			return ret
 		})
-		return nil
+		return next, nil
 	}
 
-	// Check timestamp
-	if seller.Info().InventoryTimestamp.Before(*Sellers[i].Info().InventoryTimestamp) {
-		return errors.New("new inventory is older than current one")
+	if seller.Info().InventoryTimestamp.Before(*current[i].Info().InventoryTimestamp) {
+		return nil, errors.New("new inventory is older than current one")
 	}
 
-	// Load inventory
 	inv := seller.Inventory()
-
-	// Do not update in case the new inventory wasn't completely loaded
-	// for example due to API problems, unless the old inventory was already sparse
-	old := Sellers[i].Inventory()
+	old := current[i].Inventory()
 	if len(inv) > 0 && len(inv) < len(old)/2 && len(old) > 100 {
-		return errors.New("new inventory is missing too many entries")
+		return nil, errors.New("new inventory is missing too many entries")
 	}
 
-	Sellers[i] = seller
-
-	return nil
+	next := make([]mtgban.Seller, len(current))
+	copy(next, current)
+	next[i] = seller
+	return next, nil
 }
 
 func updateVendors(scraper mtgban.Scraper) {
+	vendor := scraper.(mtgban.Vendor)
+
+	scrapersWriteMu.Lock()
+	defer scrapersWriteMu.Unlock()
+
+	current := GetVendors()
+
 	vendorIndex := -1
-	for i, vendor := range Vendors {
-		if vendor.Info().Shorthand == scraper.Info().Shorthand {
+	for i, v := range current {
+		if v.Info().Shorthand == vendor.Info().Shorthand {
 			vendorIndex = i
 			break
 		}
 	}
 
-	err := updateVendorAtPosition(scraper.(mtgban.Vendor), vendorIndex)
+	next, err := buildNextVendors(current, vendor, vendorIndex)
 	if err != nil {
 		msg := fmt.Sprintf("vendor %s %s - %s", scraper.Info().Name, scraper.Info().Shorthand, err.Error())
 		ServerNotify("refresh", msg, true)
 		return
 	}
+	vendorsPtr.Store(&next)
 
 	msg := fmt.Sprintf("%s buylist updated at position %d", scraper.Info().Shorthand, vendorIndex)
 	ServerNotify("refresh", msg)
-
-	return
 }
 
-func updateVendorAtPosition(vendor mtgban.Vendor, i int) error {
-	// Save vendor in global array
+func buildNextVendors(current []mtgban.Vendor, vendor mtgban.Vendor, i int) ([]mtgban.Vendor, error) {
 	if i < 0 {
-		Vendors = append(Vendors, vendor)
+		next := make([]mtgban.Vendor, len(current)+1)
+		copy(next, current)
+		next[len(current)] = vendor
 
-		// Keep slices sorted
-		slices.SortFunc(Vendors, func(a, b mtgban.Vendor) int {
+		slices.SortFunc(next, func(a, b mtgban.Vendor) int {
 			ret := strings.Compare(a.Info().Name, b.Info().Name)
 			if ret == 0 {
 				ret = strings.Compare(a.Info().Shorthand, b.Info().Shorthand)
 			}
 			return ret
 		})
-		return nil
+		return next, nil
 	}
 
-	// Check timestamp
-	if vendor.Info().BuylistTimestamp.Before(*Vendors[i].Info().BuylistTimestamp) {
-		return errors.New("new buylist is older than current one")
+	if vendor.Info().BuylistTimestamp.Before(*current[i].Info().BuylistTimestamp) {
+		return nil, errors.New("new buylist is older than current one")
 	}
 
-	// Load buylist
 	bl := vendor.Buylist()
-
-	// Do not update in case the new buylist wasn't completely loaded
-	// for example due to API problems, unless the old inventory was already sparse
-	old := Vendors[i].Buylist()
+	old := current[i].Buylist()
 	if len(bl) > 0 && len(bl) < len(old)/2 && len(old) > 100 {
-		return errors.New("new buylist is missing too many entries")
+		return nil, errors.New("new buylist is missing too many entries")
 	}
 
-	Vendors[i] = vendor
-
-	return nil
+	next := make([]mtgban.Vendor, len(current))
+	copy(next, current)
+	next[i] = vendor
+	return next, nil
 }

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -447,9 +448,35 @@ var SkipPrices bool
 var SkipNewspaper bool
 var LogDir string
 
-var LastDatastoreUpdate time.Time
-var LastStashUpdate time.Time
-var LastNewspaperUpdate time.Time
+// Timestamps written by background goroutines (datastore reload, stash
+// cron, newspaper cron) and read by the admin dashboard. Held behind
+// atomic.Pointer so concurrent reads can't observe a torn time.Time
+// (it's a 24-byte struct, not a single word).
+var (
+	lastDatastoreUpdatePtr atomic.Pointer[time.Time]
+	lastStashUpdatePtr     atomic.Pointer[time.Time]
+	lastNewspaperUpdatePtr atomic.Pointer[time.Time]
+)
+
+// SetLastDatastoreUpdate / SetLastStashUpdate / SetLastNewspaperUpdate
+// publish a new timestamp atomically.
+func SetLastDatastoreUpdate(t time.Time) { lastDatastoreUpdatePtr.Store(&t) }
+func SetLastStashUpdate(t time.Time)     { lastStashUpdatePtr.Store(&t) }
+func SetLastNewspaperUpdate(t time.Time) { lastNewspaperUpdatePtr.Store(&t) }
+
+// GetLastDatastoreUpdate / GetLastStashUpdate / GetLastNewspaperUpdate
+// return the most recent timestamp, or the zero time if none has been
+// published yet.
+func GetLastDatastoreUpdate() time.Time { return loadTime(lastDatastoreUpdatePtr.Load()) }
+func GetLastStashUpdate() time.Time     { return loadTime(lastStashUpdatePtr.Load()) }
+func GetLastNewspaperUpdate() time.Time { return loadTime(lastNewspaperUpdatePtr.Load()) }
+
+func loadTime(p *time.Time) time.Time {
+	if p == nil {
+		return time.Time{}
+	}
+	return *p
+}
 
 var Newspaper3dayDB *sql.DB
 var Newspaper1dayDB *sql.DB
@@ -801,7 +828,7 @@ func loadDatastore(ds string) error {
 		return err
 	}
 
-	LastDatastoreUpdate = time.Now()
+	SetLastDatastoreUpdate(time.Now())
 	go JobLog.RunJob("post-datastore.updateStaticData", updateStaticData)
 	go JobLog.RunJob("post-datastore.cacheNewspaper", cacheNewspaper)
 	ServerNotify("init", "Datastore installed")
@@ -1036,7 +1063,7 @@ func main() {
 
 	// /healthz: returns 200 only if dependencies are OK.
 	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		if len(Sellers) == 0 || len(Vendors) == 0 {
+		if len(GetSellers()) == 0 || len(GetVendors()) == 0 {
 			http.Error(w, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
 			return
 		}
@@ -1144,12 +1171,12 @@ var funcMap = template.FuncMap{
 		return strings.Contains(s, p)
 	},
 	"is_sealed_scraper": func(shorthand string) bool {
-		for _, seller := range Sellers {
+		for _, seller := range GetSellers() {
 			if seller != nil && seller.Info().Shorthand == shorthand {
 				return seller.Info().SealedMode
 			}
 		}
-		for _, vendor := range Vendors {
+		for _, vendor := range GetVendors() {
 			if vendor != nil && vendor.Info().Shorthand == shorthand {
 				return vendor.Info().SealedMode
 			}

--- a/news.go
+++ b/news.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/mtgban/go-mtgban/mtgban"
@@ -392,8 +393,21 @@ var gameMap = map[string]string{
 	"pokemon":   "Pokemon",
 }
 
-// Cache of card UUIDs that appear in the newspaper spike score pages
-var NewspaperUUIDs map[string]struct{}
+// Cache of card UUIDs that appear in the newspaper spike score pages.
+// Published atomically alongside newspaperPagesPtr so readers always see a
+// fully-built map.
+var newspaperUUIDsPtr atomic.Pointer[map[string]struct{}]
+
+// GetNewspaperUUIDs returns the current set of UUIDs that appear in the
+// newspaper spike-score pages. The returned map is shared and MUST NOT be
+// modified by callers. Returns nil before the first successful cache run.
+func GetNewspaperUUIDs() map[string]struct{} {
+	p := newspaperUUIDsPtr.Load()
+	if p == nil {
+		return nil
+	}
+	return *p
+}
 
 func cacheNewspaper() {
 	if Config.OfflineKey != "" || SkipNewspaper {
@@ -414,18 +428,24 @@ func cacheNewspaper() {
 		return
 	}
 
-	for i := range NewspaperPages {
-		if !NewspaperPages[i].NewNewspaper {
+	// Build a fresh slice from the current snapshot so readers never observe
+	// torn struct fields (slice headers, in particular) while we update them.
+	current := GetNewspaperPages()
+	next := make([]NewspaperPage, len(current))
+	copy(next, current)
+
+	for i := range next {
+		if !next[i].NewNewspaper {
 			continue
 		}
-		if NewspaperPages[i].Query == "" {
+		if next[i].Query == "" {
 			continue
 		}
-		if NewspaperPages[i].NeedsBuylist && Config.Game != DefaultGame {
+		if next[i].NeedsBuylist && Config.Game != DefaultGame {
 			continue
 		}
 
-		query := NewspaperPages[i].Query + " AND game_name = '" + game + "' ORDER BY ranking ASC;"
+		query := next[i].Query + " AND game_name = '" + game + "' ORDER BY ranking ASC;"
 
 		results, err := getResults(NewNewspaperDB, query)
 		if err != nil {
@@ -433,11 +453,11 @@ func cacheNewspaper() {
 			continue
 		}
 		if len(results) == 0 {
-			ServerNotify("newspaper", NewspaperPages[i].Option+" results are empty", true)
+			ServerNotify("newspaper", next[i].Option+" results are empty", true)
 			continue
 		}
-		if NewspaperPages[i].Results != nil && len(results) < len(NewspaperPages[i].Results)/2 {
-			ServerNotify("newspaper", NewspaperPages[i].Option+" too few results "+fmt.Sprint(len(results)), true)
+		if next[i].Results != nil && len(results) < len(next[i].Results)/2 {
+			ServerNotify("newspaper", next[i].Option+" too few results "+fmt.Sprint(len(results)), true)
 			continue
 		}
 
@@ -454,13 +474,13 @@ func cacheNewspaper() {
 		sort.Strings(editions)
 		sort.Strings(variants)
 
-		log.Println(NewspaperPages[i].Option, "has", len(results), "elements")
-		NewspaperPages[i].Results = results
-		NewspaperPages[i].AvailableEditions = editions
-		NewspaperPages[i].PossibleFinish = variants
+		log.Println(next[i].Option, "has", len(results), "elements")
+		next[i].Results = results
+		next[i].AvailableEditions = editions
+		next[i].PossibleFinish = variants
 
 		// Cache UUIDs from spike score pages for the "on:newspaper" search filter
-		if NewspaperPages[i].Option == "combined_spike_score" || NewspaperPages[i].Option == "spike_score" {
+		if next[i].Option == "combined_spike_score" || next[i].Option == "spike_score" {
 			for _, result := range results {
 				newspaperUUIDs[result.UUID] = struct{}{}
 			}
@@ -486,20 +506,44 @@ func cacheNewspaper() {
 		sort.Strings(editions3day)
 		sort.Strings(variants3day)
 
-		log.Println(NewspaperPages[i].Option, "(3day) has", len(results3day), "elements")
-		NewspaperPages[i].Results3Day = results3day
-		NewspaperPages[i].AvailableEditions3Day = editions3day
-		NewspaperPages[i].PossibleFinish3Day = variants3day
+		log.Println(next[i].Option, "(3day) has", len(results3day), "elements")
+		next[i].Results3Day = results3day
+		next[i].AvailableEditions3Day = editions3day
+		next[i].PossibleFinish3Day = variants3day
 	}
 
-	NewspaperUUIDs = newspaperUUIDs
+	newspaperPagesPtr.Store(&next)
+	newspaperUUIDsPtr.Store(&newspaperUUIDs)
 	log.Println("Newspaper UUIDs cached:", len(newspaperUUIDs))
 
-	LastNewspaperUpdate = time.Now()
+	SetLastNewspaperUpdate(time.Now())
 	log.Println("Newspaper All Ready")
 }
 
-var NewspaperPages = []NewspaperPage{
+// newspaperPagesPtr holds the current cached newspaper data. cacheNewspaper
+// builds a fresh slice from the previous snapshot and publishes it with a
+// single Store so readers always see a fully-constructed slice.
+var newspaperPagesPtr atomic.Pointer[[]NewspaperPage]
+
+// GetNewspaperPages returns the current newspaper-pages snapshot. The
+// returned slice and the structs it contains are shared and MUST NOT be
+// modified by callers.
+func GetNewspaperPages() []NewspaperPage {
+	p := newspaperPagesPtr.Load()
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+func init() {
+	// Seed the atomic pointer with the static literal so readers see the
+	// configured pages even before the first cacheNewspaper run completes.
+	initial := newspaperPagesInitial
+	newspaperPagesPtr.Store(&initial)
+}
+
+var newspaperPagesInitial = []NewspaperPage{
 	{
 		Title:  "Top Singles by Combined Spike Score",
 		Desc:   "Best cards to buy, combining TCGplayer sales data and Card Kingdom pricing changes",
@@ -1442,8 +1486,9 @@ func Newspaper(w http.ResponseWriter, r *http.Request) {
 		pageVars.Nav = filterNavForMobile(pageVars.Nav)
 	}
 
-	pageVars.EditionsCategories = AllEditionsCategoriesSorted
-	pageVars.EditionsByCategory = AllEditionsByCategory
+	editions := GetEditions()
+	pageVars.EditionsCategories = editions.AllEditionsCategoriesSorted
+	pageVars.EditionsByCategory = editions.AllEditionsByCategory
 	pageVars.PickerID = "news-editions-picker"
 
 	// Check if any DB connection was made
@@ -1498,15 +1543,16 @@ func Newspaper(w http.ResponseWriter, r *http.Request) {
 	miscSearchOpts := strings.Split(readCookie(r, "SearchMiscOpts"), ",")
 	preferFlavor := slices.Contains(miscSearchOpts, "preferFlavor")
 
+	newspaperPages := GetNewspaperPages()
 	oldMode := page == "old"
-	for _, newspage := range NewspaperPages {
+	for _, newspage := range newspaperPages {
 		if page == newspage.Option {
 			oldMode = !newspage.NewNewspaper
 			break
 		}
 	}
 
-	for _, newspage := range NewspaperPages {
+	for _, newspage := range newspaperPages {
 		if (oldMode && newspage.NewNewspaper) || (!oldMode && !newspage.NewNewspaper) {
 			continue
 		}
@@ -1519,7 +1565,7 @@ func Newspaper(w http.ResponseWriter, r *http.Request) {
 		pageVars.ToC = append(pageVars.ToC, newspage)
 	}
 
-	pageVars.LastUpdate = LastNewspaperUpdate
+	pageVars.LastUpdate = GetLastNewspaperUpdate()
 	if oldMode {
 		var err error
 		pageVars.LastUpdate, err = getLastDBUpdate(db)

--- a/palette.go
+++ b/palette.go
@@ -183,7 +183,7 @@ func PaletteStores(w http.ResponseWriter, r *http.Request) {
 		Vendors: []PaletteStore{},
 	}
 	seen := map[string]bool{}
-	for _, s := range Sellers {
+	for _, s := range GetSellers() {
 		if s == nil {
 			continue
 		}
@@ -200,7 +200,7 @@ func PaletteStores(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 	seen = map[string]bool{}
-	for _, v := range Vendors {
+	for _, v := range GetVendors() {
 		if v == nil {
 			continue
 		}
@@ -239,14 +239,15 @@ func paletteNewspaperTargetsJSON() template.JS {
 	titleCounts := map[string]int{}
 
 	// First pass: count title occurrences so we know which need disambiguation.
-	for _, p := range NewspaperPages {
+	newspaperPages := GetNewspaperPages()
+	for _, p := range newspaperPages {
 		if p.Option == "" || p.Option == "options" {
 			continue
 		}
 		titleCounts[p.Title]++
 	}
 
-	for _, p := range NewspaperPages {
+	for _, p := range newspaperPages {
 		if p.Option == "" || p.Option == "options" {
 			continue
 		}

--- a/product.go
+++ b/product.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/mtgban/go-mtgban/mtgban"
@@ -48,30 +49,84 @@ type FlatEditionEntry struct {
 	ColorHex []ColorEntry
 }
 
-// Contains all the set value computations shown on sealed products
-var Infos map[string]mtgban.InventoryRecord
+// Snapshot of set-value computations shown on sealed products. Held behind
+// atomic.Pointer so readers always see a fully-constructed map. The map is
+// rebuilt from scratch in runSealedAnalysis and published in a single Store;
+// callers must treat the returned map as read-only.
+var infosPtr atomic.Pointer[map[string]mtgban.InventoryRecord]
 
-// All editions containing sealed products
-var SealedEditionsSorted []string
-var SealedEditionsList map[string][]EditionEntry
+// GetInfos returns the current Infos snapshot. The returned map is shared
+// and MUST NOT be modified by callers.
+func GetInfos() map[string]mtgban.InventoryRecord {
+	p := infosPtr.Load()
+	if p == nil {
+		return nil
+	}
+	return *p
+}
 
-// All different editions
-var AllEditionsKeys []string
-var AllEditionsKeysNoFoilOrPromos []string
-var AllEditionsMap map[string]EditionEntry
-var AllEditionsByCategory map[string][]EditionEntry
-var AllEditionsCategoriesSorted []string
+// EditionsSnapshot bundles every piece of edition-derived state produced by
+// updateStaticData. Publishing them together under a single atomic.Pointer
+// guarantees readers always see a fully-consistent view — previously the 12
+// individual stores could be observed out of sync, e.g. AllEditionsKeys
+// updated while AllEditionsMap was still the previous version, producing
+// nil-map lookups in search.
+type EditionsSnapshot struct {
+	// All editions containing sealed products
+	SealedEditionsSorted []string
+	SealedEditionsList   map[string][]EditionEntry
 
-// Editions with parent sets
-var TreeEditionsKeys []string
-var TreeEditionsMap map[string][]EditionEntry
+	// All different editions
+	AllEditionsKeys               []string
+	AllEditionsKeysNoFoilOrPromos []string
+	AllEditionsMap                map[string]EditionEntry
+	AllEditionsByCategory         map[string][]EditionEntry
+	AllEditionsCategoriesSorted   []string
 
-// Long time no reprint data
-var ReprintsKeys []string
-var ReprintsMap map[string][]ReprintEntry
+	// Editions with parent sets
+	TreeEditionsKeys []string
+	TreeEditionsMap  map[string][]EditionEntry
 
-// The number of editions, cards, and printings
-var TotalSets, TotalCards, TotalUnique int
+	// The number of editions, cards, and printings
+	TotalSets   int
+	TotalCards  int
+	TotalUnique int
+}
+
+var editionsPtr atomic.Pointer[EditionsSnapshot]
+
+func init() {
+	// Seed an empty snapshot so accessors return a usable value before
+	// updateStaticData first runs.
+	editionsPtr.Store(&EditionsSnapshot{})
+}
+
+// GetEditions returns the current editions snapshot. The returned struct's
+// fields are shared and MUST NOT be modified by callers.
+func GetEditions() *EditionsSnapshot {
+	return editionsPtr.Load()
+}
+
+// Long time no reprint data. ReprintsKeys is the ordered list of section
+// titles; ReprintsMap holds the entries per section. They are published
+// together as a single immutable snapshot so readers can never observe new
+// keys against a stale map (or vice versa).
+type reprintsSnapshot struct {
+	Keys []string
+	Map  map[string][]ReprintEntry
+}
+
+var reprintsPtr atomic.Pointer[reprintsSnapshot]
+
+// GetReprints returns the current reprints snapshot. The returned slice and
+// map are shared and MUST NOT be modified by callers.
+func GetReprints() ([]string, map[string][]ReprintEntry) {
+	p := reprintsPtr.Load()
+	if p == nil {
+		return nil, nil
+	}
+	return p.Keys, p.Map
+}
 
 var categoryEdition = map[string]string{
 	"archenemy":        "Boxed Sets",
@@ -613,14 +668,15 @@ func runSealedAnalysis() {
 	ckBuylist, _ := findVendorBuylist("CK")
 	directNetBuylist, _ := findVendorBuylist("TCGDirectNet")
 
-	ReprintsKeys, ReprintsMap = getReprintsGlobal(tcgInventory, tcgMarket)
+	reprintsKeys, reprintsMap := getReprintsGlobal(tcgInventory, tcgMarket)
+	reprintsPtr.Store(&reprintsSnapshot{Keys: reprintsKeys, Map: reprintsMap})
 
 	infos := map[string]mtgban.InventoryRecord{}
 
 	runRawSetValue(infos, tcgInventory, tcgDirect, ckBuylist, directNetBuylist)
 	infos["hotlist"] = checkHighestBuylists("CK")
 
-	Infos = infos
+	infosPtr.Store(&infos)
 }
 
 func checkHighestBuylists(store string) mtgban.InventoryRecord {
@@ -807,13 +863,14 @@ func runRawSetValue(infos map[string]mtgban.InventoryRecord, tcgInventory, tcgDi
 }
 
 func updateStaticData() {
-	SealedEditionsSorted, SealedEditionsList = getSealedEditions()
-	AllEditionsKeys, AllEditionsMap = getAllEditions()
-	AllEditionsCategoriesSorted, AllEditionsByCategory = getAllEditionsByCategory()
-	TreeEditionsKeys, TreeEditionsMap = getTreeEditions()
+	snap := &EditionsSnapshot{}
+	snap.SealedEditionsSorted, snap.SealedEditionsList = getSealedEditions()
+	snap.AllEditionsKeys, snap.AllEditionsMap = getAllEditions()
+	snap.AllEditionsCategoriesSorted, snap.AllEditionsByCategory = getAllEditionsByCategory()
+	snap.TreeEditionsKeys, snap.TreeEditionsMap = getTreeEditions()
 
 	var filteredEditions []string
-	for _, code := range AllEditionsKeys {
+	for _, code := range snap.AllEditionsKeys {
 		set, err := mtgmatcher.GetSet(code)
 		if err != nil {
 			continue
@@ -826,17 +883,19 @@ func updateStaticData() {
 		}
 		filteredEditions = append(filteredEditions, code)
 	}
-	AllEditionsKeysNoFoilOrPromos = filteredEditions
+	snap.AllEditionsKeysNoFoilOrPromos = filteredEditions
 
-	TotalSets = len(AllEditionsKeys)
-	TotalUnique = len(mtgmatcher.GetUUIDs())
+	snap.TotalSets = len(snap.AllEditionsKeys)
+	snap.TotalUnique = len(mtgmatcher.GetUUIDs())
 	var totalCards int
-	for _, key := range AllEditionsKeys {
-		totalCards += AllEditionsMap[key].Size
+	for _, key := range snap.AllEditionsKeys {
+		totalCards += snap.AllEditionsMap[key].Size
 	}
-	TotalCards = totalCards
+	snap.TotalCards = totalCards
 
-	if other := AllEditionsByCategory["Other"]; len(other) > 0 {
+	if other := snap.AllEditionsByCategory["Other"]; len(other) > 0 {
 		log.Printf("AllEditionsByCategory: %d uncategorized sets", len(other))
 	}
+
+	editionsPtr.Store(snap)
 }

--- a/product_test.go
+++ b/product_test.go
@@ -3,26 +3,28 @@ package main
 import "testing"
 
 func TestAllEditionsByCategoryCoversAllEditions(t *testing.T) {
-	if len(AllEditionsKeys) == 0 {
+	editions := GetEditions()
+	if len(editions.AllEditionsKeys) == 0 {
 		t.Skip("mtgmatcher data not loaded; skipping")
 	}
 	categorized := 0
-	for _, entries := range AllEditionsByCategory {
+	for _, entries := range editions.AllEditionsByCategory {
 		categorized += len(entries)
 	}
-	if categorized != len(AllEditionsKeys) {
+	if categorized != len(editions.AllEditionsKeys) {
 		t.Fatalf("AllEditionsByCategory covers %d sets but AllEditionsKeys has %d",
-			categorized, len(AllEditionsKeys))
+			categorized, len(editions.AllEditionsKeys))
 	}
 }
 
 func TestAllEditionsByCategoryHasKnownCategories(t *testing.T) {
-	if len(AllEditionsByCategory) == 0 {
+	editions := GetEditions()
+	if len(editions.AllEditionsByCategory) == 0 {
 		t.Skip("mtgmatcher data not loaded; skipping")
 	}
 	wanted := []string{"Expansions", "Commander Decks", "Core Sets"}
 	for _, w := range wanted {
-		if _, ok := AllEditionsByCategory[w]; !ok {
+		if _, ok := editions.AllEditionsByCategory[w]; !ok {
 			t.Errorf("expected category %q in AllEditionsByCategory", w)
 		}
 	}

--- a/search.go
+++ b/search.go
@@ -119,10 +119,10 @@ func Search(w http.ResponseWriter, r *http.Request) {
 	pageVars.HasAvailable = len(mtgmatcher.GetSealedUUIDs()) > 0
 
 	// Populate all seller/vendor keys (for settings drawer and options page)
-	for _, seller := range Sellers {
+	for _, seller := range GetSellers() {
 		pageVars.SellerKeys = append(pageVars.SellerKeys, seller.Info().Shorthand)
 	}
-	for _, vendor := range Vendors {
+	for _, vendor := range GetVendors() {
 		pageVars.VendorKeys = append(pageVars.VendorKeys, vendor.Info().Shorthand)
 	}
 	pageVars.SellerKeys = sortKeysByScraperName(pageVars.SellerKeys)
@@ -192,44 +192,45 @@ func Search(w http.ResponseWriter, r *http.Request) {
 
 	// If query is empty there is nothing to do
 	if query == "" {
+		editions := GetEditions()
 		// Hijack sealed list
 		if pageVars.IsSealed {
 			pageVars.Title = strings.Replace(pageVars.Title, "Search", "Sealed Search", 1)
 
-			pageVars.EditionSort = SealedEditionsSorted
-			pageVars.EditionList = SealedEditionsList
+			pageVars.EditionSort = editions.SealedEditionsSorted
+			pageVars.EditionList = editions.SealedEditionsList
 			render(w, "search.html", pageVars)
 			return
 		} else if isSetsPage {
 			pageVars.Title = strings.Replace(pageVars.Title, "Search", "Editions", 1)
 
-			pageVars.TotalSets = TotalSets
-			pageVars.TotalCards = TotalCards
-			pageVars.TotalUnique = TotalUnique
+			pageVars.TotalSets = editions.TotalSets
+			pageVars.TotalCards = editions.TotalCards
+			pageVars.TotalUnique = editions.TotalUnique
 
 			sortOpt := r.FormValue("sort")
-			sortedKeys := TreeEditionsKeys
+			sortedKeys := editions.TreeEditionsKeys
 
 			if sortOpt == "name" {
-				namedSort := make([]string, len(TreeEditionsKeys))
-				copy(namedSort, TreeEditionsKeys)
+				namedSort := make([]string, len(editions.TreeEditionsKeys))
+				copy(namedSort, editions.TreeEditionsKeys)
 				sort.SliceStable(namedSort, func(i, j int) bool {
-					return strings.ToLower(TreeEditionsMap[namedSort[i]][0].Name) < strings.ToLower(TreeEditionsMap[namedSort[j]][0].Name)
+					return strings.ToLower(editions.TreeEditionsMap[namedSort[i]][0].Name) < strings.ToLower(editions.TreeEditionsMap[namedSort[j]][0].Name)
 				})
 				sortedKeys = namedSort
 			} else if sortOpt == "size" {
-				sizeSort := make([]string, len(TreeEditionsKeys))
-				copy(sizeSort, TreeEditionsKeys)
+				sizeSort := make([]string, len(editions.TreeEditionsKeys))
+				copy(sizeSort, editions.TreeEditionsKeys)
 				sort.SliceStable(sizeSort, func(i, j int) bool {
-					if TreeEditionsMap[sizeSort[i]][0].Size == TreeEditionsMap[sizeSort[j]][0].Size {
-						return strings.ToLower(TreeEditionsMap[sizeSort[i]][0].Name) < strings.ToLower(TreeEditionsMap[sizeSort[j]][0].Name)
+					if editions.TreeEditionsMap[sizeSort[i]][0].Size == editions.TreeEditionsMap[sizeSort[j]][0].Size {
+						return strings.ToLower(editions.TreeEditionsMap[sizeSort[i]][0].Name) < strings.ToLower(editions.TreeEditionsMap[sizeSort[j]][0].Name)
 					}
-					return TreeEditionsMap[sizeSort[i]][0].Size > TreeEditionsMap[sizeSort[j]][0].Size
+					return editions.TreeEditionsMap[sizeSort[i]][0].Size > editions.TreeEditionsMap[sizeSort[j]][0].Size
 				})
 				sortedKeys = sizeSort
 			}
 
-			pageVars.FlatEditions = flattenEditions(sortedKeys, TreeEditionsMap)
+			pageVars.FlatEditions = flattenEditions(sortedKeys, editions.TreeEditionsMap)
 			pageVars.SortOption = sortOpt
 
 			render(w, "sets.html", pageVars)
@@ -615,8 +616,9 @@ func Search(w http.ResponseWriter, r *http.Request) {
 
 	// CHART ALL THE THINGS
 	if chartId != "" {
-		pageVars.EditionSort = SealedEditionsSorted
-		pageVars.EditionList = SealedEditionsList
+		chartEditions := GetEditions()
+		pageVars.EditionSort = chartEditions.SealedEditionsSorted
+		pageVars.EditionList = chartEditions.SealedEditionsList
 
 		// Rebuild the search query by faking a uuid lookup
 		cfg := parseSearchOptionsNG(chartId, nil, nil, nil)
@@ -717,7 +719,7 @@ func searchSellersNG(cardIds []string, config SearchConfig) (foundSellers map[st
 	entryFilters := config.EntryFilters
 
 	// Search sellers
-	for _, seller := range Sellers {
+	for _, seller := range GetSellers() {
 		if shouldSkipStoreNG(seller, storeFilters) {
 			continue
 		}
@@ -811,7 +813,7 @@ func searchVendorsNG(cardIds []string, config SearchConfig) (foundVendors map[st
 	priceFilters := config.PriceFilters
 	entryFilters := config.EntryFilters
 
-	for _, vendor := range Vendors {
+	for _, vendor := range GetVendors() {
 		if shouldSkipStoreNG(vendor, storeFilters) {
 			continue
 		}

--- a/searchfilter.go
+++ b/searchfilter.go
@@ -157,7 +157,7 @@ func fixupStoreCodeNG(code string) []string {
 		filters[i] = strings.Trim(filters[i], "\"")
 
 		// Validate the input against the registered scrapers
-		for _, seller := range Sellers {
+		for _, seller := range GetSellers() {
 			if filters[i] != strings.ToLower(seller.Info().Name) &&
 				filters[i] != strings.ToLower(seller.Info().Shorthand) {
 				continue
@@ -165,7 +165,7 @@ func fixupStoreCodeNG(code string) []string {
 			filters[i] = strings.ToLower(seller.Info().Shorthand)
 			break
 		}
-		for _, vendor := range Vendors {
+		for _, vendor := range GetVendors() {
 			if filters[i] != strings.ToLower(vendor.Info().Name) &&
 				filters[i] != strings.ToLower(vendor.Info().Shorthand) {
 				continue
@@ -1619,13 +1619,13 @@ var FilterCardFuncs = map[string]func(filters []string, co *mtgmatcher.CardObjec
 					return false
 				}
 			case "hotlist":
-				_, found := Infos["hotlist"][co.UUID]
+				_, found := GetInfos()["hotlist"][co.UUID]
 				if found {
 					return false
 				}
 			case "newspaper":
-				if NewspaperUUIDs != nil {
-					if _, found := NewspaperUUIDs[co.UUID]; found {
+				if uuids := GetNewspaperUUIDs(); uuids != nil {
+					if _, found := uuids[co.UUID]; found {
 						return false
 					}
 				}

--- a/sleep.go
+++ b/sleep.go
@@ -59,7 +59,7 @@ func Sleepers(w http.ResponseWriter, r *http.Request) {
 	// Built before merging the user's cookie hide-list so hidden vendors still
 	// appear in the picker (rendered as pre-checked by js/settings.js bindList).
 	var modalSellerKeys, modalVendorKeys []string
-	for _, seller := range Sellers {
+	for _, seller := range GetSellers() {
 		if seller.Info().CountryFlag != "" ||
 			seller.Info().SealedMode ||
 			seller.Info().MetadataOnly ||
@@ -68,7 +68,7 @@ func Sleepers(w http.ResponseWriter, r *http.Request) {
 		}
 		modalSellerKeys = append(modalSellerKeys, seller.Info().Shorthand)
 	}
-	for _, vendor := range Vendors {
+	for _, vendor := range GetVendors() {
 		if vendor.Info().CountryFlag != "" ||
 			vendor.Info().SealedMode ||
 			vendor.Info().MetadataOnly ||
@@ -95,7 +95,7 @@ func Sleepers(w http.ResponseWriter, r *http.Request) {
 		skipEditions = strings.Split(skipEditionsOpt, ",")
 	}
 
-	for _, seller := range Sellers {
+	for _, seller := range GetSellers() {
 		if seller.Info().SealedMode ||
 			slices.Contains(blocklistRetail, seller.Info().Shorthand) {
 			continue
@@ -107,8 +107,9 @@ func Sleepers(w http.ResponseWriter, r *http.Request) {
 	cyoa, _ := strconv.ParseBool(GetParamFromSig(sig, "SleepersCYOA"))
 	pageVars.CanShowAll = cyoa || (DevMode && !SigCheck)
 
-	pageVars.EditionsCategories = AllEditionsCategoriesSorted
-	pageVars.EditionsByCategory = AllEditionsByCategory
+	editions := GetEditions()
+	pageVars.EditionsCategories = editions.AllEditionsCategoriesSorted
+	pageVars.EditionsByCategory = editions.AllEditionsByCategory
 	pageVars.PickerID = "sleep-editions-picker"
 
 	var tiers map[string]int
@@ -290,7 +291,7 @@ func getHotlist(skipEditions []string) map[string]int {
 	// Skip bad editions
 	skipEditions = append(skipEditions, "30A", "PTK", "CED", "CEI", "CMB1", "CMB2")
 
-	for cardId, hotlistEntries := range Infos["hotlist"] {
+	for cardId, hotlistEntries := range GetInfos()["hotlist"] {
 		// Make sure the older price is set, otherwise a lot of cards that were
 		// previously not being bought will show up and pollute results
 		oldPrice := hotlistEntries[0].Price
@@ -323,8 +324,9 @@ func getReprints(skipEditions []string) map[string]int {
 	tiers := map[string]int{}
 
 	// Filter results
-	for _, key := range ReprintsKeys {
-		reprints, found := ReprintsMap[key]
+	reprintsKeys, reprintsMap := GetReprints()
+	for _, key := range reprintsKeys {
+		reprints, found := reprintsMap[key]
 		if !found {
 			continue
 		}
@@ -360,8 +362,11 @@ func getReprints(skipEditions []string) map[string]int {
 func getTiers(blocklistRetail, blocklistBuylist, skipEditions []string) map[string]int {
 	tiers := map[string]int{}
 
+	sellersSnapshot := GetSellers()
+	vendorsSnapshot := GetVendors()
+
 	var tcgSeller mtgban.Seller
-	for _, seller := range Sellers {
+	for _, seller := range sellersSnapshot {
 		if seller != nil && seller.Info().Shorthand == "TCGLow" {
 			tcgSeller = seller
 			break
@@ -378,7 +383,7 @@ func getTiers(blocklistRetail, blocklistBuylist, skipEditions []string) map[stri
 		CustomCardFilter: noOversize,
 	}
 
-	for _, seller := range Sellers {
+	for _, seller := range sellersSnapshot {
 		if seller.Info().MetadataOnly {
 			continue
 		}
@@ -394,7 +399,7 @@ func getTiers(blocklistRetail, blocklistBuylist, skipEditions []string) map[stri
 			continue
 		}
 
-		for _, vendor := range Vendors {
+		for _, vendor := range vendorsSnapshot {
 			if vendor.Info().Shorthand == seller.Info().Shorthand {
 				continue
 			}
@@ -435,7 +440,7 @@ func getGap(blocklistRetail []string, ref, target string, skipEditions []string)
 
 	var referenceSeller mtgban.Seller
 	var targetSeller mtgban.Seller
-	for _, seller := range Sellers {
+	for _, seller := range GetSellers() {
 		if seller.Info().SealedMode ||
 			slices.Contains(blocklistRetail, seller.Info().Shorthand) {
 			continue

--- a/upload.go
+++ b/upload.go
@@ -289,12 +289,12 @@ func Upload(w http.ResponseWriter, r *http.Request) {
 	var allVendors []string
 
 	// Load all possible sellers, and vendors according to user permissions
-	for _, seller := range Sellers {
+	for _, seller := range GetSellers() {
 		if seller != nil && !slices.Contains(blocklistRetail, seller.Info().Shorthand) && !seller.Info().SealedMode && !seller.Info().MetadataOnly {
 			allSellers = append(allSellers, seller.Info().Shorthand)
 		}
 	}
-	for _, vendor := range Vendors {
+	for _, vendor := range GetVendors() {
 		if vendor != nil && !slices.Contains(blocklistBuylist, vendor.Info().Shorthand) && !vendor.Info().SealedMode {
 			allVendors = append(allVendors, vendor.Info().Shorthand)
 		}
@@ -908,8 +908,9 @@ func Upload(w http.ResponseWriter, r *http.Request) {
 		pageVars.Optimized = optimizedResults
 		pageVars.OptimizedTotals = optimizedTotals
 		pageVars.HighestTotal = highestTotal
-		pageVars.Editions = AllEditionsKeys
-		pageVars.EditionsMap = AllEditionsMap
+		uploadEditions := GetEditions()
+		pageVars.Editions = uploadEditions.AllEditionsKeys
+		pageVars.EditionsMap = uploadEditions.AllEditionsMap
 	}
 
 	// Logs

--- a/utils.go
+++ b/utils.go
@@ -218,7 +218,7 @@ const (
 
 // Return the CreditMultiplier for any given vendor
 func findCredit(shorthand string) float64 {
-	for _, vendor := range Vendors {
+	for _, vendor := range GetVendors() {
 		if strings.EqualFold(vendor.Info().Shorthand, shorthand) {
 			return vendor.Info().CreditMultiplier
 		}
@@ -228,7 +228,7 @@ func findCredit(shorthand string) float64 {
 
 // Look up a seller and return its inventory
 func findSellerInventory(shorthand string) (mtgban.InventoryRecord, error) {
-	for _, seller := range Sellers {
+	for _, seller := range GetSellers() {
 		if strings.EqualFold(seller.Info().Shorthand, shorthand) {
 			return seller.Inventory(), nil
 		}
@@ -238,7 +238,7 @@ func findSellerInventory(shorthand string) (mtgban.InventoryRecord, error) {
 
 // Look up a vendor and return its buylist
 func findVendorBuylist(shorthand string) (mtgban.BuylistRecord, error) {
-	for _, vendor := range Vendors {
+	for _, vendor := range GetVendors() {
 		if strings.EqualFold(vendor.Info().Shorthand, shorthand) {
 			return vendor.Buylist(), nil
 		}
@@ -248,7 +248,7 @@ func findVendorBuylist(shorthand string) (mtgban.BuylistRecord, error) {
 
 // Look up a seller with its name and return its inventory
 func findSellerInventoryByName(name string, sealed bool) (mtgban.InventoryRecord, error) {
-	for _, seller := range Sellers {
+	for _, seller := range GetSellers() {
 		if seller.Info().SealedMode == sealed && strings.EqualFold(seller.Info().Name, name) {
 			return seller.Inventory(), nil
 		}
@@ -258,7 +258,7 @@ func findSellerInventoryByName(name string, sealed bool) (mtgban.InventoryRecord
 
 // Look up a vendor with its name and return its inventory
 func findVendorBuylistByName(name string, sealed bool) (mtgban.BuylistRecord, error) {
-	for _, vendor := range Vendors {
+	for _, vendor := range GetVendors() {
 		if vendor.Info().SealedMode == sealed && strings.EqualFold(vendor.Info().Name, name) {
 			return vendor.Buylist(), nil
 		}
@@ -358,8 +358,8 @@ func uuid2card(cardId string, useThumbs, genPrints, preferFlavorName bool) Gener
 	}
 
 	var newspaper bool
-	if NewspaperUUIDs != nil {
-		_, newspaper = NewspaperUUIDs[cardId]
+	if uuids := GetNewspaperUUIDs(); uuids != nil {
+		_, newspaper = uuids[cardId]
 	}
 
 	variant := ""
@@ -537,7 +537,7 @@ func uuid2card(cardId string, useThumbs, genPrints, preferFlavorName bool) Gener
 	}
 
 	var hotlistStore string
-	_, found = Infos["hotlist"][cardId]
+	_, found = GetInfos()["hotlist"][cardId]
 	if found {
 		hotlistStore = "CK"
 	}
@@ -636,8 +636,9 @@ func genSealedPrintings(co *mtgmatcher.CardObject) string {
 	// The first chunk is always present, even for foil-only sets
 	b.WriteString("<h6>Set Value</h6><table class='setValue'>")
 
+	infos := GetInfos()
 	for i, title := range ProductTitles {
-		entries, found := Infos[ProductKeys[i]][co.SetCode]
+		entries, found := infos[ProductKeys[i]][co.SetCode]
 		if found {
 			fmt.Fprintf(&b, "<tr class='setValue'><td class='setValue'><h5>%s</h5></td><td>$ %.02f</td></tr>", title, entries[0].Price)
 		}
@@ -645,12 +646,12 @@ func genSealedPrintings(co *mtgmatcher.CardObject) string {
 	b.WriteString("</table>")
 
 	// The second chunk is optional, check for the first key
-	if len(Infos[ProductFoilKeys[0]][co.SetCode]) > 0 {
+	if len(infos[ProductFoilKeys[0]][co.SetCode]) > 0 {
 		b.WriteString("<br>")
 		b.WriteString("<h6>Foil Set Value</h6><table class='setValue'>")
 
 		for i, title := range ProductTitles {
-			entries, found := Infos[ProductFoilKeys[i]][co.SetCode]
+			entries, found := infos[ProductFoilKeys[i]][co.SetCode]
 			if found {
 				fmt.Fprintf(&b, "<tr class='setValue'><td class='setValue'><h5>%s</h5></td><td>$ %.02f</td></tr>", title, entries[0].Price)
 			}
@@ -903,12 +904,12 @@ func getTCGSimulationIQR(productId string) float64 {
 
 // Return the full display name displayed from the input shorthand
 func scraperName(shorthand string) string {
-	for _, seller := range Sellers {
+	for _, seller := range GetSellers() {
 		if shorthand == seller.Info().Shorthand {
 			return seller.Info().Name
 		}
 	}
-	for _, vendor := range Vendors {
+	for _, vendor := range GetVendors() {
 		if shorthand == vendor.Info().Shorthand {
 			return vendor.Info().Name
 		}


### PR DESCRIPTION
Symptom: server crashed every day or so with span free-list assertion failures, often preceded by template parser errors complaining of U+0000 or unexpected EOF — damage that had clearly happened minutes earlier in unrelated code paths.

Root cause was in-place mutation of package-level globals while HTTP handlers read them concurrently. The smoking gun was slices.SortFunc on the Sellers / Vendors interface slices in load.go: each interface slot is a 16-byte (typePtr, dataPtr) pair, and an in-place swap during sort lets a reader observe a torn interface — typePtr from one slot, dataPtr from another. Calling a method on that torn value dispatches against a bogus data pointer, and the next GC traces through it, seeding heap corruption that surfaces tens of minutes later.

Fix shape (applied consistently across every shared global that's mutated post-init):

  - Sellers, Vendors (load.go): atomic.Pointer[[]mtgban.Seller] / atomic.Pointer[[]mtgban.Vendor]. Writers hold scrapersWriteMu, build a fresh slice via buildNextSellers / buildNextVendors (copy-on-write), and publish in a single Store. The in-place SortFunc is now on the private copy, never the shared snapshot. Readers go through GetSellers / GetVendors — ~100 reader sites swept across admin, api, api_banprice, api_prices, arbit, auth, chart, discord, main, palette, search, searchfilter, sleep, upload, utils.

  - Infos (product.go): atomic.Pointer[map[string]mtgban.InventoryRecord]. runSealedAnalysis builds the map locally and publishes via a single Store. Accessor: GetInfos.

  - ReprintsKeys + ReprintsMap (product.go): bundled into a reprintsSnapshot struct under one atomic.Pointer so readers can never observe new keys against a stale map (or vice versa). Accessor: GetReprints returns both.

  - StashingInProgress (chart.go): atomic.Bool. The actual gate is now a CompareAndSwap(false, true) at the top of stashInTimeseries with defer Store(false), fixing the previous TOCTOU window where the cron and admin button could both spawn a stash goroutine. Accessor: IsStashingInProgress.

  - NewspaperPages (news.go): atomic.Pointer[[]NewspaperPage]. The static literal lives in newspaperPagesInitial and is seeded into the pointer at init. cacheNewspaper now copies the current snapshot, mutates the copy's per-element Results / AvailableEditions / PossibleFinish (and the 3Day trio), then publishes via a single Store. The half-stale check now reads from the working copy. Accessor: GetNewspaperPages.

  - NewspaperUUIDs (news.go): atomic.Pointer[map[string]struct{}]. Published alongside NewspaperPages by cacheNewspaper. Accessor: GetNewspaperUUIDs.

  - EditionsSnapshot (product.go): bundles the 12 globals that updateStaticData used to publish via 12 separate non-atomic stores (SealedEditionsSorted/List, the 5 AllEditions* vars, the 2 TreeEditions* vars, TotalSets/Cards/Unique). updateStaticData now builds the snapshot locally and publishes once. An empty snapshot is seeded at init so reads before the first update don't panic on nil-map lookups. Accessor: GetEditions returns *EditionsSnapshot; reader sites hoist the snapshot into a local so the whole computation sees a consistent view.

  - LastDatastoreUpdate / LastStashUpdate / LastNewspaperUpdate (main.go): atomic.Pointer[time.Time], 24-byte time.Time struct reads were torn-able. Writers use Set*; readers use Get*. Display only, but the race detector now stays quiet on these.

Convention for new code: never mutate the slice / map returned by an accessor; never split-publish two related globals; new writers must build the complete replacement value locally and publish via a single Store (or CompareAndSwap for the bool gate).

go build ./... and go build -race ./... are both clean.

Remaining audit item not addressed in this commit: Config struct whole-replacement at admin.go:319 races with the tens of handlers that read Config.* fields. Window is admin-save-only and the realistic blast radius is small, so deferred to a separate change.