### PR TITLE
observability: recycle idle DB connections to avoid stale-connection write failures

### DIFF
--- a/observability/config.go
+++ b/observability/config.go
@@ -41,6 +41,8 @@ func NewClient(cfg SqlConfig) (*Client, error) {
 	db.SetMaxOpenConns(maxOpen)
 	db.SetMaxIdleConns(maxIdle)
 	db.SetConnMaxLifetime(lifetime)
+	// Recycle idle conns before a NAT or firewall can silently drop them.
+	db.SetConnMaxIdleTime(time.Minute)
 
 	if err := db.Ping(); err != nil {
 		db.Close()


### PR DESCRIPTION
## Summary

The telemetry recorder's background flush occasionally failed with a TCP read timeout (`wsarecv` on Windows) when a pooled Postgres connection had gone stale:

```
observability: insert batch: read tcp ...->146.190.132.126:5432: wsarecv: ... connected host has failed to respond.
```

During quiet periods there are no events to flush, so a pooled connection can sit idle for minutes, and a NAT or firewall on the path silently drops it. The next flush then checks out that dead connection and the read times out.

This was already handled safely (the recorder logs the error, drops that one batch, and the app keeps running), but the batch of events is lost and the log is noisy.

## Fix

Set a short `ConnMaxIdleTime` (60s) on the observability pool. `database/sql` discards an over-idle connection on checkout and opens a fresh one, so the recorder never hands a query to a connection the network has already killed. The existing 30-minute `ConnMaxLifetime` is unchanged.

## Notes

- The same pool setup exists in the `userstate` and `timeseries` clients. They are used more frequently so are far less likely to sit idle long enough to go stale, but the same one-liner applies if they ever show it.
