### PR TITLE
Feat/sealed uploader

### DIFF
--- a/css/upload.css
+++ b/css/upload.css
@@ -124,6 +124,53 @@
     color: var(--text-dim);
 }
 
+/* ── Singles / Sealed Tabs ── */
+.upload-tabs {
+    display: flex;
+    gap: 0.25em;
+    border-bottom: 1px solid var(--border-subtle);
+    margin-bottom: 1em;
+}
+
+.upload-tab {
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+    padding: 0.6em 1.2em;
+    font-size: var(--text-md);
+    font-weight: 500;
+    color: var(--text-dim);
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s;
+}
+
+.upload-tab:hover {
+    color: var(--activetext);
+}
+
+.upload-tab.active {
+    color: var(--activetext);
+    border-bottom-color: var(--dodgerblue);
+    font-weight: 600;
+}
+
+.upload-store-area {
+    flex: 1;
+    min-width: 0;
+}
+
+.upload-store-hidden {
+    display: none;
+}
+
+.upload-sealed-note {
+    display: block;
+    font-size: var(--text-base);
+    color: var(--text-dim);
+    margin-top: 0.6em;
+}
+
 /* ── Store Selector Grid ── */
 .upload-store-grid {
     display: grid;

--- a/css/upload.css
+++ b/css/upload.css
@@ -161,7 +161,7 @@
 }
 
 .upload-store-hidden {
-    display: none;
+    display: none !important;
 }
 
 .upload-sealed-note {

--- a/main.go
+++ b/main.go
@@ -187,26 +187,30 @@ type PageVars struct {
 	SealedIndexKeys   []string
 
 	// Additional sources for index keys if needed
-	AltKeys         []string
-	SellerKeys      []string
-	VendorKeys      []string
-	ModalSellerKeys []string
-	ModalVendorKeys []string
-	UploadEntries   []UploadEntry
-	IsBuylist       bool
-	TotalEntries    map[string]float64
-	EnabledSellers  []string
-	EnabledVendors  []string
-	CanBuylist      bool
-	CanChangeStores bool
-	RemoteLinkURL   string
-	TotalQuantity   int
-	Optimized       map[string][]OptimizedUploadEntry
-	OptimizedTotals map[string]float64
-	HighestTotal    float64
-	MissingCounts   map[string]int
-	MissingPrices   map[string]float64
-	ResultPrices    map[string]map[string]float64
+	AltKeys              []string
+	SellerKeys           []string
+	VendorKeys           []string
+	SealedSellerKeys     []string
+	SealedVendorKeys     []string
+	ModalSellerKeys      []string
+	ModalVendorKeys      []string
+	UploadEntries        []UploadEntry
+	IsBuylist            bool
+	TotalEntries         map[string]float64
+	EnabledSellers       []string
+	EnabledVendors       []string
+	EnabledSealedSellers []string
+	EnabledSealedVendors []string
+	CanBuylist           bool
+	CanChangeStores      bool
+	RemoteLinkURL        string
+	TotalQuantity        int
+	Optimized            map[string][]OptimizedUploadEntry
+	OptimizedTotals      map[string]float64
+	HighestTotal         float64
+	MissingCounts        map[string]int
+	MissingPrices        map[string]float64
+	ResultPrices         map[string]map[string]float64
 }
 
 type NavElem struct {

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -34,6 +34,10 @@
                         <h2>Select Mode &amp; Stores</h2>
                     </div>
 
+                    <div class="upload-tabs" id="uploadTabs">
+                        <button type="button" class="upload-tab active" id="tab-singles" onclick="selectTab('singles')">Singles</button>
+                        <button type="button" class="upload-tab" id="tab-sealed" onclick="selectTab('sealed')">Sealed</button>
+                    </div>
                     <div class="upload-mode-stores-row">
                         <div class="upload-mode-col">
                             <div class="upload-mode-toggle">
@@ -52,7 +56,10 @@
                                 <span class="upload-mode-hint">Buylist access requires Legacy tier</span>
                             {{end}}
                         </div>
-                        <div class="upload-store-grid" id="storesBox">
+                        <div class="upload-store-area">
+                            <div class="upload-store-grid" id="singlesBox"></div>
+                            <div class="upload-store-grid upload-store-hidden" id="sealedBox"></div>
+                            <span class="upload-sealed-note upload-store-hidden" id="sealedNote">Sealed products in your upload are priced with these stores.</span>
                         </div>
                     </div>
                     {{if not .CanChangeStores}}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -316,43 +316,69 @@
 
             window.reloadSelect = function(mode) {
                 localStorage.setItem("uploadMode", mode);
-                var selectBox = document.getElementById('storesBox');
-                if (selectBox) {
-                    const fields = [
-                        'submit_download', 'submit_estimate', 'submit_deckbox', 'submit_tcgplayer_csv'
-                    ];
+                const fields = [
+                    'submit_download', 'submit_estimate', 'submit_deckbox', 'submit_tcgplayer_csv'
+                ];
+                var singlesBox = document.getElementById('singlesBox');
+                if (singlesBox) {
                     if (mode == "buylist") {
-                        selectBox.innerHTML = " \
+                        singlesBox.innerHTML = " \
                             {{range .VendorKeys}} \
                                 <label class='upload-store-item'> \
                                     <input type='checkbox' name='stores' id='{{.}}' value='{{.}}' {{if slice_has $.EnabledVendors .}}checked{{end}} {{if not $.CanChangeStores}}disabled{{end}}> {{scraper_name .}} \
                                 </label> \
                             {{end}} \
                         ";
-
-                        fields.forEach(element => {
-                            var btn = document.getElementById(element);
-                            if (btn) {
-                                btn.style.display = "inline"
-                            }
-                        })
-                    } else if (mode == "retail") {
-                        selectBox.innerHTML = " \
+                    } else {
+                        singlesBox.innerHTML = " \
                             {{range .SellerKeys}} \
                                 <label class='upload-store-item'> \
                                     <input type='checkbox' name='stores' id='{{.}}' value='{{.}}' {{if slice_has $.EnabledSellers .}}checked{{end}} {{if not $.CanChangeStores}}disabled{{end}}> {{scraper_name .}} \
                                 </label> \
                             {{end}} \
                         ";
-
-                        fields.forEach(element => {
-                            var btn = document.getElementById(element);
-                            if (btn) {
-                                btn.style.display = "inline"
-                            }
-                        })
+                    }
+                    fields.forEach(element => {
+                        var btn = document.getElementById(element);
+                        if (btn) { btn.style.display = "inline"; }
+                    });
+                }
+                var sealedBox = document.getElementById('sealedBox');
+                if (sealedBox) {
+                    if (mode == "buylist") {
+                        sealedBox.innerHTML = " \
+                            {{range .SealedVendorKeys}} \
+                                <label class='upload-store-item'> \
+                                    <input type='checkbox' name='sealed_stores' id='sealed-{{.}}' value='{{.}}' {{if slice_has $.EnabledSealedVendors .}}checked{{end}} {{if not $.CanChangeStores}}disabled{{end}}> {{scraper_name .}} \
+                                </label> \
+                            {{end}} \
+                        ";
+                    } else {
+                        sealedBox.innerHTML = " \
+                            {{range .SealedSellerKeys}} \
+                                <label class='upload-store-item'> \
+                                    <input type='checkbox' name='sealed_stores' id='sealed-{{.}}' value='{{.}}' {{if slice_has $.EnabledSealedSellers .}}checked{{end}} {{if not $.CanChangeStores}}disabled{{end}}> {{scraper_name .}} \
+                                </label> \
+                            {{end}} \
+                        ";
+                    }
+                    if (!sealedBox.querySelector('input')) {
+                        sealedBox.innerHTML = "<span class='upload-mode-hint'>No sealed stores available for this mode.</span>";
                     }
                 }
+            };
+
+            window.selectTab = function(tab) {
+                var isSealed = (tab === 'sealed');
+                document.getElementById('tab-singles').classList.toggle('active', !isSealed);
+                document.getElementById('tab-sealed').classList.toggle('active', isSealed);
+                var singlesBox = document.getElementById('singlesBox');
+                var sealedBox = document.getElementById('sealedBox');
+                var sealedNote = document.getElementById('sealedNote');
+                if (singlesBox) singlesBox.classList.toggle('upload-store-hidden', isSealed);
+                if (sealedBox) sealedBox.classList.toggle('upload-store-hidden', !isSealed);
+                if (sealedNote) sealedNote.classList.toggle('upload-store-hidden', !isSealed);
+                try { localStorage.setItem('uploadTab', tab); } catch(e) {}
             };
 
             (function() {
@@ -432,6 +458,8 @@
                 }
                 reloadSelect(savedMode);
 
+                var savedTab = localStorage.getItem("uploadTab");
+                selectTab(savedTab === "sealed" ? "sealed" : "singles");
 
                 var gdocInput = document.getElementById('gdocURL');
                 if (gdocInput) {

--- a/upload.go
+++ b/upload.go
@@ -671,14 +671,15 @@ func Upload(w http.ResponseWriter, r *http.Request) {
 	// Search — fetch card and sealed prices separately then merge
 	var results map[string]map[string]*BanPrice
 	var credits map[string]float64
-	enabledSealedStores := sealedSellers
+	sealedStores := r.Form["sealed_stores"]
+	enabledSealedStores := filterEnabledStores(sealedStores, sealedSellers, canChangeStores)
 	if blMode {
 		results = getVendorPrices("", enabledStores, "", cardIds, "", false, shouldCheckForConditions, false, tagPref)
-		enabledSealedStores = sealedVendors
+		enabledSealedStores = filterEnabledStores(sealedStores, sealedVendors, canChangeStores)
 
 		// Fetch sealed vendor prices and merge
-		if len(sealedProductIds) > 0 && len(sealedVendors) > 0 {
-			sealedResults := getVendorPrices("", sealedVendors, "", sealedProductIds, "", false, false, true, tagPref)
+		if len(sealedProductIds) > 0 && len(enabledSealedStores) > 0 {
+			sealedResults := getVendorPrices("", enabledSealedStores, "", sealedProductIds, "", false, false, true, tagPref)
 			for cardId, stores := range sealedResults {
 				if results[cardId] == nil {
 					results[cardId] = map[string]*BanPrice{}
@@ -700,8 +701,8 @@ func Upload(w http.ResponseWriter, r *http.Request) {
 		results = getSellerPrices("", enabledStores, "", cardIds, "", false, shouldCheckForConditions, false, tagPref)
 
 		// Fetch sealed seller prices and merge
-		if len(sealedProductIds) > 0 && len(sealedSellers) > 0 {
-			sealedResults := getSellerPrices("", sealedSellers, "", sealedProductIds, "", false, false, true, tagPref)
+		if len(sealedProductIds) > 0 && len(enabledSealedStores) > 0 {
+			sealedResults := getSellerPrices("", enabledSealedStores, "", sealedProductIds, "", false, false, true, tagPref)
 			for cardId, stores := range sealedResults {
 				if results[cardId] == nil {
 					results[cardId] = map[string]*BanPrice{}
@@ -711,6 +712,15 @@ func Upload(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
+	}
+
+	// Save user preferred sealed stores in cookies, mirroring singles above
+	if blMode {
+		setForeverCookie(w, "enabledSealedVendors", strings.Join(enabledSealedStores, "|"))
+		pageVars.EnabledSealedVendors = enabledSealedStores
+	} else {
+		setForeverCookie(w, "enabledSealedSellers", strings.Join(enabledSealedStores, "|"))
+		pageVars.EnabledSealedSellers = enabledSealedStores
 	}
 
 	// Allow downloading data as CSV

--- a/upload.go
+++ b/upload.go
@@ -673,9 +673,15 @@ func Upload(w http.ResponseWriter, r *http.Request) {
 	var credits map[string]float64
 	sealedStores := r.Form["sealed_stores"]
 	enabledSealedStores := filterEnabledStores(sealedStores, sealedSellers, canChangeStores)
+	if len(sealedStores) == 0 && canChangeStores {
+		enabledSealedStores = pageVars.EnabledSealedSellers
+	}
 	if blMode {
 		results = getVendorPrices("", enabledStores, "", cardIds, "", false, shouldCheckForConditions, false, tagPref)
 		enabledSealedStores = filterEnabledStores(sealedStores, sealedVendors, canChangeStores)
+		if len(sealedStores) == 0 && canChangeStores {
+			enabledSealedStores = pageVars.EnabledSealedVendors
+		}
 
 		// Fetch sealed vendor prices and merge
 		if len(sealedProductIds) > 0 && len(enabledSealedStores) > 0 {

--- a/upload.go
+++ b/upload.go
@@ -344,6 +344,8 @@ func Upload(w http.ResponseWriter, r *http.Request) {
 	// Set the store names for the <select> box
 	pageVars.SellerKeys = allSellers
 	pageVars.VendorKeys = allVendors
+	pageVars.SealedSellerKeys = sealedSellers
+	pageVars.SealedVendorKeys = sealedVendors
 	pageVars.AltKeys = UploadIndexComparePriceList
 
 	// Load the preferred list of enabled stores for the <select> box
@@ -361,6 +363,20 @@ func Upload(w http.ResponseWriter, r *http.Request) {
 		pageVars.EnabledVendors = allVendors
 	} else {
 		pageVars.EnabledVendors = strings.Split(enabledVendors, "|")
+	}
+
+	enabledSealedSellers := readCookie(r, "enabledSealedSellers")
+	if len(enabledSealedSellers) == 0 || !canChangeStores {
+		pageVars.EnabledSealedSellers = sealedSellers
+	} else {
+		pageVars.EnabledSealedSellers = strings.Split(enabledSealedSellers, "|")
+	}
+
+	enabledSealedVendors := readCookie(r, "enabledSealedVendors")
+	if len(enabledSealedVendors) == 0 || !canChangeStores {
+		pageVars.EnabledSealedVendors = sealedVendors
+	} else {
+		pageVars.EnabledSealedVendors = strings.Split(enabledSealedVendors, "|")
 	}
 
 	cachedGdocURL := readCookie(r, "gdocURL")

--- a/upload.go
+++ b/upload.go
@@ -137,6 +137,24 @@ type OptimizedUploadEntry struct {
 	Profitability float64
 }
 
+// filterEnabledStores intersects submitted stores with the allowed list.
+// A locked user, or a submission that resolves to nothing, gets the full list.
+func filterEnabledStores(submitted, allowed []string, canChange bool) []string {
+	if !canChange {
+		return allowed
+	}
+	var out []string
+	for _, store := range submitted {
+		if slices.Contains(allowed, store) {
+			out = append(out, store)
+		}
+	}
+	if len(out) == 0 {
+		return allowed
+	}
+	return out
+}
+
 func Upload(w http.ResponseWriter, r *http.Request) {
 	sig := getSignatureFromCookies(r)
 

--- a/upload_test.go
+++ b/upload_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFilterEnabledStores(t *testing.T) {
+	allowed := []string{"a", "b", "c"}
+
+	tests := []struct {
+		name      string
+		submitted []string
+		canChange bool
+		want      []string
+	}{
+		{"locked returns all", []string{"a"}, false, allowed},
+		{"empty submit falls back to all", nil, true, allowed},
+		{"filters to valid subset", []string{"a", "c", "x"}, true, []string{"a", "c"}},
+		{"all invalid falls back to all", []string{"x", "y"}, true, allowed},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filterEnabledStores(tc.submitted, allowed, tc.canChange)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("filterEnabledStores(%v, %v, %v) = %v, want %v",
+					tc.submitted, allowed, tc.canChange, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The uploader's "Select Mode & Stores" card is now a Singles/Sealed tabbed control. Sealed stores are selectable (editable grid, tier-gated like singles), the selection is honored in the backend fetch and persisted via forever-cookie, and the sealed path is now visible in the UI.

<img width="1769" height="497" alt="image" src="https://github.com/user-attachments/assets/4257da35-c162-49a0-9baf-51f9bb2d5d75" />


closes #206 