### PR TITLE
observability: per-instance dashboards and accurate uniques

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -617,11 +617,11 @@ func Admin(w http.ResponseWriter, r *http.Request) {
 		since := time.Now().AddDate(0, 0, -30)
 		includeBots := r.FormValue("bots") == "1"
 		ctx := r.Context()
-		dash := &UsageDashboard{Since: since, IncludeBots: includeBots}
-		dash.TopPages, _ = ObservabilityDB.TopPages(ctx, since, includeBots)
-		dash.ByTier, _ = ObservabilityDB.UsageByTier(ctx, since, includeBots)
-		dash.ByDevice, _ = ObservabilityDB.DeviceSplit(ctx, since, includeBots)
-		dash.SubViews, _ = ObservabilityDB.SubViewBreakdown(ctx, since, includeBots)
+		dash := &UsageDashboard{Since: since, IncludeBots: includeBots, Instance: observabilityInstance}
+		dash.TopPages, _ = ObservabilityDB.TopPages(ctx, since, includeBots, observabilityInstance)
+		dash.ByTier, _ = ObservabilityDB.UsageByTier(ctx, since, includeBots, observabilityInstance)
+		dash.ByDevice, _ = ObservabilityDB.DeviceSplit(ctx, since, includeBots, observabilityInstance)
+		dash.SubViews, _ = ObservabilityDB.SubViewBreakdown(ctx, since, includeBots, observabilityInstance)
 		pageVars.UsageStats = dash
 	}
 

--- a/main.go
+++ b/main.go
@@ -832,10 +832,12 @@ func openDBs() (err error) {
 		}
 	}
 
-	observabilityInstance = resolveInstanceName(Config.InstanceName)
+	observabilityInstance = Config.InstanceName
 
 	if Config.ObservabilityConfig == nil {
 		log.Println("no observability configuration set, telemetry won't be recorded")
+	} else if observabilityInstance == "" {
+		log.Println("observability disabled: instance_name not set in config")
 	} else if obsDB, oerr := observability.NewClient(*Config.ObservabilityConfig); oerr != nil {
 		log.Println("observability disabled, init failed:", oerr)
 	} else {

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ import (
 type UsageDashboard struct {
 	Since       time.Time
 	IncludeBots bool
+	Instance    string
 	TopPages    []observability.PathAgg
 	ByTier      []observability.TierAgg
 	ByDevice    []observability.DeviceAgg

--- a/main.go
+++ b/main.go
@@ -533,6 +533,7 @@ type ConfigType struct {
 	SqlConfig           *timeseries.SqlConfig `json:"sql_config"`
 	UserStateConfig     *userstate.SqlConfig  `json:"user_state_config"`
 	ObservabilityConfig *timeseries.SqlConfig `json:"observability_config"`
+	InstanceName        string                `json:"instance_name"`
 }
 
 var DevMode bool
@@ -829,6 +830,8 @@ func openDBs() (err error) {
 			return err
 		}
 	}
+
+	observabilityInstance = resolveInstanceName(Config.InstanceName)
 
 	if Config.ObservabilityConfig == nil {
 		log.Println("no observability configuration set, telemetry won't be recorded")

--- a/observability/event.go
+++ b/observability/event.go
@@ -12,12 +12,13 @@ import (
 
 // Event is one recorded page hit. Ts is left zero and filled by the DB default.
 type Event struct {
-	Ts      time.Time
-	Path    string
-	Tier    string
-	Device  string // "mobile" | "desktop"
-	Visitor string // sha256 of email, or "" for anonymous (stored NULL)
-	IsBot   bool
+	Ts       time.Time
+	Path     string
+	Tier     string
+	Device   string // "mobile" | "desktop"
+	Visitor  string // sha256 of email, or "" for anonymous (stored NULL)
+	IsBot    bool
+	Instance string // deployment instance (main/beta/lorcana)
 }
 
 // pageSubviews lists the recognized ?page= values per route. Anything else

--- a/observability/recorder.go
+++ b/observability/recorder.go
@@ -24,7 +24,7 @@ type recorderCfg struct {
 func defaultRecorderCfg() recorderCfg {
 	return recorderCfg{
 		bufferSize:      4096,
-		batchSize:       256, // batchSize * 5 must stay < 65535 (Postgres param limit)
+		batchSize:       256, // batchSize * 6 must stay < 65535 (Postgres param limit)
 		flushInterval:   5 * time.Second,
 		refreshInterval: time.Hour,
 	}

--- a/observability/recorder.go
+++ b/observability/recorder.go
@@ -11,22 +11,19 @@ import (
 // store is the subset of *Client the recorder needs (lets tests fake it).
 type store interface {
 	InsertBatch(ctx context.Context, evs []Event) error
-	RefreshRollup(ctx context.Context) error
 }
 
 type recorderCfg struct {
-	bufferSize      int
-	batchSize       int
-	flushInterval   time.Duration
-	refreshInterval time.Duration
+	bufferSize    int
+	batchSize     int
+	flushInterval time.Duration
 }
 
 func defaultRecorderCfg() recorderCfg {
 	return recorderCfg{
-		bufferSize:      4096,
-		batchSize:       256, // batchSize * 6 must stay < 65535 (Postgres param limit)
-		flushInterval:   5 * time.Second,
-		refreshInterval: time.Hour,
+		bufferSize:    4096,
+		batchSize:     256, // batchSize * 6 must stay < 65535 (Postgres param limit)
+		flushInterval: 5 * time.Second,
 	}
 }
 
@@ -51,9 +48,8 @@ func newRecorder(s store, cfg recorderCfg) *Recorder {
 }
 
 func (r *Recorder) start() {
-	r.wg.Add(2)
+	r.wg.Add(1)
 	go r.runFlush()
-	go r.runRefresh()
 }
 
 // NewRecorder builds a Recorder with default config and starts its goroutine.
@@ -143,31 +139,6 @@ func (r *Recorder) runFlush() {
 					return
 				}
 			}
-		}
-	}
-}
-
-func (r *Recorder) runRefresh() {
-	defer r.wg.Done()
-	refreshTicker := time.NewTicker(r.cfg.refreshInterval)
-	defer refreshTicker.Stop()
-	for {
-		select {
-		case <-refreshTicker.C:
-			func() {
-				defer func() {
-					if p := recover(); p != nil {
-						log.Println("observability: refresh panic:", p)
-					}
-				}()
-				ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-				defer cancel()
-				if err := r.store.RefreshRollup(ctx); err != nil {
-					log.Println("observability: refresh rollup:", err)
-				}
-			}()
-		case <-r.done:
-			return
 		}
 	}
 }

--- a/observability/recorder_test.go
+++ b/observability/recorder_test.go
@@ -8,26 +8,14 @@ import (
 )
 
 type fakeStore struct {
-	mu           sync.Mutex
-	inserted     int
-	refresh      int
-	refreshBlock chan struct{}
+	mu       sync.Mutex
+	inserted int
 }
 
 func (f *fakeStore) InsertBatch(ctx context.Context, evs []Event) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.inserted += len(evs)
-	return nil
-}
-func (f *fakeStore) RefreshRollup(ctx context.Context) error {
-	// Block outside the lock so count() is never deadlocked by a held refresh.
-	if f.refreshBlock != nil {
-		<-f.refreshBlock
-	}
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.refresh++
 	return nil
 }
 func (f *fakeStore) count() int {
@@ -50,7 +38,7 @@ func waitFor(t *testing.T, want int, get func() int) {
 
 func TestRecordNonBlockingWhenFull(t *testing.T) {
 	// Build without starting the goroutine so nothing drains the channel.
-	r := newRecorder(&fakeStore{}, recorderCfg{bufferSize: 2, batchSize: 10, flushInterval: time.Hour, refreshInterval: time.Hour})
+	r := newRecorder(&fakeStore{}, recorderCfg{bufferSize: 2, batchSize: 10, flushInterval: time.Hour})
 	r.ch <- Event{}
 	r.ch <- Event{} // channel now full
 	done := make(chan struct{})
@@ -67,7 +55,7 @@ func TestRecordNonBlockingWhenFull(t *testing.T) {
 
 func TestFlushOnBatchSize(t *testing.T) {
 	fs := &fakeStore{}
-	r := newRecorder(fs, recorderCfg{bufferSize: 16, batchSize: 3, flushInterval: time.Hour, refreshInterval: time.Hour})
+	r := newRecorder(fs, recorderCfg{bufferSize: 16, batchSize: 3, flushInterval: time.Hour})
 	r.start()
 	defer r.Close()
 	for i := 0; i < 3; i++ {
@@ -78,7 +66,7 @@ func TestFlushOnBatchSize(t *testing.T) {
 
 func TestCloseDrainsAndFlushes(t *testing.T) {
 	fs := &fakeStore{}
-	r := newRecorder(fs, recorderCfg{bufferSize: 16, batchSize: 100, flushInterval: time.Hour, refreshInterval: time.Hour})
+	r := newRecorder(fs, recorderCfg{bufferSize: 16, batchSize: 100, flushInterval: time.Hour})
 	r.start()
 	r.Record(Event{Path: "a"})
 	r.Record(Event{Path: "b"})
@@ -109,20 +97,4 @@ func TestDoubleCloseNoPanic(t *testing.T) {
 	if err := r.Close(); err != nil {
 		t.Fatalf("second Close: %v", err)
 	}
-}
-
-func TestRefreshDoesNotStallFlush(t *testing.T) {
-	block := make(chan struct{})
-	fs := &fakeStore{refreshBlock: block}
-	r := newRecorder(fs, recorderCfg{bufferSize: 16, batchSize: 1, flushInterval: time.Hour, refreshInterval: 10 * time.Millisecond})
-	r.start()
-	defer func() {
-		close(block) // unblock the held refresh so Close can drain
-		r.Close()
-	}()
-	// Give the refresh ticker time to fire and block inside RefreshRollup.
-	time.Sleep(50 * time.Millisecond)
-	// Even with refresh blocked, a recorded event must still flush.
-	r.Record(Event{Path: "p"})
-	waitFor(t, 1, fs.count)
 }

--- a/observability/schema.go
+++ b/observability/schema.go
@@ -13,8 +13,10 @@ var schemaStatements = []string{
     tier     text        NOT NULL,
     device   text        NOT NULL,
     visitor  text,
-    is_bot   boolean     NOT NULL DEFAULT false
+    is_bot   boolean     NOT NULL DEFAULT false,
+    instance text
 )`,
+	`ALTER TABLE events ADD COLUMN IF NOT EXISTS instance text`,
 	`CREATE INDEX IF NOT EXISTS idx_events_ts ON events (ts)`,
 	`CREATE INDEX IF NOT EXISTS idx_events_path_ts ON events (path, ts)`,
 	`CREATE MATERIALIZED VIEW IF NOT EXISTS usage_daily AS

--- a/observability/schema.go
+++ b/observability/schema.go
@@ -3,8 +3,7 @@ package observability
 
 import "database/sql"
 
-// schemaStatements create the events table, its indexes, and the daily rollup
-// materialized view. Ordered: table, then indexes, then the view that reads it.
+// schemaStatements create the events table and its indexes. Idempotent.
 var schemaStatements = []string{
 	`CREATE TABLE IF NOT EXISTS events (
     id       bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
@@ -19,13 +18,6 @@ var schemaStatements = []string{
 	`ALTER TABLE events ADD COLUMN IF NOT EXISTS instance text`,
 	`CREATE INDEX IF NOT EXISTS idx_events_ts ON events (ts)`,
 	`CREATE INDEX IF NOT EXISTS idx_events_path_ts ON events (path, ts)`,
-	`CREATE MATERIALIZED VIEW IF NOT EXISTS usage_daily AS
- SELECT date_trunc('day', ts)::date AS day, path, tier, device, is_bot,
-        count(*) AS hits, count(DISTINCT visitor) AS uniques
- FROM events
- GROUP BY 1,2,3,4,5`,
-	`CREATE UNIQUE INDEX IF NOT EXISTS usage_daily_pk
- ON usage_daily (day, path, tier, device, is_bot)`,
 }
 
 // ensureSchema applies each statement in order. Idempotent (IF NOT EXISTS).

--- a/observability/store.go
+++ b/observability/store.go
@@ -43,8 +43,8 @@ func (c *Client) RefreshRollup(ctx context.Context) error {
 	return err
 }
 
-// PathAgg is a per-path aggregate. Uniques is summed daily uniques (a
-// visitor-days approximation of range uniques), acceptable for the dashboard.
+// PathAgg is a per-path aggregate. Uniques is the true distinct-visitor count
+// over the range (anonymous NULL visitors are excluded).
 type PathAgg struct {
 	Path    string
 	Hits    int64
@@ -64,13 +64,13 @@ type DeviceAgg struct {
 	Uniques int64
 }
 
-// TopPages returns paths ordered by hits since the given day.
-func (c *Client) TopPages(ctx context.Context, since time.Time, includeBots bool) ([]PathAgg, error) {
-	const q = `SELECT path, sum(hits), sum(uniques)
-FROM usage_daily
-WHERE day >= $1::date AND ($2 OR NOT is_bot)
-GROUP BY path ORDER BY sum(hits) DESC`
-	rows, err := c.db.QueryContext(ctx, q, since, includeBots)
+// TopPages returns paths for one instance ordered by hits since the given time.
+func (c *Client) TopPages(ctx context.Context, since time.Time, includeBots bool, instance string) ([]PathAgg, error) {
+	const q = `SELECT path, count(*), count(DISTINCT visitor)
+FROM events
+WHERE ts >= $1 AND instance = $2 AND ($3 OR NOT is_bot)
+GROUP BY path ORDER BY count(*) DESC`
+	rows, err := c.db.QueryContext(ctx, q, since, instance, includeBots)
 	if err != nil {
 		return nil, err
 	}
@@ -86,13 +86,13 @@ GROUP BY path ORDER BY sum(hits) DESC`
 	return out, rows.Err()
 }
 
-// UsageByTier returns hits/uniques grouped by membership tier.
-func (c *Client) UsageByTier(ctx context.Context, since time.Time, includeBots bool) ([]TierAgg, error) {
-	const q = `SELECT tier, sum(hits), sum(uniques)
-FROM usage_daily
-WHERE day >= $1::date AND ($2 OR NOT is_bot)
-GROUP BY tier ORDER BY sum(hits) DESC`
-	rows, err := c.db.QueryContext(ctx, q, since, includeBots)
+// UsageByTier returns hits/uniques for one instance grouped by membership tier.
+func (c *Client) UsageByTier(ctx context.Context, since time.Time, includeBots bool, instance string) ([]TierAgg, error) {
+	const q = `SELECT tier, count(*), count(DISTINCT visitor)
+FROM events
+WHERE ts >= $1 AND instance = $2 AND ($3 OR NOT is_bot)
+GROUP BY tier ORDER BY count(*) DESC`
+	rows, err := c.db.QueryContext(ctx, q, since, instance, includeBots)
 	if err != nil {
 		return nil, err
 	}
@@ -108,13 +108,13 @@ GROUP BY tier ORDER BY sum(hits) DESC`
 	return out, rows.Err()
 }
 
-// DeviceSplit returns hits/uniques grouped by path and device.
-func (c *Client) DeviceSplit(ctx context.Context, since time.Time, includeBots bool) ([]DeviceAgg, error) {
-	const q = `SELECT path, device, sum(hits), sum(uniques)
-FROM usage_daily
-WHERE day >= $1::date AND ($2 OR NOT is_bot)
+// DeviceSplit returns hits/uniques for one instance grouped by path and device.
+func (c *Client) DeviceSplit(ctx context.Context, since time.Time, includeBots bool, instance string) ([]DeviceAgg, error) {
+	const q = `SELECT path, device, count(*), count(DISTINCT visitor)
+FROM events
+WHERE ts >= $1 AND instance = $2 AND ($3 OR NOT is_bot)
 GROUP BY path, device ORDER BY path, device`
-	rows, err := c.db.QueryContext(ctx, q, since, includeBots)
+	rows, err := c.db.QueryContext(ctx, q, since, instance, includeBots)
 	if err != nil {
 		return nil, err
 	}
@@ -130,14 +130,14 @@ GROUP BY path, device ORDER BY path, device`
 	return out, rows.Err()
 }
 
-// SubViewBreakdown returns only newspaper/ and sleepers/ sub-view rows.
-func (c *Client) SubViewBreakdown(ctx context.Context, since time.Time, includeBots bool) ([]PathAgg, error) {
-	const q = `SELECT path, sum(hits), sum(uniques)
-FROM usage_daily
-WHERE day >= $1::date AND ($2 OR NOT is_bot)
+// SubViewBreakdown returns only newspaper/ and sleepers/ sub-view rows for one instance.
+func (c *Client) SubViewBreakdown(ctx context.Context, since time.Time, includeBots bool, instance string) ([]PathAgg, error) {
+	const q = `SELECT path, count(*), count(DISTINCT visitor)
+FROM events
+WHERE ts >= $1 AND instance = $2 AND ($3 OR NOT is_bot)
   AND (path LIKE 'newspaper/%' OR path LIKE 'sleepers/%')
-GROUP BY path ORDER BY sum(hits) DESC`
-	rows, err := c.db.QueryContext(ctx, q, since, includeBots)
+GROUP BY path ORDER BY count(*) DESC`
+	rows, err := c.db.QueryContext(ctx, q, since, instance, includeBots)
 	if err != nil {
 		return nil, err
 	}

--- a/observability/store.go
+++ b/observability/store.go
@@ -10,25 +10,25 @@ import (
 
 // InsertBatch writes events in one multi-row INSERT. ts uses the column default.
 // An empty Visitor is stored as NULL so count(DISTINCT visitor) ignores anon hits.
-// Each event binds 5 params; callers must keep len(evs)*5 below Postgres's 65535 param limit (256 events = 1280 params).
+// Each event binds 6 params; keep len(evs)*6 below Postgres's 65535 param limit.
 func (c *Client) InsertBatch(ctx context.Context, evs []Event) error {
 	if len(evs) == 0 {
 		return nil
 	}
 	var b strings.Builder
-	b.WriteString("INSERT INTO events (path, tier, device, visitor, is_bot) VALUES ")
-	args := make([]any, 0, len(evs)*5)
+	b.WriteString("INSERT INTO events (path, tier, device, visitor, is_bot, instance) VALUES ")
+	args := make([]any, 0, len(evs)*6)
 	for i, ev := range evs {
 		if i > 0 {
 			b.WriteString(",")
 		}
-		n := i * 5
-		fmt.Fprintf(&b, "($%d,$%d,$%d,$%d,$%d)", n+1, n+2, n+3, n+4, n+5)
+		n := i * 6
+		fmt.Fprintf(&b, "($%d,$%d,$%d,$%d,$%d,$%d)", n+1, n+2, n+3, n+4, n+5, n+6)
 		var visitor any
 		if ev.Visitor != "" {
 			visitor = ev.Visitor
 		}
-		args = append(args, ev.Path, ev.Tier, ev.Device, visitor, ev.IsBot)
+		args = append(args, ev.Path, ev.Tier, ev.Device, visitor, ev.IsBot, ev.Instance)
 	}
 	_, err := c.db.ExecContext(ctx, b.String(), args...)
 	return err

--- a/observability/store.go
+++ b/observability/store.go
@@ -34,15 +34,6 @@ func (c *Client) InsertBatch(ctx context.Context, evs []Event) error {
 	return err
 }
 
-// RefreshRollup recomputes usage_daily. Non-concurrent: it takes a brief
-// ACCESS EXCLUSIVE lock, acceptable for a tiny hourly rollup on an admin-only
-// dashboard, and avoids needing the TEMPORARY database privilege that a
-// CONCURRENTLY refresh requires.
-func (c *Client) RefreshRollup(ctx context.Context) error {
-	_, err := c.db.ExecContext(ctx, "REFRESH MATERIALIZED VIEW usage_daily")
-	return err
-}
-
 // PathAgg is a per-path aggregate. Uniques is the true distinct-visitor count
 // over the range (anonymous NULL visitors are excluded).
 type PathAgg struct {

--- a/observability/store_test.go
+++ b/observability/store_test.go
@@ -44,36 +44,51 @@ func getenv(k, def string) string {
 	return def
 }
 
-func TestIntegrationInsertRefreshRead(t *testing.T) {
+func TestIntegrationInstanceFilterAndUniques(t *testing.T) {
 	c := testClient(t)
 	ctx := context.Background()
 
+	// One visitor hitting two paths across "days" plus an anon and a bot hit,
+	// all for instance "__inst_a__"; one hit for a different instance.
+	v := HashVisitor("x@y.com")
 	evs := []Event{
-		{Path: "__test__/a", Tier: "Vintage", Device: "desktop", Visitor: HashVisitor("x@y.com")},
-		{Path: "__test__/a", Tier: "Vintage", Device: "desktop", Visitor: HashVisitor("x@y.com")},
-		{Path: "__test__/a", Tier: "Any", Device: "mobile"},
-		{Path: "__test__/a", Tier: "Any", Device: "mobile", IsBot: true},
+		{Path: "__test__/a", Tier: "Vintage", Device: "desktop", Visitor: v, Instance: "__inst_a__"},
+		{Path: "__test__/a", Tier: "Vintage", Device: "desktop", Visitor: v, Instance: "__inst_a__"},
+		{Path: "__test__/b", Tier: "Vintage", Device: "desktop", Visitor: v, Instance: "__inst_a__"},
+		{Path: "__test__/a", Tier: "Any", Device: "mobile", Instance: "__inst_a__"},
+		{Path: "__test__/a", Tier: "Any", Device: "mobile", IsBot: true, Instance: "__inst_a__"},
+		{Path: "__test__/a", Tier: "Vintage", Device: "desktop", Visitor: HashVisitor("z@z.com"), Instance: "__inst_b__"},
 	}
 	if err := c.InsertBatch(ctx, evs); err != nil {
 		t.Fatalf("InsertBatch: %v", err)
 	}
-	if err := c.RefreshRollup(ctx); err != nil {
-		t.Fatalf("RefreshRollup: %v", err)
-	}
 
 	since := time.Now().AddDate(0, 0, -1)
-	pages, err := c.TopPages(ctx, since, false)
+	pages, err := c.TopPages(ctx, since, false, "__inst_a__")
 	if err != nil {
 		t.Fatalf("TopPages: %v", err)
 	}
-	var hits int64
+	got := map[string]PathAgg{}
 	for _, p := range pages {
-		if p.Path == "__test__/a" {
-			hits = p.Hits
-		}
+		got[p.Path] = p
 	}
-	// 3 human hits (bot excluded by default).
-	if hits != 3 {
-		t.Fatalf("expected 3 human hits for __test__/a, got %d", hits)
+	// instance filter excludes __inst_b__; bot excluded by default.
+	// __test__/a: 3 human hits (2 by v, 1 anon), 1 distinct visitor (anon NULL not counted).
+	if a := got["__test__/a"]; a.Hits != 3 || a.Uniques != 1 {
+		t.Fatalf("__test__/a: got hits=%d uniques=%d, want 3/1", a.Hits, a.Uniques)
+	}
+	if _, ok := got["__test__/b"]; !ok {
+		t.Fatal("__test__/b missing for __inst_a__")
+	}
+
+	// The other instance's rows must not appear.
+	pagesB, err := c.TopPages(ctx, since, false, "__inst_b__")
+	if err != nil {
+		t.Fatalf("TopPages inst_b: %v", err)
+	}
+	for _, p := range pagesB {
+		if p.Path == "__test__/b" {
+			t.Fatal("__inst_b__ should not see __inst_a__'s __test__/b")
+		}
 	}
 }

--- a/telemetry.go
+++ b/telemetry.go
@@ -3,27 +3,14 @@ package main
 
 import (
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/mtgban/mtgban-website/observability"
 )
 
-// observabilityInstance is this deployment's instance label, resolved once at
-// startup and stamped on every recorded event.
+// observabilityInstance is this deployment's instance label, set from config at
+// startup. Empty means instance_name is unset and telemetry is disabled.
 var observabilityInstance string
-
-// resolveInstanceName returns the configured instance name, else the OS
-// hostname, else "unknown". Never empty.
-func resolveInstanceName(configured string) string {
-	if configured != "" {
-		return configured
-	}
-	if h, err := os.Hostname(); err == nil && h != "" {
-		return h
-	}
-	return "unknown"
-}
 
 // recordablePath reports whether a request path should produce a telemetry
 // event. API routes are excluded: some are wired through enforceSigning but

--- a/telemetry.go
+++ b/telemetry.go
@@ -3,10 +3,27 @@ package main
 
 import (
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/mtgban/mtgban-website/observability"
 )
+
+// observabilityInstance is this deployment's instance label, resolved once at
+// startup and stamped on every recorded event.
+var observabilityInstance string
+
+// resolveInstanceName returns the configured instance name, else the OS
+// hostname, else "unknown". Never empty.
+func resolveInstanceName(configured string) string {
+	if configured != "" {
+		return configured
+	}
+	if h, err := os.Hostname(); err == nil && h != "" {
+		return h
+	}
+	return "unknown"
+}
 
 // recordablePath reports whether a request path should produce a telemetry
 // event. API routes are excluded: some are wired through enforceSigning but
@@ -37,10 +54,11 @@ func recordPageHit(r *http.Request) {
 		tier = "Any"
 	}
 	ObservabilityRecorder.Record(observability.Event{
-		Path:    observability.NormalizePath(strings.Trim(r.URL.Path, "/"), r.FormValue("page")),
-		Tier:    tier,
-		Device:  device,
-		Visitor: observability.HashVisitor(GetParamFromSig(sig, "UserEmail")),
-		IsBot:   observability.IsBot(r.UserAgent()),
+		Path:     observability.NormalizePath(strings.Trim(r.URL.Path, "/"), r.FormValue("page")),
+		Tier:     tier,
+		Device:   device,
+		Visitor:  observability.HashVisitor(GetParamFromSig(sig, "UserEmail")),
+		IsBot:    observability.IsBot(r.UserAgent()),
+		Instance: observabilityInstance,
 	})
 }

--- a/telemetry_test.go
+++ b/telemetry_test.go
@@ -12,16 +12,6 @@ func TestRecordPageHitNilRecorderNoPanic(t *testing.T) {
 	recordPageHit(req) // must return without panic
 }
 
-func TestResolveInstanceName(t *testing.T) {
-	if got := resolveInstanceName("beta"); got != "beta" {
-		t.Fatalf("configured name should win, got %q", got)
-	}
-	// Empty config falls back to hostname or "unknown"; either way non-empty.
-	if got := resolveInstanceName(""); got == "" {
-		t.Fatal("empty config must fall back to a non-empty value")
-	}
-}
-
 func TestRecordablePath(t *testing.T) {
 	cases := []struct {
 		path string

--- a/telemetry_test.go
+++ b/telemetry_test.go
@@ -12,6 +12,16 @@ func TestRecordPageHitNilRecorderNoPanic(t *testing.T) {
 	recordPageHit(req) // must return without panic
 }
 
+func TestResolveInstanceName(t *testing.T) {
+	if got := resolveInstanceName("beta"); got != "beta" {
+		t.Fatalf("configured name should win, got %q", got)
+	}
+	// Empty config falls back to hostname or "unknown"; either way non-empty.
+	if got := resolveInstanceName(""); got == "" {
+		t.Fatal("empty config must fall back to a non-empty value")
+	}
+}
+
 func TestRecordablePath(t *testing.T) {
 	cases := []struct {
 		path string

--- a/templates/partials/admin-usage.html
+++ b/templates/partials/admin-usage.html
@@ -1,7 +1,7 @@
 {{define "admin-usage"}}
 {{if .UsageStats}}
 <div class="admin-usage-bar">
-    <span class="admin-usage-range">Last 30 days{{if .UsageStats.IncludeBots}} &middot; including bots{{end}}</span>
+    <span class="admin-usage-range">{{.UsageStats.Instance}} &middot; last 30 days{{if .UsageStats.IncludeBots}} &middot; including bots{{end}}</span>
     <div class="admin-usage-toggle">
         <a href="?page=usage"{{if not .UsageStats.IncludeBots}} class="active"{{end}}>Humans</a>
         <a href="?page=usage&amp;bots=1"{{if .UsageStats.IncludeBots}} class="active"{{end}}>Include bots</a>


### PR DESCRIPTION
## What

Per-deployment instance tagging plus accurate uniques for the observability telemetry.

- Each event is tagged with the deployment's `instance`, taken from a required `instance_name` config field. A deployment that does not set `instance_name` records nothing (no recorder, no writes).
- Every admin dashboard query filters to the running deployment's own instance, so main sees only main, beta only beta, even on a shared observability DB.
- The four dashboard queries now read raw `events` with `count(DISTINCT visitor)` instead of summing the daily rollup. This fixes a uniques overcount (a single Root account showed 9; the true count is 1) and removes the up-to-an-hour hits lag.
- The now-unused `usage_daily` materialized view and its hourly refresh are removed.

## Deploy notes

- `instance` is a nullable column added by an idempotent self-migration; existing rows stay NULL until backfilled.
- After this is live, run the one-time cleanup on the observability DB: `UPDATE events SET instance = 'main' WHERE instance IS NULL`, then `DROP MATERIALIZED VIEW usage_daily`. Both must wait for deploy, since the old code still writes NULL-instance rows and reads the matview.

Tested: unit suite plus a live-DB integration test covering instance filtering and true distinct-visitor uniques.
