### PR TITLE
fix: make joblog passthrough non-blocking to stop process-wide log wedge

### DIFF
--- a/joblog/capture_unix.go
+++ b/joblog/capture_unix.go
@@ -4,16 +4,29 @@ package joblog
 
 import (
 	"bufio"
+	"fmt"
 	"os"
+	"sync/atomic"
 	"syscall"
 	"time"
 )
 
+// passthroughBufferLines is the queue depth in front of each platform-side
+// stdout/stderr fd. Sized to absorb several seconds of normal logging without
+// drops; if the platform's log collector stalls longer than that, lines are
+// dropped rather than blocking.
+const passthroughBufferLines = 4096
+
+// passthroughDropReportInterval bounds how often the drainer summarises
+// dropped lines into log_lines. Kept on the long side because the report
+// itself is only interesting if drops are sustained.
+const passthroughDropReportInterval = 30 * time.Second
+
 // StartCapture redirects this process's stdout (fd 1) and stderr (fd 2) onto
 // pipes whose read end we drain into the DB log sink. The original
 // descriptors are dup'd first so the captured bytes still reach the original
-// destination (terminal / systemd journal / log file) — capture is a tee,
-// not a hijack.
+// destination (terminal / systemd journal / managed-platform log collector) —
+// capture is a tee, not a hijack.
 //
 // Returns true if capture was wired up, false if any syscall failed; the
 // caller logs failure but does not abort startup. Safe to call only once
@@ -58,16 +71,20 @@ func (r *Runner) StartCapture() bool {
 	_ = errW.Close()
 
 	r.startSinkOnce()
-	go r.drainPipe(outR, "stdout", r.originalStdout)
-	go r.drainPipe(errR, "stderr", r.originalStderr)
+
+	outPass := newPassthroughWriter(r, r.originalStdout, "stdout", passthroughBufferLines)
+	errPass := newPassthroughWriter(r, r.originalStderr, "stderr", passthroughBufferLines)
+
+	go r.drainPipe(outR, "stdout", outPass)
+	go r.drainPipe(errR, "stderr", errPass)
 	return true
 }
 
-// drainPipe reads lines from rd, tees each line back to the local
-// passthrough (so the operator still sees stdout/stderr) and submits it to
-// the DB sink. Lines longer than the scanner buffer are split — better
-// truncation than loss.
-func (r *Runner) drainPipe(rd *os.File, source string, passthrough *os.File) {
+// drainPipe reads lines from rd, tees each line to the passthrough (which
+// queues the write non-blockingly) and submits the line to the DB sink.
+// Lines longer than the scanner buffer are split — better truncation than
+// loss.
+func (r *Runner) drainPipe(rd *os.File, source string, passthrough *passthroughWriter) {
 	scanner := bufio.NewScanner(rd)
 	// Bump the max token size so goroutine dumps and other large outputs
 	// don't trip the default 64KB cap.
@@ -75,14 +92,92 @@ func (r *Runner) drainPipe(rd *os.File, source string, passthrough *os.File) {
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		// Tee to the original destination first so local logs/terminal
-		// keep working even if the DB sink is full.
-		_, _ = passthrough.Write([]byte(line + "\n"))
+		passthrough.write(line)
 		r.sink.submit(LogLine{
 			Timestamp: time.Now(),
 			Host:      r.host,
 			Source:    source,
 			Message:   line,
 		})
+	}
+}
+
+// passthroughWriter is the non-blocking front of the platform-side
+// stdout/stderr fd. Write attempts a non-blocking enqueue and drops on a full
+// channel; a dedicated drainer goroutine performs the (potentially blocking)
+// write to dst.
+//
+// Why drop instead of block: dst is whatever the platform attached to fd 1/2
+// before we dup2'd ourselves in (a terminal, journald, a managed-platform log
+// collector). If dst stalls — common on managed platforms when their
+// collector backpressures — a synchronous write here would block the pipe
+// drainer, fill the kernel pipe behind fd 1/2, and wedge every goroutine in
+// the process that calls log.Print. Dropping lines is the cheap cost we pay
+// to keep the rest of the process moving; the same lines still reach the DB
+// sink, which is the durable record.
+type passthroughWriter struct {
+	dst     *os.File
+	ch      chan []byte
+	dropped atomic.Int64
+	name    string
+	owner   *Runner
+}
+
+// newPassthroughWriter constructs a writer and starts its drainer. The
+// drainer is process-lifetime; there is no Close.
+func newPassthroughWriter(owner *Runner, dst *os.File, name string, capacity int) *passthroughWriter {
+	p := &passthroughWriter{
+		dst:   dst,
+		ch:    make(chan []byte, capacity),
+		name:  name,
+		owner: owner,
+	}
+	go p.drain()
+	return p
+}
+
+// write queues a line (the trailing newline is added here) for the drainer.
+// Non-blocking: on a full queue the line is dropped and counted.
+func (p *passthroughWriter) write(line string) {
+	if p == nil {
+		return
+	}
+	buf := make([]byte, len(line)+1)
+	copy(buf, line)
+	buf[len(line)] = '\n'
+	select {
+	case p.ch <- buf:
+	default:
+		p.dropped.Add(1)
+	}
+}
+
+// drain runs forever. The Write to dst can block indefinitely if the
+// platform's collector is wedged; that's fine — only this goroutine pays the
+// price, the channel fills up, and write() drops new lines. When dst
+// recovers the write completes and we resume.
+//
+// Drop counts are reported to the DB sink (not back to dst, which would
+// recurse into the same wedge) so operators can see when platform-side logs
+// are missing data.
+func (p *passthroughWriter) drain() {
+	ticker := time.NewTicker(passthroughDropReportInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case buf := <-p.ch:
+			_, _ = p.dst.Write(buf)
+		case <-ticker.C:
+			if n := p.dropped.Swap(0); n > 0 && p.owner != nil {
+				p.owner.sink.submit(LogLine{
+					Timestamp: time.Now(),
+					Host:      p.owner.host,
+					Source:    "joblog",
+					Message: fmt.Sprintf(
+						"passthrough dropped %d %s lines under platform-side backpressure",
+						n, p.name),
+				})
+			}
+		}
 	}
 }


### PR DESCRIPTION
Symptom: beta box wedged solid mid-run with no panic, no restart, no diagnostic trail. Process PID 1 alive (state S), zero forward progress (/proc/1/io byte-identical over 30s), HTTP listener still accepted connections but every handler hung instantly, all 3 Postgres connections idle. Recovery required a container restart.

Root cause was in drainPipe (joblog/capture_unix.go): it wrote each captured line to the dup'd original stdout/stderr fd via a synchronous passthrough.Write. On DO App Platform that fd points at the platform's log collector pipe. When the collector backpressured, the write blocked, drainPipe stopped reading the kernel pipe behind fd 1/2, the pipe buffer filled, and every goroutine that subsequently called log.Println parked in write(2) — loadScrapersNG, the heartbeat ticker, all HTTP handlers. The earlier comment "tee to passthrough first so local logs keep working even if the DB sink is full" had the failure modes backwards: the DB sink was already non-blocking, the passthrough was the unprotected blocking call.

Fix: introduce passthroughWriter — a bounded channel (4096 lines) in front of each platform fd, drained by a dedicated goroutine that does the (potentially blocking) write. write() is non-blocking; on a full queue lines are dropped and counted. Drop counts are reported every 30s into log_lines via the DB sink, never back to the platform fd (which would recurse into the same wedge if still active). If the platform collector stalls, only the drainer goroutine parks; the rest of the process keeps moving and lines reach Postgres unaffected.