### PR TITLE
fix: newspaper queries fall back to latest available calc_date per game

### DIFF
--- a/news.go
+++ b/news.go
@@ -195,7 +195,7 @@ func cacheNewspaper() {
 			continue
 		}
 
-		query := NewspaperPages[i].Query + " AND game_name = '" + game + "' ORDER BY ranking ASC;"
+		query := strings.ReplaceAll(NewspaperPages[i].Query, "__GAME__", game) + " ORDER BY ranking ASC;"
 
 		results, err := getResults(NewNewspaperDB, query)
 		if err != nil {
@@ -285,8 +285,13 @@ var NewspaperPages = []NewspaperPage{
                        bucket_name, bucket_rank,
                        ck_retail_price, tcg_market_price, ck_buy_price
                   FROM scripts__tcgplayersalesdata_plus_cardkingdom_spike_score_cards
-                 WHERE calc_date = (SELECT MAX(calc_date) - INTERVAL '0 DAY'
-                                      FROM scripts__tcgplayersalesdata_plus_cardkingdom_spike_score_cards)`,
+                 WHERE game_name = '__GAME__'
+                   AND calc_date = (SELECT MAX(calc_date)
+                                      FROM scripts__tcgplayersalesdata_plus_cardkingdom_spike_score_cards
+                                     WHERE game_name = '__GAME__'
+                                       AND calc_date <= (SELECT MAX(calc_date)
+                                                           FROM scripts__tcgplayersalesdata_plus_cardkingdom_spike_score_cards
+                                                          WHERE game_name = '__GAME__') - INTERVAL '0 DAY')`,
 		Sort: "ranking ASC",
 		Head: []Heading{
 			{
@@ -364,8 +369,13 @@ var NewspaperPages = []NewspaperPage{
                        bucket_name, bucket_rank,
                        current_price
                   FROM scripts__tcgplayersalesdata_spike_score_cards
-                 WHERE calc_date = (SELECT MAX(calc_date) - INTERVAL '0 DAY'
-                                      FROM scripts__tcgplayersalesdata_spike_score_cards)`,
+                 WHERE game_name = '__GAME__'
+                   AND calc_date = (SELECT MAX(calc_date)
+                                      FROM scripts__tcgplayersalesdata_spike_score_cards
+                                     WHERE game_name = '__GAME__'
+                                       AND calc_date <= (SELECT MAX(calc_date)
+                                                           FROM scripts__tcgplayersalesdata_spike_score_cards
+                                                          WHERE game_name = '__GAME__') - INTERVAL '0 DAY')`,
 		Sort: "ranking ASC",
 		Head: []Heading{
 			{
@@ -429,8 +439,13 @@ var NewspaperPages = []NewspaperPage{
                        product_name, set_name, product_number, variant,
                        sellers_Today, sellers_d7, sellers_d30, pct_drop_7d
                   FROM scripts__tcgplayer_greatest_decrease_in_vendor_listings_cards
-                 WHERE calc_date = (SELECT MAX(calc_date) - INTERVAL '0 DAY'
-                                      FROM scripts__tcgplayer_greatest_decrease_in_vendor_listings_cards)
+                 WHERE game_name = '__GAME__'
+                   AND calc_date = (SELECT MAX(calc_date)
+                                      FROM scripts__tcgplayer_greatest_decrease_in_vendor_listings_cards
+                                     WHERE game_name = '__GAME__'
+                                       AND calc_date <= (SELECT MAX(calc_date)
+                                                           FROM scripts__tcgplayer_greatest_decrease_in_vendor_listings_cards
+                                                          WHERE game_name = '__GAME__') - INTERVAL '0 DAY')
                    AND pct_drop_7d <> 0`,
 		Sort: "ranking ASC",
 		Head: []Heading{
@@ -501,8 +516,13 @@ var NewspaperPages = []NewspaperPage{
                        product_name, set_name, product_number, variant,
                        sellers_Today, sellers_d7, sellers_d30, pct_gain_7d
                   FROM scripts__tcgplayer_greatest_increase_in_vendor_listings_cards
-                 WHERE calc_date = (SELECT MAX(calc_date) - INTERVAL '0 DAY'
-                                      FROM scripts__tcgplayer_greatest_increase_in_vendor_listings_cards)
+                 WHERE game_name = '__GAME__'
+                   AND calc_date = (SELECT MAX(calc_date)
+                                      FROM scripts__tcgplayer_greatest_increase_in_vendor_listings_cards
+                                     WHERE game_name = '__GAME__'
+                                       AND calc_date <= (SELECT MAX(calc_date)
+                                                           FROM scripts__tcgplayer_greatest_increase_in_vendor_listings_cards
+                                                          WHERE game_name = '__GAME__') - INTERVAL '0 DAY')
                    AND pct_gain_7d <> 0`,
 		Sort: "ranking ASC",
 		Head: []Heading{
@@ -573,8 +593,13 @@ var NewspaperPages = []NewspaperPage{
                        product_name, set_name, product_number, variant,
                        ck_buy_price, ck_buy_1d, ck_buy_7d, ck_buy_30d, pct_increase_7d
                   FROM scripts__cardkingdom_buylist_increase_score_cards
-                 WHERE calc_date = (SELECT MAX(calc_date) - INTERVAL '0 DAY'
-                                      FROM scripts__cardkingdom_buylist_increase_score_cards)
+                 WHERE game_name = '__GAME__'
+                   AND calc_date = (SELECT MAX(calc_date)
+                                      FROM scripts__cardkingdom_buylist_increase_score_cards
+                                     WHERE game_name = '__GAME__'
+                                       AND calc_date <= (SELECT MAX(calc_date)
+                                                           FROM scripts__cardkingdom_buylist_increase_score_cards
+                                                          WHERE game_name = '__GAME__') - INTERVAL '0 DAY')
                    AND pct_increase_7d <> 0`,
 		Sort: "ranking ASC",
 		Head: []Heading{
@@ -652,8 +677,13 @@ var NewspaperPages = []NewspaperPage{
                        product_name, set_name, product_number, variant,
                        ck_buy_price, ck_buy_1d, ck_buy_7d, ck_buy_30d, pct_decrease_7d
                   FROM scripts__cardkingdom_buylist_decrease_score_cards
-                 WHERE calc_date = (SELECT MAX(calc_date) - INTERVAL '0 DAY'
-                                      FROM scripts__cardkingdom_buylist_decrease_score_cards)
+                 WHERE game_name = '__GAME__'
+                   AND calc_date = (SELECT MAX(calc_date)
+                                      FROM scripts__cardkingdom_buylist_decrease_score_cards
+                                     WHERE game_name = '__GAME__'
+                                       AND calc_date <= (SELECT MAX(calc_date)
+                                                           FROM scripts__cardkingdom_buylist_decrease_score_cards
+                                                          WHERE game_name = '__GAME__') - INTERVAL '0 DAY')
                    AND pct_decrease_7d <> 0`,
 		Sort: "ranking ASC",
 		Head: []Heading{


### PR DESCRIPTION
The NewNewspaper queries pinned calc_date to MAX(calc_date) - INTERVAL 'N DAY' on a single table-wide MAX. Two problems with that:

  1. On the 3-day lookback, if no row landed exactly at MAX-3 days (sparse loaders, weekend gaps, etc.), the equality filter matched nothing and the page rendered empty.
  2. The trailing "AND game_name = '<game>'" appended in cacheNewspaper meant MAX was computed across all games. If one game's loader lagged another's, the global MAX would point at a date the lagging game had no rows for, blanking that game's newspaper.

Rewrite each WHERE clause to take MAX(calc_date) of rows where calc_date is at or before the per-game MAX minus the interval, and thread game_name into every subquery via a __GAME__ placeholder substituted once at cache time.