### PR TITLE
Move usage telemetry into the admin Usage tab

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -612,20 +612,17 @@ func Admin(w http.ResponseWriter, r *http.Request) {
 
 	pageVars.DisableChart = IsStashingInProgress()
 
-	if page == "usage" {
-		if ObservabilityDB != nil {
-			since := time.Now().AddDate(0, 0, -30)
-			includeBots := r.FormValue("bots") == "1"
-			ctx := r.Context()
-			dash := &UsageDashboard{Since: since, IncludeBots: includeBots}
-			dash.TopPages, _ = ObservabilityDB.TopPages(ctx, since, includeBots)
-			dash.ByTier, _ = ObservabilityDB.UsageByTier(ctx, since, includeBots)
-			dash.ByDevice, _ = ObservabilityDB.DeviceSplit(ctx, since, includeBots)
-			dash.SubViews, _ = ObservabilityDB.SubViewBreakdown(ctx, since, includeBots)
-			pageVars.UsageStats = dash
-		} else {
-			pageVars.InfoMessage = "Observability telemetry is not enabled"
-		}
+	// Load on every admin view so the client-switched Usage tab is always populated.
+	if ObservabilityDB != nil {
+		since := time.Now().AddDate(0, 0, -30)
+		includeBots := r.FormValue("bots") == "1"
+		ctx := r.Context()
+		dash := &UsageDashboard{Since: since, IncludeBots: includeBots}
+		dash.TopPages, _ = ObservabilityDB.TopPages(ctx, since, includeBots)
+		dash.ByTier, _ = ObservabilityDB.UsageByTier(ctx, since, includeBots)
+		dash.ByDevice, _ = ObservabilityDB.DeviceSplit(ctx, since, includeBots)
+		dash.SubViews, _ = ObservabilityDB.SubViewBreakdown(ctx, since, includeBots)
+		pageVars.UsageStats = dash
 	}
 
 	render(w, "admin.html", pageVars)

--- a/css/admin.css
+++ b/css/admin.css
@@ -145,6 +145,8 @@
     white-space: nowrap;
 }
 .admin-table th.c { text-align: center; }
+.admin-table th.num, .admin-table td.num { text-align: right; }
+.admin-table th.num { width: 6em; }
 .admin-table td {
     padding: 7px 12px;
     border-bottom: 1px solid var(--border-subtle);

--- a/css/admin.css
+++ b/css/admin.css
@@ -162,6 +162,44 @@
     font-family: var(--font-mono);
     font-size: var(--text-sm);
 }
+/* ── Usage Tab ── */
+.admin-usage-bar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+.admin-usage-range {
+    font-size: var(--text-base);
+    color: var(--text-dim);
+}
+.admin-usage-toggle {
+    display: inline-flex;
+    margin-left: auto;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+}
+.admin-usage-toggle a {
+    padding: 5px 14px;
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--activetext);
+    text-decoration: none;
+    background: var(--surface-1);
+    transition: color 0.12s;
+}
+.admin-usage-toggle a:hover { color: var(--normal); }
+.admin-usage-toggle a.active {
+    color: var(--ainfo);
+    background: var(--surface-2);
+}
+.admin-usage-toggle a + a { border-left: 1px solid var(--border-subtle); }
+.admin-table td.admin-usage-empty {
+    color: var(--text-dim);
+    text-align: center;
+    font-style: italic;
+}
 /* ── Tools Tab ── */
 .tools-grid {
     display: grid;

--- a/css/admin.css
+++ b/css/admin.css
@@ -202,6 +202,13 @@
     text-align: center;
     font-style: italic;
 }
+.admin-usage-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px 20px;
+    align-items: start;
+}
+.admin-usage-grid .admin-section { margin-bottom: 0; }
 /* ── Tools Tab ── */
 .tools-grid {
     display: grid;
@@ -527,7 +534,7 @@
 
 /* ── Responsive ── */
 @media (max-width: 900px) {
-    .tools-grid, .people-grid { grid-template-columns: 1fr; }
+    .tools-grid, .people-grid, .admin-usage-grid { grid-template-columns: 1fr; }
     .admin-status-bar { gap: 10px; }
 }
 @media (max-width: 640px) {

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -38,11 +38,10 @@
         <div class="admin-stat"><span class="sl">Stash</span><span class="sv">{{if .LastStash.IsZero}}not set{{else}}<time class="admin-localtime" datetime="{{.LastStash.UTC.Format "2006-01-02T15:04:05Z"}}">{{.LastStash.Format "Jan 02 15:04"}}</time>{{end}}</span></div>
     </div>
 
-    {{if .UsageStats}}{{template "admin-usage" .}}{{end}}
-
     <!-- Tabs -->
     <div class="admin-tabs">
         <button class="admin-tab{{if or (eq .Page "") (eq .Page "dashboard")}} active{{end}}" onclick="switchTab(this,'dashboard')">Dashboard</button>
+        <button class="admin-tab{{if eq .Page "usage"}} active{{end}}" onclick="switchTab(this,'usage')">Usage</button>
         <button class="admin-tab{{if eq .Page "people"}} active{{end}}" onclick="switchTab(this,'people')">People</button>
         <button class="admin-tab{{if eq .Page "config"}} active{{end}}" onclick="switchTab(this,'config')">Config</button>
         <button class="admin-tab{{if eq .Page "checkpoints"}} active{{end}}" onclick="switchTab(this,'checkpoints')">Checkpoints</button>
@@ -139,6 +138,13 @@
         </div>
         {{end}}
 
+    </div>
+
+    <!-- ═══════════════════════
+         USAGE
+         ═══════════════════════ -->
+    <div class="admin-panel{{if eq .Page "usage"}} active{{end}}" id="panel-usage">
+        {{template "admin-usage" .}}
     </div>
 
     <!-- ═══════════════════════

--- a/templates/partials/admin-usage.html
+++ b/templates/partials/admin-usage.html
@@ -1,58 +1,88 @@
-<!-- templates/partials/admin-usage.html -->
 {{define "admin-usage"}}
-<div class="admin-usage">
-    <h2>Usage (last 30 days{{if .UsageStats.IncludeBots}}, incl. bots{{end}})</h2>
-    <p>
-        <a href="/admin?page=usage">Humans only</a> |
-        <a href="/admin?page=usage&amp;bots=1">Include bots</a>
-    </p>
+{{if .UsageStats}}
+<div class="admin-usage-bar">
+    <span class="admin-usage-range">Last 30 days{{if .UsageStats.IncludeBots}} &middot; including bots{{end}}</span>
+    <div class="admin-usage-toggle">
+        <a href="?page=usage"{{if not .UsageStats.IncludeBots}} class="active"{{end}}>Humans</a>
+        <a href="?page=usage&amp;bots=1"{{if .UsageStats.IncludeBots}} class="active"{{end}}>Include bots</a>
+    </div>
+</div>
 
-    <h3>Top pages</h3>
-    <table class="admin-usage-table">
-        <thead><tr><th>Path</th><th>Hits</th><th>Uniques</th></tr></thead>
+<div class="admin-section">
+    <div class="admin-section-header">
+        <h2>Top pages</h2>
+        <span class="count">{{len .UsageStats.TopPages}} paths</span>
+    </div>
+    <div class="admin-table-wrap">
+    <table class="table-data admin-table">
+        <thead><tr><th>Path</th><th class="c">Hits</th><th class="c">Uniques</th></tr></thead>
         <tbody>
         {{range .UsageStats.TopPages}}
-            <tr><td>{{.Path}}</td><td>{{.Hits}}</td><td>{{.Uniques}}</td></tr>
+            <tr><td class="admin-mono">{{.Path}}</td><td class="c admin-mono">{{.Hits}}</td><td class="c admin-mono">{{.Uniques}}</td></tr>
         {{else}}
-            <tr><td colspan="3">No data yet</td></tr>
+            <tr><td colspan="3" class="admin-usage-empty">No data yet</td></tr>
         {{end}}
         </tbody>
     </table>
+    </div>
+</div>
 
-    <h3>Usage by tier</h3>
-    <table class="admin-usage-table">
-        <thead><tr><th>Tier</th><th>Hits</th><th>Uniques</th></tr></thead>
+<div class="admin-section">
+    <div class="admin-section-header">
+        <h2>Usage by tier</h2>
+        <span class="count">{{len .UsageStats.ByTier}} tiers</span>
+    </div>
+    <div class="admin-table-wrap">
+    <table class="table-data admin-table">
+        <thead><tr><th>Tier</th><th class="c">Hits</th><th class="c">Uniques</th></tr></thead>
         <tbody>
         {{range .UsageStats.ByTier}}
-            <tr><td>{{.Tier}}</td><td>{{.Hits}}</td><td>{{.Uniques}}</td></tr>
+            <tr><td>{{.Tier}}</td><td class="c admin-mono">{{.Hits}}</td><td class="c admin-mono">{{.Uniques}}</td></tr>
         {{else}}
-            <tr><td colspan="3">No data yet</td></tr>
+            <tr><td colspan="3" class="admin-usage-empty">No data yet</td></tr>
         {{end}}
         </tbody>
     </table>
+    </div>
+</div>
 
-    <h3>Mobile vs desktop by page</h3>
-    <table class="admin-usage-table">
-        <thead><tr><th>Path</th><th>Device</th><th>Hits</th><th>Uniques</th></tr></thead>
+<div class="admin-section">
+    <div class="admin-section-header">
+        <h2>Mobile vs desktop by page</h2>
+    </div>
+    <div class="admin-table-wrap">
+    <table class="table-data admin-table">
+        <thead><tr><th>Path</th><th>Device</th><th class="c">Hits</th><th class="c">Uniques</th></tr></thead>
         <tbody>
         {{range .UsageStats.ByDevice}}
-            <tr><td>{{.Path}}</td><td>{{.Device}}</td><td>{{.Hits}}</td><td>{{.Uniques}}</td></tr>
+            <tr><td class="admin-mono">{{.Path}}</td><td>{{.Device}}</td><td class="c admin-mono">{{.Hits}}</td><td class="c admin-mono">{{.Uniques}}</td></tr>
         {{else}}
-            <tr><td colspan="4">No data yet</td></tr>
+            <tr><td colspan="4" class="admin-usage-empty">No data yet</td></tr>
         {{end}}
         </tbody>
     </table>
+    </div>
+</div>
 
-    <h3>Newspaper &amp; sleepers sub-views</h3>
-    <table class="admin-usage-table">
-        <thead><tr><th>Path</th><th>Hits</th><th>Uniques</th></tr></thead>
+<div class="admin-section">
+    <div class="admin-section-header">
+        <h2>Newspaper &amp; sleepers sub-views</h2>
+        <span class="count">{{len .UsageStats.SubViews}} views</span>
+    </div>
+    <div class="admin-table-wrap">
+    <table class="table-data admin-table">
+        <thead><tr><th>Path</th><th class="c">Hits</th><th class="c">Uniques</th></tr></thead>
         <tbody>
         {{range .UsageStats.SubViews}}
-            <tr><td>{{.Path}}</td><td>{{.Hits}}</td><td>{{.Uniques}}</td></tr>
+            <tr><td class="admin-mono">{{.Path}}</td><td class="c admin-mono">{{.Hits}}</td><td class="c admin-mono">{{.Uniques}}</td></tr>
         {{else}}
-            <tr><td colspan="3">No data yet</td></tr>
+            <tr><td colspan="3" class="admin-usage-empty">No data yet</td></tr>
         {{end}}
         </tbody>
     </table>
+    </div>
 </div>
+{{else}}
+<div class="admin-msg">Observability telemetry is not enabled.</div>
+{{end}}
 {{end}}

--- a/templates/partials/admin-usage.html
+++ b/templates/partials/admin-usage.html
@@ -8,6 +8,7 @@
     </div>
 </div>
 
+<div class="admin-usage-grid">
 <div class="admin-section">
     <div class="admin-section-header">
         <h2>Top pages</h2>
@@ -81,6 +82,7 @@
         </tbody>
     </table>
     </div>
+</div>
 </div>
 {{else}}
 <div class="admin-msg">Observability telemetry is not enabled.</div>

--- a/templates/partials/admin-usage.html
+++ b/templates/partials/admin-usage.html
@@ -15,10 +15,10 @@
     </div>
     <div class="admin-table-wrap">
     <table class="table-data admin-table">
-        <thead><tr><th>Path</th><th class="c">Hits</th><th class="c">Uniques</th></tr></thead>
+        <thead><tr><th>Path</th><th class="num">Hits</th><th class="num">Uniques</th></tr></thead>
         <tbody>
         {{range .UsageStats.TopPages}}
-            <tr><td class="admin-mono">{{.Path}}</td><td class="c admin-mono">{{.Hits}}</td><td class="c admin-mono">{{.Uniques}}</td></tr>
+            <tr><td class="admin-mono">{{.Path}}</td><td class="num admin-mono">{{.Hits}}</td><td class="num admin-mono">{{.Uniques}}</td></tr>
         {{else}}
             <tr><td colspan="3" class="admin-usage-empty">No data yet</td></tr>
         {{end}}
@@ -34,10 +34,10 @@
     </div>
     <div class="admin-table-wrap">
     <table class="table-data admin-table">
-        <thead><tr><th>Tier</th><th class="c">Hits</th><th class="c">Uniques</th></tr></thead>
+        <thead><tr><th>Tier</th><th class="num">Hits</th><th class="num">Uniques</th></tr></thead>
         <tbody>
         {{range .UsageStats.ByTier}}
-            <tr><td>{{.Tier}}</td><td class="c admin-mono">{{.Hits}}</td><td class="c admin-mono">{{.Uniques}}</td></tr>
+            <tr><td>{{.Tier}}</td><td class="num admin-mono">{{.Hits}}</td><td class="num admin-mono">{{.Uniques}}</td></tr>
         {{else}}
             <tr><td colspan="3" class="admin-usage-empty">No data yet</td></tr>
         {{end}}
@@ -52,10 +52,10 @@
     </div>
     <div class="admin-table-wrap">
     <table class="table-data admin-table">
-        <thead><tr><th>Path</th><th>Device</th><th class="c">Hits</th><th class="c">Uniques</th></tr></thead>
+        <thead><tr><th>Path</th><th>Device</th><th class="num">Hits</th><th class="num">Uniques</th></tr></thead>
         <tbody>
         {{range .UsageStats.ByDevice}}
-            <tr><td class="admin-mono">{{.Path}}</td><td>{{.Device}}</td><td class="c admin-mono">{{.Hits}}</td><td class="c admin-mono">{{.Uniques}}</td></tr>
+            <tr><td class="admin-mono">{{.Path}}</td><td>{{.Device}}</td><td class="num admin-mono">{{.Hits}}</td><td class="num admin-mono">{{.Uniques}}</td></tr>
         {{else}}
             <tr><td colspan="4" class="admin-usage-empty">No data yet</td></tr>
         {{end}}
@@ -71,10 +71,10 @@
     </div>
     <div class="admin-table-wrap">
     <table class="table-data admin-table">
-        <thead><tr><th>Path</th><th class="c">Hits</th><th class="c">Uniques</th></tr></thead>
+        <thead><tr><th>Path</th><th class="num">Hits</th><th class="num">Uniques</th></tr></thead>
         <tbody>
         {{range .UsageStats.SubViews}}
-            <tr><td class="admin-mono">{{.Path}}</td><td class="c admin-mono">{{.Hits}}</td><td class="c admin-mono">{{.Uniques}}</td></tr>
+            <tr><td class="admin-mono">{{.Path}}</td><td class="num admin-mono">{{.Hits}}</td><td class="num admin-mono">{{.Uniques}}</td></tr>
         {{else}}
             <tr><td colspan="3" class="admin-usage-empty">No data yet</td></tr>
         {{end}}


### PR DESCRIPTION
## Summary

Moves the usage telemetry dashboard into the admin page's existing tabbed layout. Previously it rendered as an unstyled block wedged between the status banner and the tab bar. Now it is a proper Usage tab that matches the styling of the other admin tabs.

## Changes

- Adds a Usage tab to the admin tab row (Dashboard, Usage, People, Config, ...) with a matching panel, and removes the misplaced standalone block.
- Loads usage data on every admin view rather than only on `?page=usage`, so the tab populates through the existing client-side tab switch just like Dashboard and People.
- Rebuilds the four tables (Top pages, Usage by tier, Mobile vs desktop by page, Newspaper and sleepers sub-views) with the shared admin table components (section headers with counts, `table-data admin-table` striping, mono cells).
- Lays the four tables out in a 2x2 grid that collapses to a single column under 900px, matching the People and Tools grids.
- Right-aligns and tightens the numeric columns so values line up under their headers.
- Replaces the bare Humans / Include bots text links with a styled toggle.

## Notes

- Presentation only. No change to data collection or the observability package.
- Desktop admin only; the mobile admin template does not include the usage panel.


<img width="2560" height="1360" alt="image" src="https://github.com/user-attachments/assets/c0342fae-8451-440a-9e5a-f2d757a5992b" />
