### PR TITLE
Fix favorites sync: deletions no longer resurrect across tabs and devices

### DIFF
--- a/js/favorites.js
+++ b/js/favorites.js
@@ -1,6 +1,11 @@
 // Favorites — localStorage-backed card favorites for mobile
 (function() {
     var STORAGE_KEY = 'mtgban_favorites';
+    var TOMB_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+    var TOMB_CAP = 50;
+    function isLive(f) { return !f.del; }
+    function mtime(f) { return f.m || f.t || 0; }
+    function getLiveFavorites() { return getFavorites().filter(isLive); }
 
     function getFavorites() {
         try {
@@ -14,10 +19,13 @@
     function saveFavorites(favs) {
         try {
             var MAX_FAVORITES = 50;
-            if (favs.length > MAX_FAVORITES) {
-                favs = favs.slice(0, MAX_FAVORITES);
-            }
-            localStorage.setItem(STORAGE_KEY, JSON.stringify(favs));
+            var now = Date.now();
+            var live = favs.filter(isLive);
+            var tombs = favs.filter(function(f) { return !isLive(f) && (now - mtime(f)) <= TOMB_TTL_MS; });
+            if (live.length > MAX_FAVORITES) live = live.slice(0, MAX_FAVORITES);
+            tombs.sort(function(a, b) { return mtime(b) - mtime(a); });
+            if (tombs.length > TOMB_CAP) tombs = tombs.slice(0, TOMB_CAP);
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(live.concat(tombs)));
         } catch (e) {}
     }
 
@@ -199,12 +207,15 @@
         }
 
         var active;
-        if (idx >= 0) {
-            favs.splice(idx, 1);
+        if (idx >= 0 && !favs[idx].del) {
+            favs[idx].del = favs[idx].m = Date.now();
             active = false;
         } else {
             var data = extractCardData(btn);
             if (!data) return;
+            data.m = data.t;
+            // A fresh add replaces any old tombstone for the same card.
+            if (idx >= 0) favs.splice(idx, 1);
             favs.unshift(data);
             active = true;
         }
@@ -221,7 +232,7 @@
 
     // Mark stars on page load for already-favorited cards
     function markExistingFavorites() {
-        var favs = getFavorites();
+        var favs = getLiveFavorites();
         if (favs.length === 0) return;
 
         var favIds = {};
@@ -246,7 +257,7 @@
 
     function renderFavoritesInto(container, mode) {
         if (!container) return;
-        var favs = pinnedFirst(sortFavs(getFavorites()));
+        var favs = pinnedFirst(sortFavs(getLiveFavorites()));
 
         var containerId = container.id;
         if (!paginationState[containerId]) paginationState[containerId] = { page: 0 };
@@ -506,7 +517,11 @@
     window.deleteFavorite = function(cardId, ev) {
         if (ev) { ev.preventDefault(); ev.stopPropagation(); }
         if (!cardId) return;
-        var favs = getFavorites().filter(function(f) { return f.id !== cardId; });
+        var favs = getFavorites();
+        var now = Date.now();
+        favs.forEach(function(f) {
+            if (f.id === cardId && !f.del) { f.del = now; f.m = now; }
+        });
         saveFavorites(favs);
         renderFavorites();
         // Clear active state on any star buttons for this card on the same page.
@@ -521,12 +536,13 @@
         var favs = getFavorites();
         var changed = false;
         for (var i = 0; i < favs.length; i++) {
-            if (favs[i].id === cardId) {
+            if (favs[i].id === cardId && !favs[i].del) {
                 if (favs[i].pinned) {
                     delete favs[i].pinned;
                 } else {
                     favs[i].pinned = Date.now();
                 }
+                favs[i].m = Date.now();
                 changed = true;
                 break;
             }
@@ -551,7 +567,12 @@
 
     window.clearFavorites = function(trigger) {
         var doClear = function() {
-            localStorage.removeItem(STORAGE_KEY);
+            var now = Date.now();
+            var favs = getFavorites();
+            favs.forEach(function(f) {
+                if (!f.del) { f.del = now; f.m = now; }
+            });
+            saveFavorites(favs);
             var mobile = document.getElementById('m-favorites');
             if (mobile) mobile.innerHTML = '';
             var desktop = document.getElementById('desktop-favorites');
@@ -580,7 +601,7 @@
         return '';
     }
     window.downloadFavoritesCSV = function() {
-        var favs = getFavorites();
+        var favs = getLiveFavorites();
         if (!favs.length) return;
         var rows = [['UUID', 'Name', 'Edition', 'Set', 'Number', 'Finish', 'Best Sell', 'Sell Store', 'Best Buy', 'Buy Store']];
         favs.forEach(function(f) {
@@ -604,7 +625,7 @@
     // Hand the favorites off to the uploader exactly like the search
     // sidebar does: POST one "hashes" input per card plus the mode.
     window.sendFavoritesToUploader = function(mode) {
-        var favs = getFavorites();
+        var favs = getLiveFavorites();
         if (!favs.length) return;
         var form = document.createElement('form');
         form.method = 'post';
@@ -694,6 +715,7 @@
             var buy = parseFloat(c[8]);
 
             var prev = byId[id];
+            var live = prev && !prev.del ? prev : null;
             var fav = {
                 id: id,
                 name: name,
@@ -713,10 +735,12 @@
                 img: prev ? (prev.img || '') : '',
                 cw: prev ? !!prev.cw : false,
                 // Preserve pin + original add-time for cards already saved.
-                pinned: prev ? prev.pinned : false,
-                t: prev ? prev.t : Date.now()
+                pinned: live ? live.pinned : false,
+                t: live ? live.t : Date.now(),
+                m: live ? (live.m || live.t) : Date.now()
             };
             if (!prev) { order.push(id); added++; }
+            else if (!live) { added++; }
             byId[id] = fav;
         }
 
@@ -754,7 +778,7 @@
     var lastRefreshAttempt = 0;
 
     function refreshFavorites() {
-        var favs = getFavorites();
+        var favs = getLiveFavorites();
         if (favs.length === 0) return;
 
         // Refresh if any entry is older than STALE_MS, or if any entry is missing
@@ -781,7 +805,7 @@
     }
 
     function doRefresh(showNotification) {
-        var favs = getFavorites();
+        var favs = getLiveFavorites();
         if (favs.length === 0) return;
 
         // Chunk into batches of 50
@@ -810,6 +834,7 @@
             var updated = false;
 
             favs.forEach(function(f) {
+                if (f.del) return;
                 var prices = merged[f.id];
                 if (!prices) return;
 

--- a/js/recent-searches.js
+++ b/js/recent-searches.js
@@ -2,6 +2,11 @@
 (function() {
     var STORAGE_KEY = 'mtgban_recent_searches';
     var MAX_ENTRIES = 15;
+    var TOMB_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+    var TOMB_CAP = 50;
+    function isLive(s) { return !s.del; }
+    function mtime(s) { return s.m || s.t || 0; }
+    function getLiveSearches() { return getRecentSearches().filter(isLive); }
 
     // Parse a query for set tokens. Returns {set, keyrune} only when the query is
     // a "pure set search" - the first token is s:/e:/ee:. A query like "Birds s:7ed"
@@ -41,7 +46,13 @@
 
     function saveRecentSearches(searches) {
         try {
-            localStorage.setItem(STORAGE_KEY, JSON.stringify(searches));
+            var now = Date.now();
+            var live = searches.filter(isLive);
+            var tombs = searches.filter(function(s) { return !isLive(s) && (now - mtime(s)) <= TOMB_TTL_MS; });
+            if (live.length > MAX_ENTRIES) live = live.slice(0, MAX_ENTRIES);
+            tombs.sort(function(a, b) { return mtime(b) - mtime(a); });
+            if (tombs.length > TOMB_CAP) tombs = tombs.slice(0, TOMB_CAP);
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(live.concat(tombs)));
         } catch (e) {
             // localStorage full or unavailable - silently fail
         }
@@ -70,24 +81,27 @@
 
         var token = parseSetToken(query);
 
+        var t = Date.now();
         searches.unshift({
             q: query,
-            t: Date.now(),
+            t: t,
+            m: t,
             img: '',
             set: token.set,
             keyrune: token.keyrune
         });
-
-        if (searches.length > MAX_ENTRIES) {
-            searches = searches.slice(0, MAX_ENTRIES);
-        }
 
         saveRecentSearches(searches);
     }
 
     function clearRecentSearches(trigger) {
         var doClear = function() {
-            localStorage.removeItem(STORAGE_KEY);
+            var now = Date.now();
+            var searches = getRecentSearches();
+            searches.forEach(function(s) {
+                if (!s.del) { s.del = now; s.m = now; }
+            });
+            saveRecentSearches(searches);
             var mobile = document.getElementById('m-recent-searches');
             if (mobile) mobile.innerHTML = '';
             var desktop = document.getElementById('desktop-recent-searches');
@@ -111,7 +125,7 @@
         if (!container) return;
         var oldBody = container.querySelector('.landing-pane-body');
         var savedScroll = oldBody ? oldBody.scrollTop : 0;
-        var searches = pinnedFirst(getRecentSearches());
+        var searches = pinnedFirst(getLiveSearches());
 
         if (searches.length === 0) {
             if (mode === 'desktop') {
@@ -187,7 +201,11 @@
     window.deleteRecentSearch = function(query, ev) {
         if (ev) { ev.preventDefault(); ev.stopPropagation(); }
         if (!query) return;
-        var searches = getRecentSearches().filter(function(s) { return s.q !== query; });
+        var searches = getRecentSearches();
+        var now = Date.now();
+        searches.forEach(function(s) {
+            if (s.q === query && !s.del) { s.del = now; s.m = now; }
+        });
         saveRecentSearches(searches);
         renderRecentSearches();
     };
@@ -198,12 +216,13 @@
         var searches = getRecentSearches();
         var changed = false;
         for (var i = 0; i < searches.length; i++) {
-            if (searches[i].q === query) {
+            if (searches[i].q === query && !searches[i].del) {
                 if (searches[i].pinned) {
                     delete searches[i].pinned;
                 } else {
                     searches[i].pinned = Date.now();
                 }
+                searches[i].m = Date.now();
                 changed = true;
                 break;
             }
@@ -249,7 +268,7 @@
         var qLower = q.toLowerCase();
         var changed = false;
         for (var i = 0; i < searches.length; i++) {
-            if (searches[i].q.toLowerCase() === qLower) {
+            if (searches[i].q.toLowerCase() === qLower && !searches[i].del) {
                 if (!searches[i].img) {
                     searches[i].img = img;
                     changed = true;

--- a/js/user-state.js
+++ b/js/user-state.js
@@ -5,6 +5,11 @@
     var FETCH_KEY = 'mtgban_userstate_fetch'; // sessionStorage: {v, ts}
     var TTL_MS = 90 * 1000;
 
+    // Tombstones: entries with a del timestamp. Newest intent (m) wins merges.
+    var TOMB_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+    var TOMB_CAP = 50;
+    function mtime(x) { return x.m || x.t || 0; }
+
     // Keys that map to dedicated server columns.
     var FAVORITES_KEY = 'mtgban_favorites';
     var RECENTS_KEY = 'mtgban_recent_searches';
@@ -191,48 +196,61 @@
         }).catch(function() {});
     }
 
-    // True when local has a favorite/recent/pref the server lacks.
+    // True when local has an entry the server lacks or a newer copy of one.
     function localHasNew(favs, recents, prefs, server) {
-        var sf = {};
-        (server.favorites || []).forEach(function(f) { if (f && f.id != null) sf[f.id] = true; });
-        for (var i = 0; i < favs.length; i++) { if (!sf[favs[i].id]) return true; }
-        var sr = {};
-        (server.recents || []).forEach(function(s) { if (s && s.q != null) sr[('' + s.q).toLowerCase()] = true; });
-        for (var j = 0; j < recents.length; j++) { if (!sr[('' + recents[j].q).toLowerCase()]) return true; }
+        function newer(localList, serverList, idOf) {
+            var sv = {};
+            (serverList || []).forEach(function(x) {
+                var id = idOf(x);
+                if (id != null) sv[id] = mtime(x);
+            });
+            for (var i = 0; i < localList.length; i++) {
+                var lid = idOf(localList[i]);
+                if (lid == null) continue;
+                if (!(lid in sv) || mtime(localList[i]) > sv[lid]) return true;
+            }
+            return false;
+        }
+        if (newer(favs, server.favorites, function(f) { return f.id; })) return true;
+        if (newer(recents, server.recents, function(s) { return ('' + (s.q || '')).toLowerCase(); })) return true;
         var sp = server.preferences || {};
         var keys = Object.keys(prefs);
         for (var k = 0; k < keys.length; k++) { if (String(sp[keys[k]]) !== String(prefs[keys[k]])) return true; }
         return false;
     }
 
-    // Union by id, newer timestamp wins; dedupe and cap (render reapplies pin order).
+    // Merge by id: the copy with newer intent (m, fallback t) wins wholesale,
+    // including its del and pinned state. Ties keep the local copy.
     function mergeList(local, server, idOf, cap) {
+        var now = Date.now();
         var byId = {};
         var order = [];
         function add(item) {
             var id = idOf(item);
             if (id == null) return;
-            if (byId[id]) {
-                var existing = byId[id];
-                var et = existing.t || 0, it = item.t || 0;
-                if (it >= et) byId[id] = item; // newer wins
-                if (existing.pinned && !byId[id].pinned) byId[id].pinned = existing.pinned;
-            } else {
+            var cur = byId[id];
+            if (!cur) {
                 byId[id] = item;
                 order.push(id);
+            } else if (mtime(item) > mtime(cur)) {
+                byId[id] = item;
             }
         }
         (local || []).forEach(add);
         (server || []).forEach(add);
         var merged = order.map(function(id) { return byId[id]; });
-        merged.sort(function(a, b) { return (b.t || 0) - (a.t || 0); });
-        if (cap && merged.length > cap) {
+        var live = merged.filter(function(x) { return !x.del; });
+        var tombs = merged.filter(function(x) { return x.del && (now - mtime(x)) <= TOMB_TTL_MS; });
+        live.sort(function(a, b) { return (b.t || 0) - (a.t || 0); });
+        if (cap && live.length > cap) {
             // Keep pinned even when old; fill the rest with newest unpinned.
-            var pinned = merged.filter(function(x) { return x.pinned; });
-            var unpinned = merged.filter(function(x) { return !x.pinned; });
-            merged = pinned.concat(unpinned).slice(0, cap);
+            var pinned = live.filter(function(x) { return x.pinned; });
+            var unpinned = live.filter(function(x) { return !x.pinned; });
+            live = pinned.concat(unpinned).slice(0, cap);
         }
-        return merged;
+        tombs.sort(function(a, b) { return mtime(b) - mtime(a); });
+        if (tombs.length > TOMB_CAP) tombs = tombs.slice(0, TOMB_CAP);
+        return live.concat(tombs);
     }
 
     // Preferences: last-write-wins per key (local wins on first merge).
@@ -250,6 +268,7 @@
     function trimFavorite(f) {
         return {
             id: f.id, query: f.query, t: f.t, pinned: f.pinned,
+            m: f.m, del: f.del,
             name: f.name, set: f.set, edition: f.edition, number: f.number,
             foil: f.foil, etched: f.etched,
             finishTag: f.finishTag, finishClass: f.finishClass,

--- a/js/user-state.js
+++ b/js/user-state.js
@@ -31,6 +31,25 @@
     var DIRTY_KEY = 'mtgban_userstate_dirty';
     var SYNCED_KEY = 'mtgban_userstate_synced';
 
+    // Fingerprints of the last payload synced per section, to skip no-op writes.
+    var FP_KEY = 'mtgban_userstate_fp';
+    function hashStr(s) {
+        var h = 5381;
+        for (var i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+        return String(h);
+    }
+    function readFPs() {
+        try { return JSON.parse(readLocal(FP_KEY, '{}')); } catch (e) { return {}; }
+    }
+    function writeFP(section, payloadJSON) {
+        try {
+            var f = readFPs();
+            f[section] = hashStr(payloadJSON);
+            rawSetItem(FP_KEY, JSON.stringify(f));
+        } catch (e) {}
+    }
+    function fpMatches(section, payloadJSON) { return readFPs()[section] === hashStr(payloadJSON); }
+
     var version = 0;
     var rawSetItem = localStorage.setItem.bind(localStorage);
     var pending = {}; // section -> true
@@ -84,8 +103,26 @@
     function applyState(state) {
         if (!state) return;
         try {
-            if (state.favorites) rawSetItem(FAVORITES_KEY, JSON.stringify(state.favorites));
-            if (state.recents) rawSetItem(RECENTS_KEY, JSON.stringify(state.recents));
+            if (state.favorites) {
+                var localBy = {};
+                localFavorites().forEach(function(f) { if (f && f.id != null) localBy[f.id] = f; });
+                var favs = state.favorites.map(function(f) {
+                    var prev = f && f.id != null ? localBy[f.id] : null;
+                    if (prev && !f.del) {
+                        // Prices and refresh times are local-only; keep them across hydrates.
+                        if (f.sellPrice == null && prev.sellPrice != null) { f.sellPrice = prev.sellPrice; f.sellVendor = prev.sellVendor; }
+                        if (f.buyPrice == null && prev.buyPrice != null) { f.buyPrice = prev.buyPrice; f.buyVendor = prev.buyVendor; }
+                        if (prev.refreshedAt) f.refreshedAt = prev.refreshedAt;
+                    }
+                    return f;
+                });
+                rawSetItem(FAVORITES_KEY, JSON.stringify(favs));
+                writeFP('favorites', JSON.stringify(favs.map(trimFavorite)));
+            }
+            if (state.recents) {
+                rawSetItem(RECENTS_KEY, JSON.stringify(state.recents));
+                writeFP('recents', JSON.stringify(state.recents));
+            }
             if (state.preferences) {
                 Object.keys(state.preferences).forEach(function(k) {
                     if (PREF_KEYS.indexOf(k) >= 0) rawSetItem(k, String(state.preferences[k]));
@@ -105,7 +142,10 @@
     // PATCH one section; keepalive lets it outlive navigation.
     // Resolves true when the write (or its reconcile) landed.
     function patchSection(section, keepalive) {
-        var body = JSON.stringify({ data: payloadForSection(section), version: version });
+        var payloadJSON = JSON.stringify(payloadForSection(section));
+        // Content already on the server: succeed without a request.
+        if (fpMatches(section, payloadJSON)) return Promise.resolve(true);
+        var body = '{"data":' + payloadJSON + ',"version":' + version + '}';
         return fetch(BASE + section, {
             method: 'PATCH',
             headers: { 'Content-Type': 'application/json' },
@@ -119,6 +159,7 @@
             }
             return r.json().then(function(res) {
                 if (res && typeof res.version === 'number') { version = res.version; writeMarker(version); }
+                writeFP(section, payloadJSON);
                 return true;
             });
         }).catch(function() {
@@ -183,6 +224,9 @@
 
         // Nothing new to push: adopt version, skip the write.
         if (!localHasNew(mergedFavs, mergedRecents, mergedPrefs, serverState)) {
+            writeFP('favorites', JSON.stringify(mergedFavs.map(trimFavorite)));
+            writeFP('recents', JSON.stringify(mergedRecents));
+            writeFP('preferences', JSON.stringify(mergedPrefs));
             markClean();
             writeMarker(version);
             return Promise.resolve(true);
@@ -209,6 +253,9 @@
             return r.json().then(function(res) {
                 if (res && typeof res.version === 'number') version = res.version;
                 writeMarker(version);
+                writeFP('favorites', JSON.stringify(mergedFavs.map(trimFavorite)));
+                writeFP('recents', JSON.stringify(mergedRecents));
+                writeFP('preferences', JSON.stringify(mergedPrefs));
                 markClean();
                 return true;
             });

--- a/js/user-state.js
+++ b/js/user-state.js
@@ -103,6 +103,7 @@
     }
 
     // PATCH one section; keepalive lets it outlive navigation.
+    // Resolves true when the write (or its reconcile) landed.
     function patchSection(section, keepalive) {
         var body = JSON.stringify({ data: payloadForSection(section), version: version });
         return fetch(BASE + section, {
@@ -112,23 +113,36 @@
             keepalive: keepalive === true
         }).then(function(r) {
             if (r.status === 409) return r.json().then(function(cur) { return reconcile(cur); });
-            if (!r.ok) return null;
+            if (!r.ok) {
+                console.warn('mtgban sync: ' + section + ' write failed (' + r.status + ')');
+                return false;
+            }
             return r.json().then(function(res) {
                 if (res && typeof res.version === 'number') { version = res.version; writeMarker(version); }
+                return true;
             });
-        }).catch(function() {});
+        }).catch(function() {
+            console.warn('mtgban sync: ' + section + ' write failed (network)');
+            return false;
+        });
     }
 
     function flush() {
         timer = null;
         var sections = Object.keys(pending);
         pending = {};
+        var allOk = true;
         // Chain sequentially so version stays consistent across sections.
         sections.reduce(function(p, section) {
-            return p.then(function() { return patchSection(section); });
+            return p.then(function() {
+                return patchSection(section).then(function(ok) {
+                    // Re-queue failures so the next flush retries them.
+                    if (!ok) { allOk = false; pending[section] = true; }
+                });
+            });
         }, Promise.resolve()).then(function() {
-            // Clear dirty only if no new writes were scheduled while flushing.
-            if (!timer && Object.keys(pending).length === 0) markClean();
+            // Clear dirty only if everything synced and no new writes were scheduled.
+            if (allOk && !timer && Object.keys(pending).length === 0) markClean();
         });
     }
 
@@ -151,7 +165,7 @@
     var MAX_RECONCILE_ATTEMPTS = 5;
     function reconcile(serverState, attempt) {
         attempt = attempt || 0;
-        if (!serverState) return Promise.resolve();
+        if (!serverState) return Promise.resolve(false);
         var mergedFavs = mergeList(localFavorites(), serverState.favorites || [], function(f) { return f.id; }, 50);
         var mergedRecents = mergeList(localRecents(), serverState.recents || [], function(s) { return (s.q || '').toLowerCase(); }, 15);
         var mergedPrefs = mergePrefs(buildPreferences(), serverState.preferences || {});
@@ -170,7 +184,8 @@
         // Nothing new to push: adopt version, skip the write.
         if (!localHasNew(mergedFavs, mergedRecents, mergedPrefs, serverState)) {
             markClean();
-            return Promise.resolve();
+            writeMarker(version);
+            return Promise.resolve(true);
         }
 
         var body = JSON.stringify({
@@ -184,16 +199,23 @@
         }).then(function(r) {
             if (r.status === 409) {
                 // Someone else wrote; merge again, up to the retry budget.
-                if (attempt >= MAX_RECONCILE_ATTEMPTS) return null;
+                if (attempt >= MAX_RECONCILE_ATTEMPTS) return false;
                 return r.json().then(function(s) { return reconcile(s, attempt + 1); });
             }
-            if (!r.ok) return null;
+            if (!r.ok) {
+                console.warn('mtgban sync: reconcile write failed (' + r.status + ')');
+                return false;
+            }
             return r.json().then(function(res) {
                 if (res && typeof res.version === 'number') version = res.version;
                 writeMarker(version);
                 markClean();
+                return true;
             });
-        }).catch(function() {});
+        }).catch(function() {
+            console.warn('mtgban sync: reconcile write failed (network)');
+            return false;
+        });
     }
 
     // True when local has an entry the server lacks or a newer copy of one.

--- a/userstate/api.go
+++ b/userstate/api.go
@@ -2,6 +2,7 @@ package userstate
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -57,6 +58,7 @@ func ServeAPI(w http.ResponseWriter, r *http.Request, db *Client, email string) 
 		}
 		st, err := db.Get(ctx, hash)
 		if err != nil {
+			log.Printf("userstate: GET failed for %.10s: %v", hash, err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "read failed"})
 			return
 		}
@@ -75,6 +77,7 @@ func ServeAPI(w http.ResponseWriter, r *http.Request, db *Client, email string) 
 		}
 		result, conflict, err := db.Put(ctx, hash, body, body.Version)
 		if err != nil {
+			log.Printf("userstate: PUT failed for %.10s: %v", hash, err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "write failed"})
 			return
 		}
@@ -89,6 +92,10 @@ func ServeAPI(w http.ResponseWriter, r *http.Request, db *Client, email string) 
 			http.Error(w, "404 not found", http.StatusNotFound)
 			return
 		}
+		if !validSections[section] {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown section"})
+			return
+		}
 		var body struct {
 			Data    json.RawMessage `json:"data"`
 			Version int64           `json:"version"`
@@ -99,7 +106,8 @@ func ServeAPI(w http.ResponseWriter, r *http.Request, db *Client, email string) 
 		}
 		result, conflict, err := db.Patch(ctx, hash, section, body.Data, body.Version)
 		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			log.Printf("userstate: PATCH %s failed for %.10s: %v", section, hash, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "write failed"})
 			return
 		}
 		if conflict {

--- a/userstate/api_test.go
+++ b/userstate/api_test.go
@@ -1,0 +1,43 @@
+package userstate
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// A dead pool must yield 500 with a generic body, not a leaked pq error.
+func TestServeAPIStoreErrorIs500(t *testing.T) {
+	c := testClient(t)
+	c.Close() // force every query to fail
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/userstate/favorites",
+		strings.NewReader(`{"data":[{"id":"x"}],"version":1}`))
+	w := httptest.NewRecorder()
+	ServeAPI(w, req, c, "apierr@example.com")
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if strings.Contains(body, "pq:") || strings.Contains(body, "sql") {
+		t.Fatalf("driver error leaked to client: %s", body)
+	}
+	if !strings.Contains(body, "write failed") {
+		t.Fatalf("expected generic write failed body, got %s", body)
+	}
+}
+
+func TestServeAPIUnknownSectionIs400(t *testing.T) {
+	c := testClient(t)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/userstate/bogus",
+		strings.NewReader(`{"data":[],"version":0}`))
+	w := httptest.NewRecorder()
+	ServeAPI(w, req, c, "apibad@example.com")
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}


### PR DESCRIPTION
Fixes the reported bug where deleted favorites reappear when opening a new tab, and adds/pins/reorders fail to stick.

Root cause: the sync layer merged favorites and recents by union, which cannot represent a deletion. Any client holding an old copy of the list (a stale tab or device, or a client whose write had silently failed) re-added deleted items on its next merge, and the resurrected state then propagated everywhere. On top of that, failed writes were marked clean and never retried, and every new tab issued a content-identical PATCH (user_state rows were reaching version 4000+ in days).

Changes:

- Deletions become tombstones: entries keep an m (last user intent) timestamp and gain a del timestamp instead of being removed. On merge conflicts the copy with the newer intent wins wholesale, so stale clients can no longer resurrect deletes or unpins.
- Favorites and recents writers (delete, star toggle, pin, clear, CSV import) stamp the new fields; all readers filter tombstones. Tombstones prune after 30 days, capped at 50 per list.
- Failed section writes keep the dirty flag set and re-queue, so they are retried and the next hydrate merges instead of overwriting local state. Failures now log a console warning.
- Hydration preserves locally cached prices, and per-section payload fingerprints skip no-op PATCHes, eliminating the version churn.
- The Clear buttons now sync (they previously bypassed the sync shim via removeItem).
- Server: store errors return 500 with a generic body and are logged server-side; the raw pq error is no longer sent to clients. Unknown PATCH sections are rejected before hitting the store.
