### PR TITLE
Fix uploader results

### DIFF
--- a/css/upload.css
+++ b/css/upload.css
@@ -788,6 +788,68 @@
 .res-panel { display: none; }
 .res-panel.active { display: block; }
 
+/* ── Results sub-tabs (singles / sealed / all) ── */
+.ures-subtabs {
+    display: flex;
+    gap: 2px;
+    margin-bottom: 1em;
+    background: var(--surface-1);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    padding: 4px;
+    width: fit-content;
+}
+.ures-subtab {
+    padding: 6px 16px;
+    border-radius: var(--radius-sm);
+    font-size: var(--text-md);
+    font-weight: 600;
+    cursor: pointer;
+    color: var(--activetext);
+    border: none;
+    background: none;
+    font-family: inherit;
+    transition: all 0.12s;
+}
+.ures-subtab:hover { color: var(--normal); }
+.ures-subtab.on { background: var(--accent-muted); color: var(--ainfo); }
+
+.ures-block-title {
+    margin: 0.25em 0 0.5em;
+    font-size: var(--text-lg);
+    color: var(--text-dim);
+}
+.ures-views .ures-strip { margin-bottom: 1em; }
+.ures-views .ures-block .ures-wrap { margin-bottom: 1.5em; }
+
+/* View toggling: strips, blocks, and the grand bar are hidden by default
+   and revealed per the active data-ures-view. */
+.ures-strip, .ures-grand { display: none; }
+.ures-block { display: none; }
+.ures-views[data-ures-view="all"] .ures-strip-all,
+.ures-views[data-ures-view="singles"] .ures-strip-singles,
+.ures-views[data-ures-view="sealed"] .ures-strip-sealed { display: block; }
+.ures-views[data-ures-view="all"] .ures-block-singles,
+.ures-views[data-ures-view="all"] .ures-block-sealed,
+.ures-views[data-ures-view="singles"] .ures-block-singles,
+.ures-views[data-ures-view="sealed"] .ures-block-sealed { display: block; }
+.ures-views[data-ures-view="all"] .ures-grand {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 16px;
+    margin-bottom: 6em;
+    background: var(--surface-2);
+    border: 1px solid var(--border-moderate);
+    border-radius: var(--radius-md);
+    font-weight: 700;
+}
+.ures-grand .val {
+    color: var(--asuccess);
+    font-family: var(--font-mono);
+    font-size: var(--text-xl);
+}
+
 /* ── Results table ── */
 .ures-wrap {
     background: var(--surface-1);

--- a/css/upload.css
+++ b/css/upload.css
@@ -829,11 +829,13 @@
 .ures-block { display: none; }
 .ures-views[data-ures-view="all"] .ures-strip-all,
 .ures-views[data-ures-view="singles"] .ures-strip-singles,
-.ures-views[data-ures-view="sealed"] .ures-strip-sealed { display: block; }
+.ures-views[data-ures-view="sealed"] .ures-strip-sealed,
+.ures-views[data-ures-view="notfound"] .ures-strip-notfound { display: block; }
 .ures-views[data-ures-view="all"] .ures-block-singles,
 .ures-views[data-ures-view="all"] .ures-block-sealed,
 .ures-views[data-ures-view="singles"] .ures-block-singles,
-.ures-views[data-ures-view="sealed"] .ures-block-sealed { display: block; }
+.ures-views[data-ures-view="sealed"] .ures-block-sealed,
+.ures-views[data-ures-view="notfound"] .ures-block-notfound { display: block; }
 
 /* ── Results table ── */
 .ures-wrap {

--- a/css/upload.css
+++ b/css/upload.css
@@ -819,12 +819,13 @@
     font-size: var(--text-lg);
     color: var(--text-dim);
 }
+.ures-views { margin-bottom: 6em; }
 .ures-views .ures-strip { margin-bottom: 1em; }
 .ures-views .ures-block .ures-wrap { margin-bottom: 1.5em; }
 
-/* View toggling: strips, blocks, and the grand bar are hidden by default
+/* View toggling: strips and blocks are hidden by default
    and revealed per the active data-ures-view. */
-.ures-strip, .ures-grand { display: none; }
+.ures-strip { display: none; }
 .ures-block { display: none; }
 .ures-views[data-ures-view="all"] .ures-strip-all,
 .ures-views[data-ures-view="singles"] .ures-strip-singles,
@@ -833,22 +834,6 @@
 .ures-views[data-ures-view="all"] .ures-block-sealed,
 .ures-views[data-ures-view="singles"] .ures-block-singles,
 .ures-views[data-ures-view="sealed"] .ures-block-sealed { display: block; }
-.ures-views[data-ures-view="all"] .ures-grand {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 12px 16px;
-    margin-bottom: 6em;
-    background: var(--surface-2);
-    border: 1px solid var(--border-moderate);
-    border-radius: var(--radius-md);
-    font-weight: 700;
-}
-.ures-grand .val {
-    color: var(--asuccess);
-    font-family: var(--font-mono);
-    font-size: var(--text-xl);
-}
 
 /* ── Results table ── */
 .ures-wrap {

--- a/main.go
+++ b/main.go
@@ -214,14 +214,17 @@ type PageVars struct {
 	MissingPrices        map[string]float64
 	ResultPrices         map[string]map[string]float64
 	UploadQuery          string
-	// Upload singles/sealed split
-	SinglesEntries  []UploadEntry
-	SealedEntries   []UploadEntry
-	SinglesQuantity int
-	SealedQuantity  int
-	SinglesHighest  float64
-	SealedHighest   float64
-	HasMixed        bool
+	// Upload singles/sealed/not-found split
+	SinglesEntries    []UploadEntry
+	SealedEntries     []UploadEntry
+	NotFoundEntries   []UploadEntry
+	SinglesQuantity   int
+	SealedQuantity    int
+	SinglesHighest    float64
+	SealedHighest     float64
+	ShowResultTabs    bool
+	ShowAllTab        bool
+	DefaultResultView string
 }
 
 type NavElem struct {

--- a/main.go
+++ b/main.go
@@ -214,6 +214,14 @@ type PageVars struct {
 	MissingPrices        map[string]float64
 	ResultPrices         map[string]map[string]float64
 	UploadQuery          string
+	// Upload singles/sealed split
+	SinglesEntries  []UploadEntry
+	SealedEntries   []UploadEntry
+	SinglesQuantity int
+	SealedQuantity  int
+	SinglesHighest  float64
+	SealedHighest   float64
+	HasMixed        bool
 }
 
 type NavElem struct {

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -45,7 +45,7 @@
             <div class="page-header">
                 <h1>Results{{if and .UploadQuery (not (eq .UploadQuery "hashes"))}} from {{.UploadQuery}}{{end}}</h1>
                 <p class="page-subtitle">
-                    {{if .UploadEntries}}{{len .UploadEntries}} cards matched &middot; {{end}}{{if .IsBuylist}}Buylist{{else}}Retail{{end}} mode
+                    {{if .UploadEntries}}{{len .UploadEntries}} rows &middot; {{end}}{{if .IsBuylist}}Buylist{{else}}Retail{{end}} mode
                     {{if .RemoteLinkURL}}
                         &middot; <a href="javascript:void(0)" class="upload-share-link" onclick="copyShareLink(this)" title="Copy shareable link">
                             <i data-lucide="share-2" style="width:14px;height:14px;vertical-align:-2px"></i> Share

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -803,8 +803,8 @@
             {{if .CanBuylist}}
             <div class="res-btn-sep"></div>
             <button class="upload-btn upload-btn-secondary res-export-btn" onclick="submitExport('download', false)">Get CSV</button>
-            <button class="upload-btn upload-btn-secondary res-export-btn" onclick="submitExport('estimate', true)">CardConduit</button>
-            <button class="upload-btn upload-btn-secondary res-export-btn" onclick="submitExport('deckbox', false)">Deckbox</button>
+            <button class="upload-btn upload-btn-secondary res-export-btn" data-singles-only onclick="submitExport('estimate', true)">CardConduit</button>
+            <button class="upload-btn upload-btn-secondary res-export-btn" data-singles-only onclick="submitExport('deckbox', false)">Deckbox</button>
             <button class="upload-btn upload-btn-secondary res-export-btn" onclick="submitExport('tcgplayer_csv', false)">TCGplayer CSV</button>
             {{end}}
         </div>
@@ -812,7 +812,7 @@
     </div>
 
     <!-- Tab: Results -->
-    <div class="res-panel active" id="panel-results">
+    <div class="res-panel active" id="panel-results" data-result-view="{{.DefaultResultView}}">
         {{if .ShowResultTabs}}
             <div class="ures-subtabs">
                 {{if .ShowAllTab}}<button class="ures-subtab{{if eq .DefaultResultView "all"}} on{{end}}" onclick="showUresView('all', this)">All</button>{{end}}
@@ -1130,6 +1130,7 @@
             bar.querySelectorAll('.ures-subtab').forEach(function(b) { b.classList.remove('on'); });
         }
         btn.classList.add('on');
+        updateExportButtons(view);
     }
     // One-time localStorage → cookie migration for the upload optimizer
     document.addEventListener('DOMContentLoaded', function migrateUploadPrefs() {
@@ -1286,12 +1287,27 @@
         <input type="hidden" id="res_estimate" name="estimate" value="">
         <input type="hidden" id="res_deckbox" name="deckbox" value="">
         <input type="hidden" id="res_tcgplayer_csv" name="tcgplayer_csv" value="">
+        <input type="hidden" id="res_csvscope" name="csvscope" value="">
     </form>
 
     <script>
     var resExportFields = ["res_download", "res_estimate", "res_deckbox", "res_tcgplayer_csv"];
 
-    function ensureHashesLoaded() {
+    // The exportable result rows for a category: 'singles', 'sealed', or 'all'
+    // (both actionable blocks, never the Not Found block).
+    function exportRows(category) {
+        var views = document.querySelector('.ures-views');
+        var sel = '.ures-table tr[data-hash]';
+        if (!views) {
+            // Single-section upload (no sub-tabs): the one rendered table.
+            return document.querySelectorAll('#panel-results ' + sel);
+        }
+        if (category === 'singles') return views.querySelectorAll('.ures-block-singles ' + sel);
+        if (category === 'sealed') return views.querySelectorAll('.ures-block-sealed ' + sel);
+        return views.querySelectorAll('.ures-block-singles ' + sel + ', .ures-block-sealed ' + sel);
+    }
+
+    function ensureHashesLoaded(category) {
         var form = document.getElementById("upload_form");
 
         // Always rebuild from current row state so removed/picked rows take effect.
@@ -1300,7 +1316,7 @@
         });
 
         form.removeAttribute("enctype");
-        document.querySelectorAll('.ures-table tr[data-hash]').forEach(function(row) {
+        exportRows(category || 'all').forEach(function(row) {
             if (!row.dataset.hash) return;
             if (row.classList.contains('ures-removed-row')) return;
             var pairs = [['hash','hashes'],['qtys','hashesQtys'],['cond','hashesCond'],['price','hashesPrice']];
@@ -1315,28 +1331,70 @@
         });
     }
 
-    function submitExport(field, newWindow) {
-        ensureHashesLoaded();
+    // Active result view: 'all' | 'singles' | 'sealed' | 'notfound'. Falls back
+    // to the panel's data-result-view for single-section (untabbed) uploads.
+    function currentExportView() {
+        var views = document.querySelector('.ures-views');
+        if (views) return views.getAttribute('data-ures-view');
+        var panel = document.getElementById('panel-results');
+        return panel ? panel.getAttribute('data-result-view') : 'singles';
+    }
 
+    function runExport(field, category, newWindow) {
+        ensureHashesLoaded(category);
         resExportFields.forEach(function(id) {
             document.getElementById(id).value = "";
         });
         document.getElementById("res_" + field).value = "true";
-
+        var scope = document.getElementById("res_csvscope");
+        if (scope) {
+            scope.value = (field === 'download' && (category === 'singles' || category === 'sealed')) ? category : "";
+        }
         var form = document.getElementById("upload_form");
         form.target = newWindow ? '_blank' : '';
         form.submit();
     }
 
+    function submitExport(field, newWindow) {
+        var view = currentExportView();
+        if (view === 'notfound') return; // Not Found is not exportable
+
+        // Get CSV on the All tab splits into two narrow files (singles + sealed)
+        // because the categories use disjoint store columns. Everything else
+        // exports the active view in one file (All = both combined).
+        if (field === 'download' && view === 'all') {
+            runExport(field, 'singles', newWindow);
+            setTimeout(function() { runExport(field, 'sealed', newWindow); }, 900);
+            return;
+        }
+        runExport(field, view, newWindow);
+    }
+
+    // Hide the singles-only exporters on the Sealed tab, and all of them on
+    // Not Found.
+    function updateExportButtons(view) {
+        document.querySelectorAll('.res-export-btn').forEach(function(btn) {
+            var singlesOnly = btn.hasAttribute('data-singles-only');
+            var show = true;
+            if (view === 'notfound') show = false;
+            else if (view === 'sealed' && singlesOnly) show = false;
+            btn.style.display = show ? '' : 'none';
+        });
+    }
+
     // Re-process results with current settings (called by settings save)
     window.reprocessUploadResults = function() {
-        ensureHashesLoaded();
+        ensureHashesLoaded('all');
         syncUploadOptionsFromSettings();
         resExportFields.forEach(function(id) {
             document.getElementById(id).value = "";
         });
         document.getElementById("upload_form").submit();
     };
+
+    document.addEventListener('DOMContentLoaded', function() {
+        updateExportButtons(currentExportView());
+    });
     </script>
 
     <!-- Reload button (hidden until a pick or remove is made) -->

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -820,7 +820,7 @@
                         </div>
                         <div class="res-summary-stat">
                             <span class="label">Sealed</span>
-                            <span class="val green">$ {{printf "%.2f" .SealedHighest}}</span>
+                            <span class="val">$ {{printf "%.2f" .SealedHighest}}</span>
                         </div>
                     </div>
                 </div>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -646,24 +646,6 @@
     <tbody>
         {{range .Entries}}
             {{$cardId := .CardId}}
-            {{if .MismatchError}}
-            <tr class="ures-error-row" data-hash="" data-qtys="{{.Quantity}}" data-cond="{{.OriginalCondition}}" data-price="{{.OriginalPrice}}">
-                <td>
-                    <div class="ures-card-cell">
-                        <img src="https://cards.scryfall.io/back.png" loading="lazy">
-                        <div class="ures-card-info">
-                            <span class="ures-card-name"><a href="/search?q={{.Card.Name}}" target="_blank">{{.Card.Name}}</a></span>
-                            <span class="ures-card-set ures-not-found">Not found</span>
-                        </div>
-                    </div>
-                </td>
-                <td class="ures-price">$ {{printf "%.2f" .OriginalPrice}}</td>
-                <td style="text-align:center"><span class="cond-badge">{{.OriginalCondition}}</span></td>
-                <td style="text-align:center">{{.Quantity}}</td>
-                {{range $storeKeys}}<td class="ures-price no-data">&mdash;</td>{{end}}
-                <td></td>
-            </tr>
-            {{else}}
             {{$card := (index $root.Metadata .CardId)}}
             {{$scraperEntries := (index $root.ResultPrices (print .CardId .OriginalCondition))}}
             <tr data-hash="{{.CardId}}" data-qtys="{{.Quantity}}" data-cond="{{.OriginalCondition}}" data-price="{{.OriginalPrice}}"
@@ -714,7 +696,6 @@
                     </div>
                 </td>
             </tr>
-            {{end}}
         {{end}}
         <tr class="ures-totals-row">
             <td><span class="ures-totals-label">Totals ({{.Quantity}} {{.Noun}})</span></td>
@@ -780,6 +761,37 @@
 </div>
 {{end}}
 
+{{define "ures-notfound-table"}}
+<table class="ures-table">
+    <thead>
+        <tr>
+            <th style="width:380px;">Card</th>
+            <th class="r">Your Price</th>
+            <th class="c">Cond</th>
+            <th class="c">Qty</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{range .Entries}}
+        <tr class="ures-error-row" data-hash="" data-qtys="{{.Quantity}}" data-cond="{{.OriginalCondition}}" data-price="{{.OriginalPrice}}">
+            <td>
+                <div class="ures-card-cell">
+                    <img src="https://cards.scryfall.io/back.png" loading="lazy">
+                    <div class="ures-card-info">
+                        <span class="ures-card-name"><a href="/search?q={{.Card.Name}}" target="_blank">{{.Card.Name}}</a></span>
+                        <span class="ures-card-set ures-not-found">Not found</span>
+                    </div>
+                </div>
+            </td>
+            <td class="ures-price">$ {{printf "%.2f" .OriginalPrice}}</td>
+            <td style="text-align:center"><span class="cond-badge">{{.OriginalCondition}}</span></td>
+            <td style="text-align:center">{{.Quantity}}</td>
+        </tr>
+        {{end}}
+    </tbody>
+</table>
+{{end}}
+
 {{define "upload-results"}}
     <div class="res-header">
         <!-- Row 1: View tabs + Export buttons -->
@@ -801,13 +813,15 @@
 
     <!-- Tab: Results -->
     <div class="res-panel active" id="panel-results">
-        {{if .HasMixed}}
+        {{if .ShowResultTabs}}
             <div class="ures-subtabs">
-                <button class="ures-subtab on" onclick="showUresView('all', this)">All</button>
-                <button class="ures-subtab" onclick="showUresView('singles', this)">Singles</button>
-                <button class="ures-subtab" onclick="showUresView('sealed', this)">Sealed</button>
+                {{if .ShowAllTab}}<button class="ures-subtab{{if eq .DefaultResultView "all"}} on{{end}}" onclick="showUresView('all', this)">All</button>{{end}}
+                {{if .SinglesEntries}}<button class="ures-subtab{{if eq .DefaultResultView "singles"}} on{{end}}" onclick="showUresView('singles', this)">Singles</button>{{end}}
+                {{if .SealedEntries}}<button class="ures-subtab{{if eq .DefaultResultView "sealed"}} on{{end}}" onclick="showUresView('sealed', this)">Sealed</button>{{end}}
+                {{if .NotFoundEntries}}<button class="ures-subtab{{if eq .DefaultResultView "notfound"}} on{{end}}" onclick="showUresView('notfound', this)">Not Found</button>{{end}}
             </div>
-            <div class="ures-views" data-ures-view="all">
+            <div class="ures-views" data-ures-view="{{.DefaultResultView}}">
+                {{if .ShowAllTab}}
                 <div class="ures-strip ures-strip-all">
                     <div class="res-summary">
                         <div class="res-summary-stat">
@@ -824,25 +838,57 @@
                         </div>
                     </div>
                 </div>
+                {{end}}
+                {{if .SinglesEntries}}
                 <div class="ures-strip ures-strip-singles">
                     {{template "ures-cat-strip" (dict "CountLabel" "Cards" "Quantity" .SinglesQuantity "StoreKeys" .ScraperKeys "IndexKeys" .IndexKeys "Highest" .SinglesHighest "Root" .)}}
                 </div>
+                {{end}}
+                {{if .SealedEntries}}
                 <div class="ures-strip ures-strip-sealed">
                     {{template "ures-cat-strip" (dict "CountLabel" "Products" "Quantity" .SealedQuantity "StoreKeys" .SealedScraperKeys "IndexKeys" .SealedIndexKeys "Highest" .SealedHighest "Root" .)}}
                 </div>
+                {{end}}
+                {{if .NotFoundEntries}}
+                <div class="ures-strip ures-strip-notfound">
+                    <div class="res-summary">
+                        <div class="res-summary-stat">
+                            <span class="label">Not Found</span>
+                            <span class="val">{{len .NotFoundEntries}}</span>
+                        </div>
+                    </div>
+                </div>
+                {{end}}
 
+                {{if .SinglesEntries}}
                 <div class="ures-block ures-block-singles">
                     <h3 class="ures-block-title">Singles</h3>
                     <div class="ures-wrap">
                         {{template "ures-results-table" (dict "Entries" .SinglesEntries "StoreKeys" .ScraperKeys "IndexKeys" .IndexKeys "Quantity" .SinglesQuantity "Noun" "cards" "Root" .)}}
                     </div>
                 </div>
+                {{end}}
+                {{if .SealedEntries}}
                 <div class="ures-block ures-block-sealed">
                     <h3 class="ures-block-title">Sealed</h3>
                     <div class="ures-wrap">
                         {{template "ures-results-table" (dict "Entries" .SealedEntries "StoreKeys" .SealedScraperKeys "IndexKeys" .SealedIndexKeys "Quantity" .SealedQuantity "Noun" "products" "Root" .)}}
                     </div>
                 </div>
+                {{end}}
+                {{if .NotFoundEntries}}
+                <div class="ures-block ures-block-notfound">
+                    <h3 class="ures-block-title">Not Found</h3>
+                    <div class="ures-wrap">
+                        {{template "ures-notfound-table" (dict "Entries" .NotFoundEntries)}}
+                    </div>
+                </div>
+                {{end}}
+            </div>
+        {{else if .SinglesEntries}}
+            {{template "ures-cat-strip" (dict "CountLabel" "Cards" "Quantity" .SinglesQuantity "StoreKeys" .ScraperKeys "IndexKeys" .IndexKeys "Highest" .SinglesHighest "Root" .)}}
+            <div class="ures-wrap">
+                {{template "ures-results-table" (dict "Entries" .SinglesEntries "StoreKeys" .ScraperKeys "IndexKeys" .IndexKeys "Quantity" .SinglesQuantity "Noun" "cards" "Root" .)}}
             </div>
         {{else if .SealedEntries}}
             {{template "ures-cat-strip" (dict "CountLabel" "Products" "Quantity" .SealedQuantity "StoreKeys" .SealedScraperKeys "IndexKeys" .SealedIndexKeys "Highest" .SealedHighest "Root" .)}}
@@ -850,9 +896,14 @@
                 {{template "ures-results-table" (dict "Entries" .SealedEntries "StoreKeys" .SealedScraperKeys "IndexKeys" .SealedIndexKeys "Quantity" .SealedQuantity "Noun" "products" "Root" .)}}
             </div>
         {{else}}
-            {{template "ures-cat-strip" (dict "CountLabel" "Cards" "Quantity" .SinglesQuantity "StoreKeys" .ScraperKeys "IndexKeys" .IndexKeys "Highest" .SinglesHighest "Root" .)}}
+            <div class="res-summary">
+                <div class="res-summary-stat">
+                    <span class="label">Not Found</span>
+                    <span class="val">{{len .NotFoundEntries}}</span>
+                </div>
+            </div>
             <div class="ures-wrap">
-                {{template "ures-results-table" (dict "Entries" .SinglesEntries "StoreKeys" .ScraperKeys "IndexKeys" .IndexKeys "Quantity" .SinglesQuantity "Noun" "cards" "Root" .)}}
+                {{template "ures-notfound-table" (dict "Entries" .NotFoundEntries)}}
             </div>
         {{end}}
     </div>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -717,7 +717,7 @@
             {{end}}
         {{end}}
         <tr class="ures-totals-row">
-            <td><span class="ures-totals-label">Totals ({{.Quantity}} cards)</span></td>
+            <td><span class="ures-totals-label">Totals ({{.Quantity}} {{.Noun}})</span></td>
             <td></td>
             <td></td>
             <td style="text-align:center;font-family:var(--font-mono);font-weight:700">{{.Quantity}}</td>
@@ -749,7 +749,7 @@
 {{$root := .Root}}
 <div class="res-summary">
     <div class="res-summary-stat">
-        <span class="label">Cards</span>
+        <span class="label">{{.CountLabel}}</span>
         <span class="val">{{.Quantity}}</span>
     </div>
     {{range .StoreKeys}}
@@ -811,7 +811,7 @@
                 <div class="ures-strip ures-strip-all">
                     <div class="res-summary">
                         <div class="res-summary-stat">
-                            <span class="label">Cards</span>
+                            <span class="label">Entries</span>
                             <span class="val">{{.TotalQuantity}}</span>
                         </div>
                         <div class="res-summary-stat">
@@ -825,34 +825,34 @@
                     </div>
                 </div>
                 <div class="ures-strip ures-strip-singles">
-                    {{template "ures-cat-strip" (dict "Quantity" .SinglesQuantity "StoreKeys" .ScraperKeys "IndexKeys" .IndexKeys "Highest" .SinglesHighest "Root" .)}}
+                    {{template "ures-cat-strip" (dict "CountLabel" "Cards" "Quantity" .SinglesQuantity "StoreKeys" .ScraperKeys "IndexKeys" .IndexKeys "Highest" .SinglesHighest "Root" .)}}
                 </div>
                 <div class="ures-strip ures-strip-sealed">
-                    {{template "ures-cat-strip" (dict "Quantity" .SealedQuantity "StoreKeys" .SealedScraperKeys "IndexKeys" .SealedIndexKeys "Highest" .SealedHighest "Root" .)}}
+                    {{template "ures-cat-strip" (dict "CountLabel" "Products" "Quantity" .SealedQuantity "StoreKeys" .SealedScraperKeys "IndexKeys" .SealedIndexKeys "Highest" .SealedHighest "Root" .)}}
                 </div>
 
                 <div class="ures-block ures-block-singles">
                     <h3 class="ures-block-title">Singles</h3>
                     <div class="ures-wrap">
-                        {{template "ures-results-table" (dict "Entries" .SinglesEntries "StoreKeys" .ScraperKeys "IndexKeys" .IndexKeys "Quantity" .SinglesQuantity "Root" .)}}
+                        {{template "ures-results-table" (dict "Entries" .SinglesEntries "StoreKeys" .ScraperKeys "IndexKeys" .IndexKeys "Quantity" .SinglesQuantity "Noun" "cards" "Root" .)}}
                     </div>
                 </div>
                 <div class="ures-block ures-block-sealed">
                     <h3 class="ures-block-title">Sealed</h3>
                     <div class="ures-wrap">
-                        {{template "ures-results-table" (dict "Entries" .SealedEntries "StoreKeys" .SealedScraperKeys "IndexKeys" .SealedIndexKeys "Quantity" .SealedQuantity "Root" .)}}
+                        {{template "ures-results-table" (dict "Entries" .SealedEntries "StoreKeys" .SealedScraperKeys "IndexKeys" .SealedIndexKeys "Quantity" .SealedQuantity "Noun" "products" "Root" .)}}
                     </div>
                 </div>
             </div>
         {{else if .SealedEntries}}
-            {{template "ures-cat-strip" (dict "Quantity" .SealedQuantity "StoreKeys" .SealedScraperKeys "IndexKeys" .SealedIndexKeys "Highest" .SealedHighest "Root" .)}}
+            {{template "ures-cat-strip" (dict "CountLabel" "Products" "Quantity" .SealedQuantity "StoreKeys" .SealedScraperKeys "IndexKeys" .SealedIndexKeys "Highest" .SealedHighest "Root" .)}}
             <div class="ures-wrap">
-                {{template "ures-results-table" (dict "Entries" .SealedEntries "StoreKeys" .SealedScraperKeys "IndexKeys" .SealedIndexKeys "Quantity" .SealedQuantity "Root" .)}}
+                {{template "ures-results-table" (dict "Entries" .SealedEntries "StoreKeys" .SealedScraperKeys "IndexKeys" .SealedIndexKeys "Quantity" .SealedQuantity "Noun" "products" "Root" .)}}
             </div>
         {{else}}
-            {{template "ures-cat-strip" (dict "Quantity" .SinglesQuantity "StoreKeys" .ScraperKeys "IndexKeys" .IndexKeys "Highest" .SinglesHighest "Root" .)}}
+            {{template "ures-cat-strip" (dict "CountLabel" "Cards" "Quantity" .SinglesQuantity "StoreKeys" .ScraperKeys "IndexKeys" .IndexKeys "Highest" .SinglesHighest "Root" .)}}
             <div class="ures-wrap">
-                {{template "ures-results-table" (dict "Entries" .SinglesEntries "StoreKeys" .ScraperKeys "IndexKeys" .IndexKeys "Quantity" .SinglesQuantity "Root" .)}}
+                {{template "ures-results-table" (dict "Entries" .SinglesEntries "StoreKeys" .ScraperKeys "IndexKeys" .IndexKeys "Quantity" .SinglesQuantity "Noun" "cards" "Root" .)}}
             </div>
         {{end}}
     </div>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -803,9 +803,9 @@
     <div class="res-panel active" id="panel-results">
         {{if .HasMixed}}
             <div class="ures-subtabs">
-                <button class="ures-subtab on" data-view="all" onclick="showUresView('all', this)">All</button>
-                <button class="ures-subtab" data-view="singles" onclick="showUresView('singles', this)">Singles</button>
-                <button class="ures-subtab" data-view="sealed" onclick="showUresView('sealed', this)">Sealed</button>
+                <button class="ures-subtab on" onclick="showUresView('all', this)">All</button>
+                <button class="ures-subtab" onclick="showUresView('singles', this)">Singles</button>
+                <button class="ures-subtab" onclick="showUresView('sealed', this)">Sealed</button>
             </div>
             <div class="ures-views" data-ures-view="all">
                 <div class="ures-strip ures-strip-all">

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -843,13 +843,6 @@
                         {{template "ures-results-table" (dict "Entries" .SealedEntries "StoreKeys" .SealedScraperKeys "IndexKeys" .SealedIndexKeys "Quantity" .SealedQuantity "Root" .)}}
                     </div>
                 </div>
-
-                {{if .HighestTotal}}
-                <div class="ures-grand">
-                    <span>Grand total (best price per item)</span>
-                    <span class="val">$ {{printf "%.2f" .HighestTotal}}</span>
-                </div>
-                {{end}}
             </div>
         {{else if .SealedEntries}}
             {{template "ures-cat-strip" (dict "Quantity" .SealedQuantity "StoreKeys" .SealedScraperKeys "IndexKeys" .SealedIndexKeys "Highest" .SealedHighest "Root" .)}}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -844,10 +844,12 @@
                     </div>
                 </div>
 
+                {{if .HighestTotal}}
                 <div class="ures-grand">
                     <span>Grand total (best price per item)</span>
                     <span class="val">$ {{printf "%.2f" .HighestTotal}}</span>
                 </div>
+                {{end}}
             </div>
         {{else if .SealedEntries}}
             {{template "ures-cat-strip" (dict "Quantity" .SealedQuantity "StoreKeys" .SealedScraperKeys "IndexKeys" .SealedIndexKeys "Highest" .SealedHighest "Root" .)}}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -797,161 +797,69 @@
             {{end}}
         </div>
 
-        <!-- Row 2: Summary stats -->
-        <div class="res-summary">
-            <div class="res-summary-stat">
-                <span class="label">Cards</span>
-                <span class="val">{{.TotalQuantity}}</span>
-            </div>
-            {{range .ScraperKeys}}
-                <div class="res-summary-stat">
-                    <span class="label">{{scraper_name .}}</span>
-                    <span class="val">$ {{printf "%.2f" (index $.TotalEntries .)}}</span>
-                    {{$missing := (index $.MissingCounts .)}}
-                    {{if ne $missing 0}}
-                        <span class="label">{{$missing}} missing</span>
-                    {{end}}
-                </div>
-            {{end}}
-            {{range .IndexKeys}}
-                {{$total := (index $.TotalEntries .)}}
-                {{if $total}}
-                <div class="res-summary-stat">
-                    <span class="label">{{scraper_name .}}</span>
-                    <span class="val blue">$ {{printf "%.2f" $total}}</span>
-                </div>
-                {{end}}
-            {{end}}
-            {{if .Optimized}}
-            <div class="res-summary-stat">
-                <span class="label">Optimizer Max</span>
-                <span class="val green">$ {{printf "%.2f" .HighestTotal}}</span>
-            </div>
-            {{end}}
-        </div>
     </div>
 
     <!-- Tab: Results -->
     <div class="res-panel active" id="panel-results">
-        <div class="ures-wrap">
-            <table class="ures-table">
-                <thead>
-                    <tr>
-                        <th style="width:380px;">Card</th>
-                        <th class="r">Your Price</th>
-                        <th class="c">Cond</th>
-                        <th class="c">Qty</th>
-                        {{range .ScraperKeys}}
-                            <th class="r">{{scraper_name .}}</th>
-                        {{end}}
-                        <th>Index</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {{range .UploadEntries}}
-                        {{$cardId := .CardId}}
-                        {{if .MismatchError}}
-                        <tr class="ures-error-row" data-hash="" data-qtys="{{.Quantity}}" data-cond="{{.OriginalCondition}}" data-price="{{.OriginalPrice}}">
-                            <td>
-                                <div class="ures-card-cell">
-                                    <img src="https://cards.scryfall.io/back.png" loading="lazy">
-                                    <div class="ures-card-info">
-                                        <span class="ures-card-name"><a href="/search?q={{.Card.Name}}" target="_blank">{{.Card.Name}}</a></span>
-                                        <span class="ures-card-set ures-not-found">Not found</span>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class="ures-price">$ {{printf "%.2f" .OriginalPrice}}</td>
-                            <td style="text-align:center"><span class="cond-badge">{{.OriginalCondition}}</span></td>
-                            <td style="text-align:center">{{.Quantity}}</td>
-                            {{range $.ScraperKeys}}<td class="ures-price no-data">&mdash;</td>{{end}}
-                            <td></td>
-                        </tr>
-                        {{else}}
-                        {{$card := (index $.Metadata .CardId)}}
-                        {{$scraperEntries := (index $.ResultPrices (print .CardId .OriginalCondition))}}
-                        {{$entryStoreKeys := $.ScraperKeys}}
-                        {{if $card.Sealed}}{{$entryStoreKeys = $.SealedScraperKeys}}{{end}}
-                        {{$entryIndexKeys := $.IndexKeys}}
-                        {{if $card.Sealed}}{{$entryIndexKeys = $.SealedIndexKeys}}{{end}}
-                        <tr data-hash="{{.CardId}}" data-qtys="{{.Quantity}}" data-cond="{{.OriginalCondition}}" data-price="{{.OriginalPrice}}"
-                            {{if .MismatchAlias}}class="ures-alias-row"{{end}}>
-                            <td>
-                                <div class="ures-card-cell">
-                                    <div class="foil-wrap{{if $card.HasContentWarning}} content-warning{{end}}" data-foil="{{$card.Foil}}" data-etched="{{$card.Etched}}"{{if $card.HasContentWarning}} onclick="this.classList.add('cw-revealed')"{{end}}>
-                                        <img src="{{$card.ImageURL}}" loading="lazy">
-                                    </div>
-                                    <div class="ures-card-info">
-                                        <span class="ures-card-name">
-                                            <a href="{{$card.SearchURL}}">{{$card.Name}}</a>
-                                            {{if $card.FinishTag}}<span class="result-badge {{$card.FinishClass}}">{{$card.FinishTag}}</span>{{end}}
-                                        </span>
-                                        <span class="ures-card-set">{{$card.Edition}} &middot; #{{$card.Number}}</span>
-                                        {{if .MismatchAlias}}
-                                        <button type="button" class="ures-pick-btn"
-                                            data-hash="{{.CardId}}"
-                                            data-aliases="{{range $i, $a := .PossibleAliases}}{{if $i}},{{end}}{{$a}}{{end}}"
-                                            onclick="openPrintingPicker(this)">Select printing</button>
-                                        {{end}}
-                                    </div>
-                                    <button type="button" class="ures-remove-btn" onclick="toggleRemoveRow(this)" title="Remove from results" aria-label="Remove from results">×</button>
-                                </div>
-                            </td>
-                            <td class="ures-price">$ {{printf "%.2f" .OriginalPrice}}</td>
-                            <td style="text-align:center"><span class="cond-badge">{{.OriginalCondition}}</span></td>
-                            <td style="text-align:center;font-family:var(--font-mono);font-size:var(--text-base)">{{.Quantity}}</td>
-                            {{range $entryStoreKeys}}
-                                {{$price := (index $scraperEntries .)}}
-                                <td class="ures-price {{if and (ne $price 0.0) (is_best_price $scraperEntries . $entryStoreKeys $.IsBuylist)}}best{{end}}">
-                                    {{if ne $price 0.0}}
-                                        <a href="https://mtgban.com/go/{{if $.IsBuylist}}b/{{end}}{{.}}/{{$cardId}}" target="_blank">$ {{printf "%.2f" $price}}</a>
-                                    {{else}}
-                                        &mdash;
-                                    {{end}}
-                                </td>
-                            {{end}}
-                            <td>
-                                <div class="ures-index">
-                                    {{range $entryIndexKeys}}
-                                        {{$indexName := .}}
-                                        {{$idxPrice := (index $scraperEntries $indexName)}}
-                                        {{if $idxPrice}}
-                                        <span><span class="idx-label">{{scraper_name $indexName}}</span><span class="idx-val">$ {{printf "%.2f" $idxPrice}}</span></span>
-                                        {{end}}
-                                    {{end}}
-                                </div>
-                            </td>
-                        </tr>
-                        {{end}}{{/* closes {{else}} for MismatchError */}}
-                    {{end}}
-                    <tr class="ures-totals-row">
-                        <td><span class="ures-totals-label">Totals ({{.TotalQuantity}} cards)</span></td>
-                        <td></td>
-                        <td></td>
-                        <td style="text-align:center;font-family:var(--font-mono);font-weight:700">{{.TotalQuantity}}</td>
-                        {{range .AllScraperKeys}}
-                            <td class="ures-price" style="font-weight:700">
-                                $ {{printf "%.2f" (index $.TotalEntries .)}}
-                                {{$missing := (index $.MissingCounts .)}}
-                                {{if ne $missing 0}}
-                                    <div class="ures-missing">{{$missing}} missing &middot; ~$ {{printf "%.2f" (index $.MissingPrices .)}}</div>
-                                {{end}}
-                            </td>
-                        {{end}}
-                        <td>
-                            <div class="ures-index" style="font-weight:600">
-                                {{range .IndexKeys}}
-                                    {{$total := (index $.TotalEntries .)}}
-                                    {{if $total}}
-                                    <span><span class="idx-label">{{scraper_name .}}</span><span class="idx-val">$ {{printf "%.2f" $total}}</span></span>
-                                    {{end}}
-                                {{end}}
-                            </div>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
+        {{if .HasMixed}}
+            <div class="ures-subtabs">
+                <button class="ures-subtab on" data-view="all" onclick="showUresView('all', this)">All</button>
+                <button class="ures-subtab" data-view="singles" onclick="showUresView('singles', this)">Singles</button>
+                <button class="ures-subtab" data-view="sealed" onclick="showUresView('sealed', this)">Sealed</button>
+            </div>
+            <div class="ures-views" data-ures-view="all">
+                <div class="ures-strip ures-strip-all">
+                    <div class="res-summary">
+                        <div class="res-summary-stat">
+                            <span class="label">Cards</span>
+                            <span class="val">{{.TotalQuantity}}</span>
+                        </div>
+                        <div class="res-summary-stat">
+                            <span class="label">Singles</span>
+                            <span class="val">$ {{printf "%.2f" .SinglesHighest}}</span>
+                        </div>
+                        <div class="res-summary-stat">
+                            <span class="label">Sealed</span>
+                            <span class="val green">$ {{printf "%.2f" .SealedHighest}}</span>
+                        </div>
+                    </div>
+                </div>
+                <div class="ures-strip ures-strip-singles">
+                    {{template "ures-cat-strip" (dict "Quantity" .SinglesQuantity "StoreKeys" .ScraperKeys "IndexKeys" .IndexKeys "Highest" .SinglesHighest "Root" .)}}
+                </div>
+                <div class="ures-strip ures-strip-sealed">
+                    {{template "ures-cat-strip" (dict "Quantity" .SealedQuantity "StoreKeys" .SealedScraperKeys "IndexKeys" .SealedIndexKeys "Highest" .SealedHighest "Root" .)}}
+                </div>
+
+                <div class="ures-block ures-block-singles">
+                    <h3 class="ures-block-title">Singles</h3>
+                    <div class="ures-wrap">
+                        {{template "ures-results-table" (dict "Entries" .SinglesEntries "StoreKeys" .ScraperKeys "IndexKeys" .IndexKeys "Quantity" .SinglesQuantity "Root" .)}}
+                    </div>
+                </div>
+                <div class="ures-block ures-block-sealed">
+                    <h3 class="ures-block-title">Sealed</h3>
+                    <div class="ures-wrap">
+                        {{template "ures-results-table" (dict "Entries" .SealedEntries "StoreKeys" .SealedScraperKeys "IndexKeys" .SealedIndexKeys "Quantity" .SealedQuantity "Root" .)}}
+                    </div>
+                </div>
+
+                <div class="ures-grand">
+                    <span>Grand total (best price per item)</span>
+                    <span class="val">$ {{printf "%.2f" .HighestTotal}}</span>
+                </div>
+            </div>
+        {{else if .SealedEntries}}
+            {{template "ures-cat-strip" (dict "Quantity" .SealedQuantity "StoreKeys" .SealedScraperKeys "IndexKeys" .SealedIndexKeys "Highest" .SealedHighest "Root" .)}}
+            <div class="ures-wrap">
+                {{template "ures-results-table" (dict "Entries" .SealedEntries "StoreKeys" .SealedScraperKeys "IndexKeys" .SealedIndexKeys "Quantity" .SealedQuantity "Root" .)}}
+            </div>
+        {{else}}
+            {{template "ures-cat-strip" (dict "Quantity" .SinglesQuantity "StoreKeys" .ScraperKeys "IndexKeys" .IndexKeys "Highest" .SinglesHighest "Root" .)}}
+            <div class="ures-wrap">
+                {{template "ures-results-table" (dict "Entries" .SinglesEntries "StoreKeys" .ScraperKeys "IndexKeys" .IndexKeys "Quantity" .SinglesQuantity "Root" .)}}
+            </div>
+        {{end}}
     </div>
 
     <!-- Tab: Optimizer -->
@@ -1166,6 +1074,15 @@
         document.querySelectorAll('.res-panel').forEach(function(p) { p.classList.remove('active'); });
         document.getElementById('panel-' + panel).classList.add('active');
         document.querySelectorAll('.res-tab').forEach(function(t) { t.classList.remove('on'); });
+        btn.classList.add('on');
+    }
+    function showUresView(view, btn) {
+        var views = document.querySelector('.ures-views');
+        if (views) { views.setAttribute('data-ures-view', view); }
+        var bar = btn.closest('.ures-subtabs');
+        if (bar) {
+            bar.querySelectorAll('.ures-subtab').forEach(function(b) { b.classList.remove('on'); });
+        }
         btn.classList.add('on');
     }
     // One-time localStorage → cookie migration for the upload optimizer

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -626,6 +626,160 @@
     {{end}}
 {{end}}
 
+{{define "ures-results-table"}}
+{{$root := .Root}}
+{{$storeKeys := .StoreKeys}}
+{{$indexKeys := .IndexKeys}}
+<table class="ures-table">
+    <thead>
+        <tr>
+            <th style="width:380px;">Card</th>
+            <th class="r">Your Price</th>
+            <th class="c">Cond</th>
+            <th class="c">Qty</th>
+            {{range $storeKeys}}
+                <th class="r">{{scraper_name .}}</th>
+            {{end}}
+            <th>Index</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{range .Entries}}
+            {{$cardId := .CardId}}
+            {{if .MismatchError}}
+            <tr class="ures-error-row" data-hash="" data-qtys="{{.Quantity}}" data-cond="{{.OriginalCondition}}" data-price="{{.OriginalPrice}}">
+                <td>
+                    <div class="ures-card-cell">
+                        <img src="https://cards.scryfall.io/back.png" loading="lazy">
+                        <div class="ures-card-info">
+                            <span class="ures-card-name"><a href="/search?q={{.Card.Name}}" target="_blank">{{.Card.Name}}</a></span>
+                            <span class="ures-card-set ures-not-found">Not found</span>
+                        </div>
+                    </div>
+                </td>
+                <td class="ures-price">$ {{printf "%.2f" .OriginalPrice}}</td>
+                <td style="text-align:center"><span class="cond-badge">{{.OriginalCondition}}</span></td>
+                <td style="text-align:center">{{.Quantity}}</td>
+                {{range $storeKeys}}<td class="ures-price no-data">&mdash;</td>{{end}}
+                <td></td>
+            </tr>
+            {{else}}
+            {{$card := (index $root.Metadata .CardId)}}
+            {{$scraperEntries := (index $root.ResultPrices (print .CardId .OriginalCondition))}}
+            <tr data-hash="{{.CardId}}" data-qtys="{{.Quantity}}" data-cond="{{.OriginalCondition}}" data-price="{{.OriginalPrice}}"
+                {{if .MismatchAlias}}class="ures-alias-row"{{end}}>
+                <td>
+                    <div class="ures-card-cell">
+                        <div class="foil-wrap{{if $card.HasContentWarning}} content-warning{{end}}" data-foil="{{$card.Foil}}" data-etched="{{$card.Etched}}"{{if $card.HasContentWarning}} onclick="this.classList.add('cw-revealed')"{{end}}>
+                            <img src="{{$card.ImageURL}}" loading="lazy">
+                        </div>
+                        <div class="ures-card-info">
+                            <span class="ures-card-name">
+                                <a href="{{$card.SearchURL}}">{{$card.Name}}</a>
+                                {{if $card.FinishTag}}<span class="result-badge {{$card.FinishClass}}">{{$card.FinishTag}}</span>{{end}}
+                            </span>
+                            <span class="ures-card-set">{{$card.Edition}} &middot; #{{$card.Number}}</span>
+                            {{if .MismatchAlias}}
+                            <button type="button" class="ures-pick-btn"
+                                data-hash="{{.CardId}}"
+                                data-aliases="{{range $i, $a := .PossibleAliases}}{{if $i}},{{end}}{{$a}}{{end}}"
+                                onclick="openPrintingPicker(this)">Select printing</button>
+                            {{end}}
+                        </div>
+                        <button type="button" class="ures-remove-btn" onclick="toggleRemoveRow(this)" title="Remove from results" aria-label="Remove from results">×</button>
+                    </div>
+                </td>
+                <td class="ures-price">$ {{printf "%.2f" .OriginalPrice}}</td>
+                <td style="text-align:center"><span class="cond-badge">{{.OriginalCondition}}</span></td>
+                <td style="text-align:center;font-family:var(--font-mono);font-size:var(--text-base)">{{.Quantity}}</td>
+                {{range $storeKeys}}
+                    {{$price := (index $scraperEntries .)}}
+                    <td class="ures-price {{if and (ne $price 0.0) (is_best_price $scraperEntries . $storeKeys $root.IsBuylist)}}best{{end}}">
+                        {{if ne $price 0.0}}
+                            <a href="https://mtgban.com/go/{{if $root.IsBuylist}}b/{{end}}{{.}}/{{$cardId}}" target="_blank">$ {{printf "%.2f" $price}}</a>
+                        {{else}}
+                            &mdash;
+                        {{end}}
+                    </td>
+                {{end}}
+                <td>
+                    <div class="ures-index">
+                        {{range $indexKeys}}
+                            {{$indexName := .}}
+                            {{$idxPrice := (index $scraperEntries $indexName)}}
+                            {{if $idxPrice}}
+                            <span><span class="idx-label">{{scraper_name $indexName}}</span><span class="idx-val">$ {{printf "%.2f" $idxPrice}}</span></span>
+                            {{end}}
+                        {{end}}
+                    </div>
+                </td>
+            </tr>
+            {{end}}
+        {{end}}
+        <tr class="ures-totals-row">
+            <td><span class="ures-totals-label">Totals ({{.Quantity}} cards)</span></td>
+            <td></td>
+            <td></td>
+            <td style="text-align:center;font-family:var(--font-mono);font-weight:700">{{.Quantity}}</td>
+            {{range $storeKeys}}
+                <td class="ures-price" style="font-weight:700">
+                    $ {{printf "%.2f" (index $root.TotalEntries .)}}
+                    {{$missing := (index $root.MissingCounts .)}}
+                    {{if ne $missing 0}}
+                        <div class="ures-missing">{{$missing}} missing &middot; ~$ {{printf "%.2f" (index $root.MissingPrices .)}}</div>
+                    {{end}}
+                </td>
+            {{end}}
+            <td>
+                <div class="ures-index" style="font-weight:600">
+                    {{range $indexKeys}}
+                        {{$total := (index $root.TotalEntries .)}}
+                        {{if $total}}
+                        <span><span class="idx-label">{{scraper_name .}}</span><span class="idx-val">$ {{printf "%.2f" $total}}</span></span>
+                        {{end}}
+                    {{end}}
+                </div>
+            </td>
+        </tr>
+    </tbody>
+</table>
+{{end}}
+
+{{define "ures-cat-strip"}}
+{{$root := .Root}}
+<div class="res-summary">
+    <div class="res-summary-stat">
+        <span class="label">Cards</span>
+        <span class="val">{{.Quantity}}</span>
+    </div>
+    {{range .StoreKeys}}
+        <div class="res-summary-stat">
+            <span class="label">{{scraper_name .}}</span>
+            <span class="val">$ {{printf "%.2f" (index $root.TotalEntries .)}}</span>
+            {{$missing := (index $root.MissingCounts .)}}
+            {{if ne $missing 0}}
+                <span class="label">{{$missing}} missing</span>
+            {{end}}
+        </div>
+    {{end}}
+    {{range .IndexKeys}}
+        {{$total := (index $root.TotalEntries .)}}
+        {{if $total}}
+        <div class="res-summary-stat">
+            <span class="label">{{scraper_name .}}</span>
+            <span class="val blue">$ {{printf "%.2f" $total}}</span>
+        </div>
+        {{end}}
+    {{end}}
+    {{if $root.Optimized}}
+    <div class="res-summary-stat">
+        <span class="label">Optimizer Max</span>
+        <span class="val green">$ {{printf "%.2f" .Highest}}</span>
+    </div>
+    {{end}}
+</div>
+{{end}}
+
 {{define "upload-results"}}
     <div class="res-header">
         <!-- Row 1: View tabs + Export buttons -->

--- a/upload.go
+++ b/upload.go
@@ -731,8 +731,12 @@ func Upload(w http.ResponseWriter, r *http.Request) {
 
 	// Allow downloading data as CSV
 	if download && canBuylist {
+		csvName := "mtgban_prices"
+		if scope := r.FormValue("csvscope"); scope == "singles" || scope == "sealed" {
+			csvName += "_" + scope
+		}
 		w.Header().Set("Content-Type", "text/csv")
-		w.Header().Set("Content-Disposition", "attachment; filename=\"mtgban_prices.csv\"")
+		w.Header().Set("Content-Disposition", "attachment; filename=\""+csvName+".csv\"")
 		csvWriter := csv.NewWriter(w)
 
 		// Search for all csv-specific indexes

--- a/upload.go
+++ b/upload.go
@@ -1067,13 +1067,38 @@ func Upload(w http.ResponseWriter, r *http.Request) {
 
 	sortResults(uploadedData, optimizedResults, sorting, preferFlavor)
 
-	// Split sorted entries into singles and sealed for the tabbed results view
-	singlesEntries, sealedEntries := partitionEntries(uploadedData, sealedProductIds)
+	// Split sorted entries into singles, sealed, and not-found for the tabbed view
+	singlesEntries, sealedEntries, notFoundEntries := partitionEntries(uploadedData, sealedProductIds)
 	pageVars.SinglesEntries = singlesEntries
 	pageVars.SealedEntries = sealedEntries
-	pageVars.HasMixed = len(singlesEntries) > 0 && len(sealedEntries) > 0
+	pageVars.NotFoundEntries = notFoundEntries
 	pageVars.SinglesHighest = singlesHighest
 	pageVars.SealedHighest = sealedHighest
+
+	// Decide which result sub-tabs to show. The All tab appears only when both
+	// actionable categories are present; the bar appears when more than one
+	// section (singles, sealed, not-found) exists.
+	hasSingles := len(singlesEntries) > 0
+	hasSealed := len(sealedEntries) > 0
+	hasNotFound := len(notFoundEntries) > 0
+	sections := 0
+	for _, present := range []bool{hasSingles, hasSealed, hasNotFound} {
+		if present {
+			sections++
+		}
+	}
+	pageVars.ShowResultTabs = sections > 1
+	pageVars.ShowAllTab = hasSingles && hasSealed
+	switch {
+	case pageVars.ShowAllTab:
+		pageVars.DefaultResultView = "all"
+	case hasSingles:
+		pageVars.DefaultResultView = "singles"
+	case hasSealed:
+		pageVars.DefaultResultView = "sealed"
+	default:
+		pageVars.DefaultResultView = "notfound"
+	}
 
 	pageVars.MissingCounts = missingCounts
 	pageVars.MissingPrices = missingPrices
@@ -1224,41 +1249,26 @@ func adjustQty(qty, multiplier, maxQty int) int {
 	return qty
 }
 
-// partitionEntries splits entries into singles and sealed by membership in
-// sealedIds. Unmatched entries follow the singles side, unless every matched
-// entry is sealed (then errors join the sealed side so a sealed-only upload
-// does not produce a singles table of only "not found" rows).
-func partitionEntries(entries []UploadEntry, sealedIds []string) (singles, sealed []UploadEntry) {
+// partitionEntries splits entries into singles, sealed, and notFound. Entries
+// with a match error go to notFound; matched entries split by membership in
+// sealedIds.
+func partitionEntries(entries []UploadEntry, sealedIds []string) (singles, sealed, notFound []UploadEntry) {
 	sealedSet := make(map[string]bool, len(sealedIds))
 	for _, id := range sealedIds {
 		sealedSet[id] = true
 	}
 
-	var matchedSingles, matchedSealed int
 	for _, e := range entries {
-		if e.MismatchError != nil {
-			continue
-		}
-		if sealedSet[e.CardId] {
-			matchedSealed++
-		} else {
-			matchedSingles++
-		}
-	}
-	errorsToSealed := matchedSealed > 0 && matchedSingles == 0
-
-	for _, e := range entries {
-		isSealed := e.MismatchError == nil && sealedSet[e.CardId]
-		if e.MismatchError != nil && errorsToSealed {
-			isSealed = true
-		}
-		if isSealed {
+		switch {
+		case e.MismatchError != nil:
+			notFound = append(notFound, e)
+		case sealedSet[e.CardId]:
 			sealed = append(sealed, e)
-		} else {
+		default:
 			singles = append(singles, e)
 		}
 	}
-	return singles, sealed
+	return singles, sealed, notFound
 }
 
 func mergeIdenticalEntries(uploadedData []UploadEntry) []UploadEntry {

--- a/upload.go
+++ b/upload.go
@@ -847,6 +847,7 @@ func Upload(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var highestTotal float64
+	var singlesHighest, sealedHighest float64
 
 	optimizedResults := map[string][]OptimizedUploadEntry{}
 	optimizedTotals := map[string]float64{}
@@ -912,7 +913,13 @@ func Upload(w http.ResponseWriter, r *http.Request) {
 		if uploadedData[i].HasQuantity {
 			qty = uploadedData[i].Quantity
 		}
-		pageVars.TotalQuantity += adjustQty(qty, multiplier, maxQty)
+		adjusted := adjustQty(qty, multiplier, maxQty)
+		pageVars.TotalQuantity += adjusted
+		if isSealed {
+			pageVars.SealedQuantity += adjusted
+		} else {
+			pageVars.SinglesQuantity += adjusted
+		}
 
 		// Run summaries for each vendor
 		for shorthand, banPrice := range results[cardId] {
@@ -1046,6 +1053,11 @@ func Upload(w http.ResponseWriter, r *http.Request) {
 			optimizedTotals[bestStore] += bestPrice
 			if j == 0 {
 				highestTotal += bestPrice
+				if isSealed {
+					sealedHighest += bestPrice
+				} else {
+					singlesHighest += bestPrice
+				}
 			}
 		}
 
@@ -1054,6 +1066,14 @@ func Upload(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sortResults(uploadedData, optimizedResults, sorting, preferFlavor)
+
+	// Split sorted entries into singles and sealed for the tabbed results view
+	singlesEntries, sealedEntries := partitionEntries(uploadedData, sealedProductIds)
+	pageVars.SinglesEntries = singlesEntries
+	pageVars.SealedEntries = sealedEntries
+	pageVars.HasMixed = len(singlesEntries) > 0 && len(sealedEntries) > 0
+	pageVars.SinglesHighest = singlesHighest
+	pageVars.SealedHighest = sealedHighest
 
 	pageVars.MissingCounts = missingCounts
 	pageVars.MissingPrices = missingPrices

--- a/upload.go
+++ b/upload.go
@@ -1204,6 +1204,43 @@ func adjustQty(qty, multiplier, maxQty int) int {
 	return qty
 }
 
+// partitionEntries splits entries into singles and sealed by membership in
+// sealedIds. Unmatched entries follow the singles side, unless every matched
+// entry is sealed (then errors join the sealed side so a sealed-only upload
+// does not produce a singles table of only "not found" rows).
+func partitionEntries(entries []UploadEntry, sealedIds []string) (singles, sealed []UploadEntry) {
+	sealedSet := make(map[string]bool, len(sealedIds))
+	for _, id := range sealedIds {
+		sealedSet[id] = true
+	}
+
+	var matchedSingles, matchedSealed int
+	for _, e := range entries {
+		if e.MismatchError != nil {
+			continue
+		}
+		if sealedSet[e.CardId] {
+			matchedSealed++
+		} else {
+			matchedSingles++
+		}
+	}
+	errorsToSealed := matchedSealed > 0 && matchedSingles == 0
+
+	for _, e := range entries {
+		isSealed := e.MismatchError == nil && sealedSet[e.CardId]
+		if e.MismatchError != nil && errorsToSealed {
+			isSealed = true
+		}
+		if isSealed {
+			sealed = append(sealed, e)
+		} else {
+			singles = append(singles, e)
+		}
+	}
+	return singles, sealed
+}
+
 func mergeIdenticalEntries(uploadedData []UploadEntry) []UploadEntry {
 	var uploadedDataClean []UploadEntry
 	duplicatedHashes := map[string]bool{}

--- a/upload_test.go
+++ b/upload_test.go
@@ -49,6 +49,12 @@ func TestPartitionEntries(t *testing.T) {
 			wantSingles: []UploadEntry{errEntry},
 			wantSealed:  nil,
 		},
+		{
+			name:        "errors stay with singles in mixed upload",
+			entries:     []UploadEntry{s1, sealed1, errEntry},
+			wantSingles: []UploadEntry{s1, errEntry},
+			wantSealed:  []UploadEntry{sealed1},
+		},
 	}
 
 	for _, tc := range tests {

--- a/upload_test.go
+++ b/upload_test.go
@@ -14,10 +14,11 @@ func TestPartitionEntries(t *testing.T) {
 	sealedIds := []string{"sealed1", "sealed2"}
 
 	tests := []struct {
-		name        string
-		entries     []UploadEntry
-		wantSingles []UploadEntry
-		wantSealed  []UploadEntry
+		name         string
+		entries      []UploadEntry
+		wantSingles  []UploadEntry
+		wantSealed   []UploadEntry
+		wantNotFound []UploadEntry
 	}{
 		{
 			name:        "mixed splits by membership",
@@ -29,42 +30,44 @@ func TestPartitionEntries(t *testing.T) {
 			name:        "singles only",
 			entries:     []UploadEntry{s1, s2},
 			wantSingles: []UploadEntry{s1, s2},
-			wantSealed:  nil,
 		},
 		{
-			name:        "errors join sealed when no matched singles",
-			entries:     []UploadEntry{sealed1, errEntry},
-			wantSingles: nil,
-			wantSealed:  []UploadEntry{sealed1, errEntry},
+			name:         "errors go to notFound with sealed",
+			entries:      []UploadEntry{sealed1, errEntry},
+			wantSealed:   []UploadEntry{sealed1},
+			wantNotFound: []UploadEntry{errEntry},
 		},
 		{
-			name:        "errors stay with singles when singles present",
-			entries:     []UploadEntry{s1, errEntry},
-			wantSingles: []UploadEntry{s1, errEntry},
-			wantSealed:  nil,
+			name:         "errors go to notFound with singles",
+			entries:      []UploadEntry{s1, errEntry},
+			wantSingles:  []UploadEntry{s1},
+			wantNotFound: []UploadEntry{errEntry},
 		},
 		{
-			name:        "only errors go to singles",
-			entries:     []UploadEntry{errEntry},
-			wantSingles: []UploadEntry{errEntry},
-			wantSealed:  nil,
+			name:         "only errors go to notFound",
+			entries:      []UploadEntry{errEntry},
+			wantNotFound: []UploadEntry{errEntry},
 		},
 		{
-			name:        "errors stay with singles in mixed upload",
-			entries:     []UploadEntry{s1, sealed1, errEntry},
-			wantSingles: []UploadEntry{s1, errEntry},
-			wantSealed:  []UploadEntry{sealed1},
+			name:         "mixed with errors",
+			entries:      []UploadEntry{s1, sealed1, errEntry},
+			wantSingles:  []UploadEntry{s1},
+			wantSealed:   []UploadEntry{sealed1},
+			wantNotFound: []UploadEntry{errEntry},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			gotSingles, gotSealed := partitionEntries(tc.entries, sealedIds)
+			gotSingles, gotSealed, gotNotFound := partitionEntries(tc.entries, sealedIds)
 			if !reflect.DeepEqual(gotSingles, tc.wantSingles) {
 				t.Errorf("singles = %v, want %v", gotSingles, tc.wantSingles)
 			}
 			if !reflect.DeepEqual(gotSealed, tc.wantSealed) {
 				t.Errorf("sealed = %v, want %v", gotSealed, tc.wantSealed)
+			}
+			if !reflect.DeepEqual(gotNotFound, tc.wantNotFound) {
+				t.Errorf("notFound = %v, want %v", gotNotFound, tc.wantNotFound)
 			}
 		})
 	}

--- a/upload_test.go
+++ b/upload_test.go
@@ -1,9 +1,68 @@
 package main
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 )
+
+func TestPartitionEntries(t *testing.T) {
+	errEntry := UploadEntry{MismatchError: errors.New("not found")}
+	s1 := UploadEntry{CardId: "single1"}
+	s2 := UploadEntry{CardId: "single2"}
+	sealed1 := UploadEntry{CardId: "sealed1"}
+	sealedIds := []string{"sealed1", "sealed2"}
+
+	tests := []struct {
+		name        string
+		entries     []UploadEntry
+		wantSingles []UploadEntry
+		wantSealed  []UploadEntry
+	}{
+		{
+			name:        "mixed splits by membership",
+			entries:     []UploadEntry{s1, sealed1},
+			wantSingles: []UploadEntry{s1},
+			wantSealed:  []UploadEntry{sealed1},
+		},
+		{
+			name:        "singles only",
+			entries:     []UploadEntry{s1, s2},
+			wantSingles: []UploadEntry{s1, s2},
+			wantSealed:  nil,
+		},
+		{
+			name:        "errors join sealed when no matched singles",
+			entries:     []UploadEntry{sealed1, errEntry},
+			wantSingles: nil,
+			wantSealed:  []UploadEntry{sealed1, errEntry},
+		},
+		{
+			name:        "errors stay with singles when singles present",
+			entries:     []UploadEntry{s1, errEntry},
+			wantSingles: []UploadEntry{s1, errEntry},
+			wantSealed:  nil,
+		},
+		{
+			name:        "only errors go to singles",
+			entries:     []UploadEntry{errEntry},
+			wantSingles: []UploadEntry{errEntry},
+			wantSealed:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotSingles, gotSealed := partitionEntries(tc.entries, sealedIds)
+			if !reflect.DeepEqual(gotSingles, tc.wantSingles) {
+				t.Errorf("singles = %v, want %v", gotSingles, tc.wantSingles)
+			}
+			if !reflect.DeepEqual(gotSealed, tc.wantSealed) {
+				t.Errorf("sealed = %v, want %v", gotSealed, tc.wantSealed)
+			}
+		})
+	}
+}
 
 func TestFilterEnabledStores(t *testing.T) {
 	allowed := []string{"a", "b", "c"}


### PR DESCRIPTION
fixes #222 - adds a tabbed layout for uploader results (when applicable)

<img width="1405" height="350" alt="image" src="https://github.com/user-attachments/assets/fd4c7154-e4d4-4038-8179-a942160a4dd8" />

also introduces split-csv exporting when mixed results are present and the 'Get CSV' option is selected from the 'All' tab, while Singles/Sealed tabs export just those results respectively. TCGplayer CSV combines both lists on 'All' as they are exported with the same format

