### PR TITLE
screener: fix lagging metrics (e.g. Sealed EV) returning no movers

### DIFF
--- a/timeseries/movers.go
+++ b/timeseries/movers.go
@@ -22,8 +22,11 @@ func (c *Client) GetMovers(ctx context.Context, datasetIndex int, windowDays int
 
 	// Resolve both dates first so the join can use literal-date index equality;
 	// folding the date lookups into the join degrades to a ~40x slower plan.
+	// Anchor to the selected column: a lagging metric (e.g. sealed EV, filled a
+	// day after singles) has no data on the global latest date.
 	var latest sql.NullTime
-	if err := c.db.QueryRowContext(ctx, `SELECT max(date) FROM product_prices`).Scan(&latest); err != nil {
+	if err := c.db.QueryRowContext(ctx,
+		fmt.Sprintf(`SELECT max(date) FROM product_prices WHERE %s > 0`, column)).Scan(&latest); err != nil {
 		return nil, err
 	}
 	if !latest.Valid {
@@ -34,7 +37,7 @@ func (c *Client) GetMovers(ctx context.Context, datasetIndex int, windowDays int
 
 	var prior sql.NullTime
 	if err := c.db.QueryRowContext(ctx,
-		`SELECT max(date) FROM product_prices WHERE date <= $1::date`, targetStr).Scan(&prior); err != nil {
+		fmt.Sprintf(`SELECT max(date) FROM product_prices WHERE date <= $1::date AND %s > 0`, column), targetStr).Scan(&prior); err != nil {
 		return nil, err
 	}
 	if !prior.Valid {

--- a/timeseries/movers_test.go
+++ b/timeseries/movers_test.go
@@ -1,0 +1,58 @@
+package timeseries
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"testing"
+)
+
+func getenvOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+// moversTestClient connects to the price DB described by env vars, skipping
+// unless TIMESERIES_TEST is set.
+func moversTestClient(t *testing.T) *Client {
+	t.Helper()
+	if os.Getenv("TIMESERIES_TEST") == "" {
+		t.Skip("TIMESERIES_TEST not set; skipping DB integration test")
+	}
+	port, _ := strconv.Atoi(getenvOr("TS_PORT", "5432"))
+	cfg := SqlConfig{
+		Host:     getenvOr("TS_HOST", "127.0.0.1"),
+		Port:     port,
+		User:     getenvOr("TS_USER", "mtgelmo666"),
+		Password: os.Getenv("TS_PASS"),
+		DBName:   getenvOr("TS_DB", "card_prices"),
+		SSLMode:  getenvOr("TS_SSLMODE", "require"),
+		ReadOnly: true,
+	}
+	c, err := NewClient(cfg)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	return c
+}
+
+// TestGetMoversAnchorsToColumnLatest guards the sealed-EV date-anchor bug: a
+// metric that has data must return movers even when its column lags the global
+// latest date. Index 8 (sealed EV) lags the singles pull by a day; index 2
+// (tcgplayer low) does not. Before the fix, index 8 returned zero.
+func TestGetMoversAnchorsToColumnLatest(t *testing.T) {
+	c := moversTestClient(t)
+	ctx := context.Background()
+	for _, idx := range []int{2, 8} {
+		rows, err := c.GetMovers(ctx, idx, 90, 0, 0)
+		if err != nil {
+			t.Fatalf("GetMovers(%d): %v", idx, err)
+		}
+		if len(rows) == 0 {
+			t.Errorf("GetMovers(%d) returned 0 movers; a metric with data must return some", idx)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the Price Movers Screener returning "No cards match" for metrics whose column lags the newest price date, most visibly Sealed EV (TCG Low).

## Root cause

`GetMovers` (`timeseries/movers.go`) anchored both the current and prior comparison dates to the global `max(date)` in `product_prices`. Sealed EV is populated a day after the singles pull, so on the newest date its column is empty: the current-day CTE matched nothing and the join returned zero rows. The bug was intermittent, only "working" on days when the sealed EV job had caught up to the singles data.

## Fix

Anchor both date lookups to the selected metric's column: `max(date) ... WHERE <column> > 0` for the current date, and the newest date on or before `(latest - window)` that also has that column for the prior date. `<column>` is the hard-coded `columnForDataset` value, so it stays safe to interpolate. Normal metrics are unaffected (their latest equals the global latest); lagging or sparse metrics now land on a date that actually has data.

## Verification

Added an env-gated integration test (`timeseries/movers_test.go`, gated on `TIMESERIES_TEST`) that calls the real `GetMovers` against the price DB. Index 8 (Sealed EV) now returns movers where it previously returned zero; index 2 (TCGplayer Low, singles) is unchanged. `go build` and `go vet` are clean, and the test skips without the env flag.

## Note

This does not change the Type filter. Sealed EV is a sealed-only metric, so with Type = Singles it correctly returns nothing; select Type = Sealed to see results.
