### PR TITLE
Add server-side usage telemetry with admin dashboard

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -612,6 +612,22 @@ func Admin(w http.ResponseWriter, r *http.Request) {
 
 	pageVars.DisableChart = IsStashingInProgress()
 
+	if page == "usage" {
+		if ObservabilityDB != nil {
+			since := time.Now().AddDate(0, 0, -30)
+			includeBots := r.FormValue("bots") == "1"
+			ctx := r.Context()
+			dash := &UsageDashboard{Since: since, IncludeBots: includeBots}
+			dash.TopPages, _ = ObservabilityDB.TopPages(ctx, since, includeBots)
+			dash.ByTier, _ = ObservabilityDB.UsageByTier(ctx, since, includeBots)
+			dash.ByDevice, _ = ObservabilityDB.DeviceSplit(ctx, since, includeBots)
+			dash.SubViews, _ = ObservabilityDB.SubViewBreakdown(ctx, since, includeBots)
+			pageVars.UsageStats = dash
+		} else {
+			pageVars.InfoMessage = "Observability telemetry is not enabled"
+		}
+	}
+
 	render(w, "admin.html", pageVars)
 }
 

--- a/auth.go
+++ b/auth.go
@@ -435,6 +435,7 @@ func enforceSigning(next http.Handler) http.Handler {
 				}) {
 					_, noAuth := Config.ACL["Any"][nav.Name]
 					if noAuth {
+						recordPageHit(r)
 						noSigning(next).ServeHTTP(w, r)
 						return
 					}
@@ -577,6 +578,7 @@ func enforceSigning(next http.Handler) http.Handler {
 			}
 		}
 
+		recordPageHit(r)
 		gziphandler.GzipHandler(next).ServeHTTP(w, r)
 	})
 }

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/NYTimes/gziphandler"
 	"github.com/hashicorp/go-cleanhttp"
 	_ "github.com/lib/pq"
+	"github.com/mtgban/mtgban-website/observability"
 	"github.com/mtgban/mtgban-website/timeseries"
 	"github.com/mtgban/mtgban-website/userstate"
 
@@ -518,7 +519,8 @@ type ConfigType struct {
 	sourcePath string
 
 	SqlConfig       *timeseries.SqlConfig `json:"sql_config"`
-	UserStateConfig *userstate.SqlConfig  `json:"user_state_config"`
+	UserStateConfig     *userstate.SqlConfig  `json:"user_state_config"`
+	ObservabilityConfig *timeseries.SqlConfig `json:"observability_config"`
 }
 
 var DevMode bool
@@ -562,6 +564,9 @@ var NewNewspaperDB *sql.DB
 var PricesArchiveDB *timeseries.Client
 
 var UserStateDB *userstate.Client
+
+var ObservabilityDB *observability.Client
+var ObservabilityRecorder *observability.Recorder
 
 var GoogleDocsClient *http.Client
 
@@ -811,6 +816,16 @@ func openDBs() (err error) {
 			log.Println("error creating a user_state SQL client:", err)
 			return err
 		}
+	}
+
+	if Config.ObservabilityConfig == nil {
+		log.Println("no observability configuration set, telemetry won't be recorded")
+	} else if obsDB, oerr := observability.NewClient(*Config.ObservabilityConfig); oerr != nil {
+		log.Println("observability disabled, init failed:", oerr)
+	} else {
+		ObservabilityDB = obsDB
+		ObservabilityRecorder = observability.NewRecorder(obsDB)
+		log.Println("observability telemetry enabled")
 	}
 
 	if Config.NewNewspaperConfigLine == "" {
@@ -1142,6 +1157,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer func() {
 		ServerNotify("shutdown", "Server cleaning up...")
+		ObservabilityRecorder.Close()
 		cleanupDiscord()
 		cancel()
 	}()

--- a/main.go
+++ b/main.go
@@ -40,6 +40,16 @@ import (
 	_ "net/http/pprof"
 )
 
+// UsageDashboard holds the telemetry aggregates rendered on /admin?page=usage.
+type UsageDashboard struct {
+	Since       time.Time
+	IncludeBots bool
+	TopPages    []observability.PathAgg
+	ByTier      []observability.TierAgg
+	ByDevice    []observability.DeviceAgg
+	SubViews    []observability.PathAgg
+}
+
 type PageVars struct {
 	Pagination
 
@@ -70,6 +80,7 @@ type PageVars struct {
 	ErrorMessage   string
 	WarningMessage string
 	InfoMessage    string
+	UsageStats     *UsageDashboard
 
 	AllKeys        []string
 	CardQuantities map[string]int
@@ -1225,6 +1236,8 @@ func renderTemplateFiles(tmpl string, isMobile bool) (baseName string, files []s
 				"templates/partials/settings-modal.html",
 				"templates/partials/editions-picker.html",
 			)
+		case "admin.html":
+			files = append(files, "templates/partials/admin-usage.html")
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -518,7 +518,7 @@ type ConfigType struct {
 	// The location of the configuation file
 	sourcePath string
 
-	SqlConfig       *timeseries.SqlConfig `json:"sql_config"`
+	SqlConfig           *timeseries.SqlConfig `json:"sql_config"`
 	UserStateConfig     *userstate.SqlConfig  `json:"user_state_config"`
 	ObservabilityConfig *timeseries.SqlConfig `json:"observability_config"`
 }

--- a/observability/config.go
+++ b/observability/config.go
@@ -1,0 +1,62 @@
+// observability/config.go
+package observability
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/mtgban/mtgban-website/timeseries"
+
+	_ "github.com/lib/pq"
+)
+
+// SqlConfig reuses the timeseries shape so observability_config matches sql_config.
+type SqlConfig = timeseries.SqlConfig
+
+// Client wraps a Postgres connection pool for the telemetry tables.
+type Client struct {
+	db *sql.DB
+}
+
+// NewClient opens a pool, applies small pool caps, pings, and ensures the schema.
+func NewClient(cfg SqlConfig) (*Client, error) {
+	db, err := sql.Open("postgres", cfg.DSN())
+	if err != nil {
+		return nil, fmt.Errorf("observability: open: %w", err)
+	}
+
+	maxOpen := cfg.MaxOpenConns
+	if maxOpen <= 0 {
+		maxOpen = 5
+	}
+	maxIdle := cfg.MaxIdleConns
+	if maxIdle <= 0 {
+		maxIdle = 2
+	}
+	lifetime := time.Duration(cfg.ConnMaxLifetimeSeconds) * time.Second
+	if lifetime <= 0 {
+		lifetime = 30 * time.Minute
+	}
+	db.SetMaxOpenConns(maxOpen)
+	db.SetMaxIdleConns(maxIdle)
+	db.SetConnMaxLifetime(lifetime)
+
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("observability: ping: %w", err)
+	}
+	if err := ensureSchema(db); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("observability: ensure schema: %w", err)
+	}
+	return &Client{db: db}, nil
+}
+
+// Close shuts down the connection pool.
+func (c *Client) Close() error {
+	if c != nil && c.db != nil {
+		return c.db.Close()
+	}
+	return nil
+}

--- a/observability/event.go
+++ b/observability/event.go
@@ -1,0 +1,73 @@
+// observability/event.go
+package observability
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"time"
+
+	"github.com/mileusna/useragent"
+)
+
+// Event is one recorded page hit. Ts is left zero and filled by the DB default.
+type Event struct {
+	Ts      time.Time
+	Path    string
+	Tier    string
+	Device  string // "mobile" | "desktop"
+	Visitor string // sha256 of email, or "" for anonymous (stored NULL)
+	IsBot   bool
+}
+
+// pageSubviews lists the recognized ?page= values per route. Anything else
+// buckets to "<route>/other" so cardinality stays bounded.
+var pageSubviews = map[string]map[string]bool{
+	"newspaper": {
+		"combined_spike_score": true, "spike_score": true,
+		"greatest_increase_listings": true, "greatest_decrease_listings": true,
+		"greatest_increase_buylist": true, "greatest_decrease_buylist": true,
+		"syp": true, "options": true,
+	},
+	"sleepers": {
+		"bulk": true, "reprint": true, "mismatch": true,
+		"gap": true, "hotlist": true, "options": true,
+	},
+}
+
+// NormalizePath maps a request path plus its page param to a low-cardinality key.
+func NormalizePath(base, page string) string {
+	base = strings.Trim(base, "/")
+	if base == "" {
+		return "home"
+	}
+	subs, ok := pageSubviews[base]
+	if !ok {
+		return base
+	}
+	if page == "" {
+		return base + "/index"
+	}
+	if subs[page] {
+		return base + "/" + page
+	}
+	return base + "/other"
+}
+
+// HashVisitor returns sha256(lowercased trimmed email) hex, or "" for empty input.
+func HashVisitor(email string) string {
+	email = strings.ToLower(strings.TrimSpace(email))
+	if email == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(email))
+	return hex.EncodeToString(sum[:])
+}
+
+// IsBot reports whether the user-agent string looks like a crawler.
+func IsBot(userAgent string) bool {
+	if userAgent == "" {
+		return false
+	}
+	return useragent.Parse(userAgent).Bot
+}

--- a/observability/event_test.go
+++ b/observability/event_test.go
@@ -1,0 +1,48 @@
+// observability/event_test.go
+package observability
+
+import "testing"
+
+func TestNormalizePath(t *testing.T) {
+	cases := []struct{ base, page, want string }{
+		{"/newspaper", "", "newspaper/index"},
+		{"/newspaper", "spike_score", "newspaper/spike_score"},
+		{"/newspaper", "bogus", "newspaper/other"},
+		{"/sleepers", "hotlist", "sleepers/hotlist"},
+		{"/sleepers", "", "sleepers/index"},
+		{"/search", "options", "search"},
+		{"/arbit", "", "arbit"},
+		{"/", "", "home"},
+	}
+	for _, c := range cases {
+		if got := NormalizePath(c.base, c.page); got != c.want {
+			t.Errorf("NormalizePath(%q,%q)=%q want %q", c.base, c.page, got, c.want)
+		}
+	}
+}
+
+func TestHashVisitor(t *testing.T) {
+	if HashVisitor("") != "" {
+		t.Fatal("empty email must hash to empty string")
+	}
+	a := HashVisitor("User@Example.com ")
+	b := HashVisitor("user@example.com")
+	if a != b {
+		t.Fatalf("hash must be case/space insensitive: %q vs %q", a, b)
+	}
+	if len(a) != 64 {
+		t.Fatalf("sha256 hex must be 64 chars, got %d", len(a))
+	}
+}
+
+func TestIsBot(t *testing.T) {
+	if IsBot("") {
+		t.Fatal("empty UA is not a bot")
+	}
+	if !IsBot("Googlebot/2.1 (+http://www.google.com/bot.html)") {
+		t.Fatal("Googlebot must classify as bot")
+	}
+	if IsBot("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15") {
+		t.Fatal("a normal phone UA is not a bot")
+	}
+}

--- a/observability/recorder.go
+++ b/observability/recorder.go
@@ -38,6 +38,7 @@ type Recorder struct {
 	dropped int64
 	done    chan struct{}
 	wg      sync.WaitGroup
+	once    sync.Once
 }
 
 func newRecorder(s store, cfg recorderCfg) *Recorder {
@@ -86,7 +87,7 @@ func (r *Recorder) Close() error {
 	if r == nil {
 		return nil
 	}
-	close(r.done)
+	r.once.Do(func() { close(r.done) })
 	r.wg.Wait()
 	return nil
 }
@@ -115,7 +116,7 @@ func (r *Recorder) run() {
 				log.Println("observability: insert batch:", err)
 			}
 		}()
-		batch = batch[:0]
+		batch = batch[:0:0]
 	}
 
 	for {

--- a/observability/recorder.go
+++ b/observability/recorder.go
@@ -24,7 +24,7 @@ type recorderCfg struct {
 func defaultRecorderCfg() recorderCfg {
 	return recorderCfg{
 		bufferSize:      4096,
-		batchSize:       256,
+		batchSize:       256, // batchSize * 5 must stay < 65535 (Postgres param limit)
 		flushInterval:   5 * time.Second,
 		refreshInterval: time.Hour,
 	}
@@ -51,8 +51,9 @@ func newRecorder(s store, cfg recorderCfg) *Recorder {
 }
 
 func (r *Recorder) start() {
-	r.wg.Add(1)
-	go r.run()
+	r.wg.Add(2)
+	go r.runFlush()
+	go r.runRefresh()
 }
 
 // NewRecorder builds a Recorder with default config and starts its goroutine.
@@ -92,12 +93,10 @@ func (r *Recorder) Close() error {
 	return nil
 }
 
-func (r *Recorder) run() {
+func (r *Recorder) runFlush() {
 	defer r.wg.Done()
 	flushTicker := time.NewTicker(r.cfg.flushInterval)
-	refreshTicker := time.NewTicker(r.cfg.refreshInterval)
 	defer flushTicker.Stop()
-	defer refreshTicker.Stop()
 
 	batch := make([]Event, 0, r.cfg.batchSize)
 	flush := func() {
@@ -131,6 +130,29 @@ func (r *Recorder) run() {
 			if d := atomic.LoadInt64(&r.dropped); d > 0 {
 				log.Printf("observability: dropped %d events (buffer full)", d)
 			}
+		case <-r.done:
+			for {
+				select {
+				case ev := <-r.ch:
+					batch = append(batch, ev)
+					if len(batch) >= r.cfg.batchSize {
+						flush()
+					}
+				default:
+					flush()
+					return
+				}
+			}
+		}
+	}
+}
+
+func (r *Recorder) runRefresh() {
+	defer r.wg.Done()
+	refreshTicker := time.NewTicker(r.cfg.refreshInterval)
+	defer refreshTicker.Stop()
+	for {
+		select {
 		case <-refreshTicker.C:
 			func() {
 				defer func() {
@@ -145,18 +167,7 @@ func (r *Recorder) run() {
 				}
 			}()
 		case <-r.done:
-			for {
-				select {
-				case ev := <-r.ch:
-					batch = append(batch, ev)
-					if len(batch) >= r.cfg.batchSize {
-						flush()
-					}
-				default:
-					flush()
-					return
-				}
-			}
+			return
 		}
 	}
 }

--- a/observability/recorder.go
+++ b/observability/recorder.go
@@ -1,0 +1,161 @@
+package observability
+
+import (
+	"context"
+	"log"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// store is the subset of *Client the recorder needs (lets tests fake it).
+type store interface {
+	InsertBatch(ctx context.Context, evs []Event) error
+	RefreshRollup(ctx context.Context) error
+}
+
+type recorderCfg struct {
+	bufferSize      int
+	batchSize       int
+	flushInterval   time.Duration
+	refreshInterval time.Duration
+}
+
+func defaultRecorderCfg() recorderCfg {
+	return recorderCfg{
+		bufferSize:      4096,
+		batchSize:       256,
+		flushInterval:   5 * time.Second,
+		refreshInterval: time.Hour,
+	}
+}
+
+// Recorder buffers events and flushes them to the store off the request path.
+type Recorder struct {
+	ch      chan Event
+	store   store
+	cfg     recorderCfg
+	dropped int64
+	done    chan struct{}
+	wg      sync.WaitGroup
+}
+
+func newRecorder(s store, cfg recorderCfg) *Recorder {
+	return &Recorder{
+		ch:    make(chan Event, cfg.bufferSize),
+		store: s,
+		cfg:   cfg,
+		done:  make(chan struct{}),
+	}
+}
+
+func (r *Recorder) start() {
+	r.wg.Add(1)
+	go r.run()
+}
+
+// NewRecorder builds a Recorder with default config and starts its goroutine.
+func NewRecorder(s store) *Recorder {
+	r := newRecorder(s, defaultRecorderCfg())
+	r.start()
+	return r
+}
+
+// Record enqueues an event without blocking. A full buffer drops the event.
+func (r *Recorder) Record(ev Event) {
+	if r == nil {
+		return
+	}
+	select {
+	case r.ch <- ev:
+	default:
+		atomic.AddInt64(&r.dropped, 1)
+	}
+}
+
+// Dropped returns the number of events dropped due to a full buffer.
+func (r *Recorder) Dropped() int64 {
+	if r == nil {
+		return 0
+	}
+	return atomic.LoadInt64(&r.dropped)
+}
+
+// Close stops the goroutine after draining and flushing pending events.
+func (r *Recorder) Close() error {
+	if r == nil {
+		return nil
+	}
+	close(r.done)
+	r.wg.Wait()
+	return nil
+}
+
+func (r *Recorder) run() {
+	defer r.wg.Done()
+	flushTicker := time.NewTicker(r.cfg.flushInterval)
+	refreshTicker := time.NewTicker(r.cfg.refreshInterval)
+	defer flushTicker.Stop()
+	defer refreshTicker.Stop()
+
+	batch := make([]Event, 0, r.cfg.batchSize)
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		func() {
+			defer func() {
+				if p := recover(); p != nil {
+					log.Println("observability: flush panic:", p)
+				}
+			}()
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if err := r.store.InsertBatch(ctx, batch); err != nil {
+				log.Println("observability: insert batch:", err)
+			}
+		}()
+		batch = batch[:0]
+	}
+
+	for {
+		select {
+		case ev := <-r.ch:
+			batch = append(batch, ev)
+			if len(batch) >= r.cfg.batchSize {
+				flush()
+			}
+		case <-flushTicker.C:
+			flush()
+			if d := atomic.LoadInt64(&r.dropped); d > 0 {
+				log.Printf("observability: dropped %d events (buffer full)", d)
+			}
+		case <-refreshTicker.C:
+			func() {
+				defer func() {
+					if p := recover(); p != nil {
+						log.Println("observability: refresh panic:", p)
+					}
+				}()
+				ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+				defer cancel()
+				if err := r.store.RefreshRollup(ctx); err != nil {
+					log.Println("observability: refresh rollup:", err)
+				}
+			}()
+		case <-r.done:
+			for {
+				select {
+				case ev := <-r.ch:
+					batch = append(batch, ev)
+					if len(batch) >= r.cfg.batchSize {
+						flush()
+					}
+				default:
+					flush()
+					return
+				}
+			}
+		}
+	}
+}

--- a/observability/recorder_test.go
+++ b/observability/recorder_test.go
@@ -95,3 +95,13 @@ func TestNilRecorderSafe(t *testing.T) {
 		t.Fatal("nil Dropped must be 0")
 	}
 }
+
+func TestDoubleCloseNoPanic(t *testing.T) {
+	r := NewRecorder(&fakeStore{})
+	if err := r.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}

--- a/observability/recorder_test.go
+++ b/observability/recorder_test.go
@@ -8,9 +8,10 @@ import (
 )
 
 type fakeStore struct {
-	mu       sync.Mutex
-	inserted int
-	refresh  int
+	mu           sync.Mutex
+	inserted     int
+	refresh      int
+	refreshBlock chan struct{}
 }
 
 func (f *fakeStore) InsertBatch(ctx context.Context, evs []Event) error {
@@ -20,6 +21,10 @@ func (f *fakeStore) InsertBatch(ctx context.Context, evs []Event) error {
 	return nil
 }
 func (f *fakeStore) RefreshRollup(ctx context.Context) error {
+	// Block outside the lock so count() is never deadlocked by a held refresh.
+	if f.refreshBlock != nil {
+		<-f.refreshBlock
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.refresh++
@@ -104,4 +109,20 @@ func TestDoubleCloseNoPanic(t *testing.T) {
 	if err := r.Close(); err != nil {
 		t.Fatalf("second Close: %v", err)
 	}
+}
+
+func TestRefreshDoesNotStallFlush(t *testing.T) {
+	block := make(chan struct{})
+	fs := &fakeStore{refreshBlock: block}
+	r := newRecorder(fs, recorderCfg{bufferSize: 16, batchSize: 1, flushInterval: time.Hour, refreshInterval: 10 * time.Millisecond})
+	r.start()
+	defer func() {
+		close(block) // unblock the held refresh so Close can drain
+		r.Close()
+	}()
+	// Give the refresh ticker time to fire and block inside RefreshRollup.
+	time.Sleep(50 * time.Millisecond)
+	// Even with refresh blocked, a recorded event must still flush.
+	r.Record(Event{Path: "p"})
+	waitFor(t, 1, fs.count)
 }

--- a/observability/recorder_test.go
+++ b/observability/recorder_test.go
@@ -1,0 +1,97 @@
+package observability
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+type fakeStore struct {
+	mu       sync.Mutex
+	inserted int
+	refresh  int
+}
+
+func (f *fakeStore) InsertBatch(ctx context.Context, evs []Event) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.inserted += len(evs)
+	return nil
+}
+func (f *fakeStore) RefreshRollup(ctx context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.refresh++
+	return nil
+}
+func (f *fakeStore) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.inserted
+}
+
+func waitFor(t *testing.T, want int, get func() int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if get() >= want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d, got %d", want, get())
+}
+
+func TestRecordNonBlockingWhenFull(t *testing.T) {
+	// Build without starting the goroutine so nothing drains the channel.
+	r := newRecorder(&fakeStore{}, recorderCfg{bufferSize: 2, batchSize: 10, flushInterval: time.Hour, refreshInterval: time.Hour})
+	r.ch <- Event{}
+	r.ch <- Event{} // channel now full
+	done := make(chan struct{})
+	go func() { r.Record(Event{}); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Record blocked on a full buffer")
+	}
+	if r.Dropped() != 1 {
+		t.Fatalf("expected 1 dropped, got %d", r.Dropped())
+	}
+}
+
+func TestFlushOnBatchSize(t *testing.T) {
+	fs := &fakeStore{}
+	r := newRecorder(fs, recorderCfg{bufferSize: 16, batchSize: 3, flushInterval: time.Hour, refreshInterval: time.Hour})
+	r.start()
+	defer r.Close()
+	for i := 0; i < 3; i++ {
+		r.Record(Event{Path: "p"})
+	}
+	waitFor(t, 3, fs.count)
+}
+
+func TestCloseDrainsAndFlushes(t *testing.T) {
+	fs := &fakeStore{}
+	r := newRecorder(fs, recorderCfg{bufferSize: 16, batchSize: 100, flushInterval: time.Hour, refreshInterval: time.Hour})
+	r.start()
+	r.Record(Event{Path: "a"})
+	r.Record(Event{Path: "b"})
+	if err := r.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if fs.count() != 2 {
+		t.Fatalf("expected 2 flushed on close, got %d", fs.count())
+	}
+}
+
+func TestNilRecorderSafe(t *testing.T) {
+	var r *Recorder
+	r.Record(Event{}) // must not panic
+	if err := r.Close(); err != nil {
+		t.Fatalf("nil Close: %v", err)
+	}
+	if r.Dropped() != 0 {
+		t.Fatal("nil Dropped must be 0")
+	}
+}

--- a/observability/schema.go
+++ b/observability/schema.go
@@ -1,0 +1,37 @@
+// observability/schema.go
+package observability
+
+import "database/sql"
+
+// schemaStatements create the events table, its indexes, and the daily rollup
+// materialized view. Ordered: table, then indexes, then the view that reads it.
+var schemaStatements = []string{
+	`CREATE TABLE IF NOT EXISTS events (
+    id       bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    ts       timestamptz NOT NULL DEFAULT now(),
+    path     text        NOT NULL,
+    tier     text        NOT NULL,
+    device   text        NOT NULL,
+    visitor  text,
+    is_bot   boolean     NOT NULL DEFAULT false
+)`,
+	`CREATE INDEX IF NOT EXISTS idx_events_ts ON events (ts)`,
+	`CREATE INDEX IF NOT EXISTS idx_events_path_ts ON events (path, ts)`,
+	`CREATE MATERIALIZED VIEW IF NOT EXISTS usage_daily AS
+ SELECT date_trunc('day', ts)::date AS day, path, tier, device, is_bot,
+        count(*) AS hits, count(DISTINCT visitor) AS uniques
+ FROM events
+ GROUP BY 1,2,3,4,5`,
+	`CREATE UNIQUE INDEX IF NOT EXISTS usage_daily_pk
+ ON usage_daily (day, path, tier, device, is_bot)`,
+}
+
+// ensureSchema applies each statement in order. Idempotent (IF NOT EXISTS).
+func ensureSchema(db *sql.DB) error {
+	for _, stmt := range schemaStatements {
+		if _, err := db.Exec(stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/observability/store.go
+++ b/observability/store.go
@@ -1,0 +1,150 @@
+// observability/store.go
+package observability
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// InsertBatch writes events in one multi-row INSERT. ts uses the column default.
+// An empty Visitor is stored as NULL so count(DISTINCT visitor) ignores anon hits.
+func (c *Client) InsertBatch(ctx context.Context, evs []Event) error {
+	if len(evs) == 0 {
+		return nil
+	}
+	var b strings.Builder
+	b.WriteString("INSERT INTO events (path, tier, device, visitor, is_bot) VALUES ")
+	args := make([]any, 0, len(evs)*5)
+	for i, ev := range evs {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		n := i * 5
+		fmt.Fprintf(&b, "($%d,$%d,$%d,$%d,$%d)", n+1, n+2, n+3, n+4, n+5)
+		var visitor any
+		if ev.Visitor != "" {
+			visitor = ev.Visitor
+		}
+		args = append(args, ev.Path, ev.Tier, ev.Device, visitor, ev.IsBot)
+	}
+	_, err := c.db.ExecContext(ctx, b.String(), args...)
+	return err
+}
+
+// RefreshRollup recomputes usage_daily without locking it against readers.
+func (c *Client) RefreshRollup(ctx context.Context) error {
+	_, err := c.db.ExecContext(ctx, "REFRESH MATERIALIZED VIEW CONCURRENTLY usage_daily")
+	return err
+}
+
+// PathAgg is a per-path aggregate. Uniques is summed daily uniques (a
+// visitor-days approximation of range uniques), acceptable for the dashboard.
+type PathAgg struct {
+	Path    string
+	Hits    int64
+	Uniques int64
+}
+
+type TierAgg struct {
+	Tier    string
+	Hits    int64
+	Uniques int64
+}
+
+type DeviceAgg struct {
+	Path    string
+	Device  string
+	Hits    int64
+	Uniques int64
+}
+
+// TopPages returns paths ordered by hits since the given day.
+func (c *Client) TopPages(ctx context.Context, since time.Time, includeBots bool) ([]PathAgg, error) {
+	const q = `SELECT path, sum(hits), sum(uniques)
+FROM usage_daily
+WHERE day >= $1::date AND ($2 OR NOT is_bot)
+GROUP BY path ORDER BY sum(hits) DESC`
+	rows, err := c.db.QueryContext(ctx, q, since, includeBots)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []PathAgg
+	for rows.Next() {
+		var a PathAgg
+		if err := rows.Scan(&a.Path, &a.Hits, &a.Uniques); err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// UsageByTier returns hits/uniques grouped by membership tier.
+func (c *Client) UsageByTier(ctx context.Context, since time.Time, includeBots bool) ([]TierAgg, error) {
+	const q = `SELECT tier, sum(hits), sum(uniques)
+FROM usage_daily
+WHERE day >= $1::date AND ($2 OR NOT is_bot)
+GROUP BY tier ORDER BY sum(hits) DESC`
+	rows, err := c.db.QueryContext(ctx, q, since, includeBots)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []TierAgg
+	for rows.Next() {
+		var a TierAgg
+		if err := rows.Scan(&a.Tier, &a.Hits, &a.Uniques); err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// DeviceSplit returns hits/uniques grouped by path and device.
+func (c *Client) DeviceSplit(ctx context.Context, since time.Time, includeBots bool) ([]DeviceAgg, error) {
+	const q = `SELECT path, device, sum(hits), sum(uniques)
+FROM usage_daily
+WHERE day >= $1::date AND ($2 OR NOT is_bot)
+GROUP BY path, device ORDER BY path, device`
+	rows, err := c.db.QueryContext(ctx, q, since, includeBots)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []DeviceAgg
+	for rows.Next() {
+		var a DeviceAgg
+		if err := rows.Scan(&a.Path, &a.Device, &a.Hits, &a.Uniques); err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// SubViewBreakdown returns only newspaper/ and sleepers/ sub-view rows.
+func (c *Client) SubViewBreakdown(ctx context.Context, since time.Time, includeBots bool) ([]PathAgg, error) {
+	const q = `SELECT path, sum(hits), sum(uniques)
+FROM usage_daily
+WHERE day >= $1::date AND ($2 OR NOT is_bot)
+  AND (path LIKE 'newspaper/%' OR path LIKE 'sleepers/%')
+GROUP BY path ORDER BY sum(hits) DESC`
+	rows, err := c.db.QueryContext(ctx, q, since, includeBots)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []PathAgg
+	for rows.Next() {
+		var a PathAgg
+		if err := rows.Scan(&a.Path, &a.Hits, &a.Uniques); err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}

--- a/observability/store.go
+++ b/observability/store.go
@@ -10,6 +10,7 @@ import (
 
 // InsertBatch writes events in one multi-row INSERT. ts uses the column default.
 // An empty Visitor is stored as NULL so count(DISTINCT visitor) ignores anon hits.
+// Each event binds 5 params; callers must keep len(evs)*5 below Postgres's 65535 param limit (256 events = 1280 params).
 func (c *Client) InsertBatch(ctx context.Context, evs []Event) error {
 	if len(evs) == 0 {
 		return nil

--- a/observability/store.go
+++ b/observability/store.go
@@ -33,9 +33,12 @@ func (c *Client) InsertBatch(ctx context.Context, evs []Event) error {
 	return err
 }
 
-// RefreshRollup recomputes usage_daily without locking it against readers.
+// RefreshRollup recomputes usage_daily. Non-concurrent: it takes a brief
+// ACCESS EXCLUSIVE lock, acceptable for a tiny hourly rollup on an admin-only
+// dashboard, and avoids needing the TEMPORARY database privilege that a
+// CONCURRENTLY refresh requires.
 func (c *Client) RefreshRollup(ctx context.Context) error {
-	_, err := c.db.ExecContext(ctx, "REFRESH MATERIALIZED VIEW CONCURRENTLY usage_daily")
+	_, err := c.db.ExecContext(ctx, "REFRESH MATERIALIZED VIEW usage_daily")
 	return err
 }
 

--- a/observability/store_test.go
+++ b/observability/store_test.go
@@ -1,0 +1,79 @@
+// observability/store_test.go
+package observability
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// testClient connects to the observability DB described by env vars. It skips
+// unless OBSERVABILITY_TEST is set. Inserted rows use a sentinel path and are
+// deleted on cleanup so the test is safe to run against the shared DB.
+func testClient(t *testing.T) *Client {
+	t.Helper()
+	if os.Getenv("OBSERVABILITY_TEST") == "" {
+		t.Skip("OBSERVABILITY_TEST not set; skipping DB integration test")
+	}
+	port, _ := strconv.Atoi(getenv("OBS_PORT", "5432"))
+	cfg := SqlConfig{
+		Host:     getenv("OBS_HOST", "127.0.0.1"),
+		Port:     port,
+		User:     getenv("OBS_USER", "observability_app"),
+		Password: os.Getenv("OBS_PASS"),
+		DBName:   getenv("OBS_DB", "observability"),
+		SSLMode:  getenv("OBS_SSLMODE", "disable"),
+	}
+	c, err := NewClient(cfg)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() {
+		c.db.Exec("DELETE FROM events WHERE path LIKE '__test__%'")
+		c.Close()
+	})
+	return c
+}
+
+func getenv(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func TestIntegrationInsertRefreshRead(t *testing.T) {
+	c := testClient(t)
+	ctx := context.Background()
+
+	evs := []Event{
+		{Path: "__test__/a", Tier: "Vintage", Device: "desktop", Visitor: HashVisitor("x@y.com")},
+		{Path: "__test__/a", Tier: "Vintage", Device: "desktop", Visitor: HashVisitor("x@y.com")},
+		{Path: "__test__/a", Tier: "Any", Device: "mobile"},
+		{Path: "__test__/a", Tier: "Any", Device: "mobile", IsBot: true},
+	}
+	if err := c.InsertBatch(ctx, evs); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if err := c.RefreshRollup(ctx); err != nil {
+		t.Fatalf("RefreshRollup: %v", err)
+	}
+
+	since := time.Now().AddDate(0, 0, -1)
+	pages, err := c.TopPages(ctx, since, false)
+	if err != nil {
+		t.Fatalf("TopPages: %v", err)
+	}
+	var hits int64
+	for _, p := range pages {
+		if p.Path == "__test__/a" {
+			hits = p.Hits
+		}
+	}
+	// 3 human hits (bot excluded by default).
+	if hits != 3 {
+		t.Fatalf("expected 3 human hits for __test__/a, got %d", hits)
+	}
+}

--- a/telemetry.go
+++ b/telemetry.go
@@ -1,0 +1,36 @@
+// telemetry.go
+package main
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/mtgban/mtgban-website/observability"
+)
+
+// recordPageHit emits one telemetry event for a served gated request. It is a
+// no-op when telemetry is disabled and never blocks the request.
+func recordPageHit(r *http.Request) {
+	if ObservabilityRecorder == nil {
+		return
+	}
+	sig := getSignatureFromCookies(r)
+	if qs := r.FormValue("sig"); qs != "" {
+		sig = qs
+	}
+	device := "desktop"
+	if isMobileRequest(r) {
+		device = "mobile"
+	}
+	tier := GetParamFromSig(sig, "UserTier")
+	if tier == "" {
+		tier = "Any"
+	}
+	ObservabilityRecorder.Record(observability.Event{
+		Path:    observability.NormalizePath(strings.Trim(r.URL.Path, "/"), r.FormValue("page")),
+		Tier:    tier,
+		Device:  device,
+		Visitor: observability.HashVisitor(GetParamFromSig(sig, "UserEmail")),
+		IsBot:   observability.IsBot(r.UserAgent()),
+	})
+}

--- a/telemetry.go
+++ b/telemetry.go
@@ -8,10 +8,20 @@ import (
 	"github.com/mtgban/mtgban-website/observability"
 )
 
+// recordablePath reports whether a request path should produce a telemetry
+// event. API routes are excluded: some are wired through enforceSigning but
+// carry high-cardinality ids that must not enter the usage tables.
+func recordablePath(urlPath string) bool {
+	return !strings.HasPrefix(urlPath, "/api/")
+}
+
 // recordPageHit emits one telemetry event for a served gated request. It is a
 // no-op when telemetry is disabled and never blocks the request.
 func recordPageHit(r *http.Request) {
 	if ObservabilityRecorder == nil {
+		return
+	}
+	if !recordablePath(r.URL.Path) {
 		return
 	}
 	sig := getSignatureFromCookies(r)

--- a/telemetry_test.go
+++ b/telemetry_test.go
@@ -11,3 +11,23 @@ func TestRecordPageHitNilRecorderNoPanic(t *testing.T) {
 	req := httptest.NewRequest("GET", "/newspaper?page=spike_score", nil)
 	recordPageHit(req) // must return without panic
 }
+
+func TestRecordablePath(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/newspaper", true},
+		{"/search", true},
+		{"/", true},
+		{"/api/tcgplayer/lastsold/12345", false},
+		{"/api/cardmarket/foo", false},
+		{"/api/search/", false},
+		{"/api/prices/", false},
+	}
+	for _, c := range cases {
+		if got := recordablePath(c.path); got != c.want {
+			t.Errorf("recordablePath(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}

--- a/telemetry_test.go
+++ b/telemetry_test.go
@@ -1,0 +1,13 @@
+// telemetry_test.go
+package main
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRecordPageHitNilRecorderNoPanic(t *testing.T) {
+	ObservabilityRecorder = nil // default, but be explicit
+	req := httptest.NewRequest("GET", "/newspaper?page=spike_score", nil)
+	recordPageHit(req) // must return without panic
+}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -38,6 +38,8 @@
         <div class="admin-stat"><span class="sl">Stash</span><span class="sv">{{if .LastStash.IsZero}}not set{{else}}<time class="admin-localtime" datetime="{{.LastStash.UTC.Format "2006-01-02T15:04:05Z"}}">{{.LastStash.Format "Jan 02 15:04"}}</time>{{end}}</span></div>
     </div>
 
+    {{if .UsageStats}}{{template "admin-usage" .}}{{end}}
+
     <!-- Tabs -->
     <div class="admin-tabs">
         <button class="admin-tab{{if or (eq .Page "") (eq .Page "dashboard")}} active{{end}}" onclick="switchTab(this,'dashboard')">Dashboard</button>

--- a/templates/partials/admin-usage.html
+++ b/templates/partials/admin-usage.html
@@ -1,0 +1,58 @@
+<!-- templates/partials/admin-usage.html -->
+{{define "admin-usage"}}
+<div class="admin-usage">
+    <h2>Usage (last 30 days{{if .UsageStats.IncludeBots}}, incl. bots{{end}})</h2>
+    <p>
+        <a href="/admin?page=usage">Humans only</a> |
+        <a href="/admin?page=usage&amp;bots=1">Include bots</a>
+    </p>
+
+    <h3>Top pages</h3>
+    <table class="admin-usage-table">
+        <thead><tr><th>Path</th><th>Hits</th><th>Uniques</th></tr></thead>
+        <tbody>
+        {{range .UsageStats.TopPages}}
+            <tr><td>{{.Path}}</td><td>{{.Hits}}</td><td>{{.Uniques}}</td></tr>
+        {{else}}
+            <tr><td colspan="3">No data yet</td></tr>
+        {{end}}
+        </tbody>
+    </table>
+
+    <h3>Usage by tier</h3>
+    <table class="admin-usage-table">
+        <thead><tr><th>Tier</th><th>Hits</th><th>Uniques</th></tr></thead>
+        <tbody>
+        {{range .UsageStats.ByTier}}
+            <tr><td>{{.Tier}}</td><td>{{.Hits}}</td><td>{{.Uniques}}</td></tr>
+        {{else}}
+            <tr><td colspan="3">No data yet</td></tr>
+        {{end}}
+        </tbody>
+    </table>
+
+    <h3>Mobile vs desktop by page</h3>
+    <table class="admin-usage-table">
+        <thead><tr><th>Path</th><th>Device</th><th>Hits</th><th>Uniques</th></tr></thead>
+        <tbody>
+        {{range .UsageStats.ByDevice}}
+            <tr><td>{{.Path}}</td><td>{{.Device}}</td><td>{{.Hits}}</td><td>{{.Uniques}}</td></tr>
+        {{else}}
+            <tr><td colspan="4">No data yet</td></tr>
+        {{end}}
+        </tbody>
+    </table>
+
+    <h3>Newspaper &amp; sleepers sub-views</h3>
+    <table class="admin-usage-table">
+        <thead><tr><th>Path</th><th>Hits</th><th>Uniques</th></tr></thead>
+        <tbody>
+        {{range .UsageStats.SubViews}}
+            <tr><td>{{.Path}}</td><td>{{.Hits}}</td><td>{{.Uniques}}</td></tr>
+        {{else}}
+            <tr><td colspan="3">No data yet</td></tr>
+        {{end}}
+        </tbody>
+    </table>
+</div>
+{{end}}


### PR DESCRIPTION
## Summary

Adds server-side, tier-aware usage telemetry so we can see which pages and in-page views actually get used, broken down by membership tier and device (mobile vs desktop). The site already resolves each request's paid tier in the auth middleware, so this records `(path, tier, device, visitor, is_bot)` once per served gated request and surfaces the aggregates on a new admin dashboard. It answers questions browser analytics cannot, like "which tier uses which feature" and "which pages justify the paywall vs which are dead weight."

## How it works

- New `observability/` package (mirrors the `userstate/` pattern): a self-migrating Postgres client, an async recorder, and a small query layer.
- A single hook in `enforceSigning` records one event per served gated HTML page. It runs on the request goroutine but only does a non-blocking channel send, so it never adds request latency.
- A background goroutine batches events into multi-row inserts. A separate goroutine refreshes a `usage_daily` materialized-view rollup hourly.
- Admin dashboard at `/admin?page=usage` (behind the existing Admin ACL, no new route or auth) shows four tables: top pages, usage by tier, mobile vs desktop per page, and a newspaper/sleepers sub-view breakdown. Bots are excluded by default with a toggle to include them.

## Design decisions

- Server-side only. No frontend changes, no third-party analytics, no client beacons.
- Best-effort and non-fatal: a full buffer drops the event rather than blocking, and a missing or unreachable telemetry DB is logged while the site runs normally. Telemetry can never take the site down or slow a request.
- Privacy: `visitor` is a sha256 of the lowercased email (the same scheme `userstate` uses), NULL for anonymous users. No PII, no cookies.
- Bots are kept as an `is_bot` dimension (classified with the existing useragent parser) rather than dropped, so we can look at bot traffic or exclude it.
- Path cardinality is bounded: only the `page` sub-view is folded in for newspaper and sleepers, and unknown values bucket to `<route>/other`.
- Raw `events` are the source of truth (kept for now); `usage_daily` is a read cache for the dashboard.

## Scope

Included here: the gated HTML pages that flow through `enforceSigning`. Intentionally left for a later pass: the `/api/*` routes and the public Home page, client-side interactions (sort clicks, in-browser filtering), and retention/funnel analysis. The raw table preserves the data needed to add those later.

## Infrastructure

Uses a dedicated `observability` Postgres database and a least-privilege `observability_app` role (already provisioned). The schema (an `events` table plus the `usage_daily` rollup) self-migrates on startup, so there is no separate migration step. Connection config lives in `config.json` under `observability_config`.

## Known limitations and follow-ups

- Scaling: the hourly rollup fully recomputes over the entire `events` table. That is fine at current volume, but a future pass should move to an incremental last-1-2-day rollup and/or prune or partition raw events so the refresh cost stays bounded as history grows.
- Hot path: the hook parses the User-Agent twice and decodes the signed token a few times per request. It is cheap (no I/O, roughly 10 microseconds) but could be roughly halved by parsing each once.
- A narrow pre-existing auth quirk means a hidden-subpage "unauthorized" view records a benign extra hit (the underlying handler already serves that path anyway). Left as-is since the fix would touch unrelated auth flow.