### PR TITLE
search: accept bare set code and collector number queries

### DIFF
--- a/searchfilter.go
+++ b/searchfilter.go
@@ -447,6 +447,10 @@ func price4vendor(cardId, shorthand string) float64 {
 
 var re *regexp.Regexp
 
+// Collector-number shapes accepted by the bare "<set> <number>" shorthand:
+// plain numbers ("148", "32★") or prefixed numbers ("c16-177", "2002-1")
+var reBareNumber = regexp.MustCompile(`^(?:[0-9]+[a-z★†]*|[a-z0-9]{2,5}-[0-9]+[a-z]*|[0-9]+-[0-9]+)$`)
+
 var FilterOperations = map[string][]string{
 	"format":    []string{":"},
 	"legal":     []string{":"},
@@ -1095,6 +1099,20 @@ func parseSearchOptionsNG(query string, blocklistRetail, blocklistBuylist []stri
 		}
 		extraConfig := parseSearchOptionsNG(extraQuery, nil, nil, miscSearchOpts)
 		filters = append(filters, extraConfig.CardFilters...)
+	}
+
+	// Rewrite bare "<set code> <number>" queries, eg "neo 234" or "plst c16-177"
+	if config.SearchMode == "" {
+		tokens := strings.Fields(query)
+		if len(tokens) == 2 && reBareNumber.MatchString(strings.ToLower(tokens[1])) {
+			set, err := mtgmatcher.GetSet(tokens[0])
+			if err == nil {
+				extraConfig := parseSearchOptionsNG("s:"+set.Code+" cn:"+tokens[1], nil, nil, nil)
+				filters = append(filters, extraConfig.CardFilters...)
+				config.AppliedFilters = append(config.AppliedFilters, extraConfig.AppliedFilters...)
+				query = ""
+			}
+		}
 	}
 
 	// Apply any search not coming from the query itself

--- a/searchfilter_test.go
+++ b/searchfilter_test.go
@@ -153,3 +153,96 @@ func TestCollectorNumberPLST(t *testing.T) {
 		t.Error("AKH-127 should be kept by cn<200")
 	}
 }
+
+func TestSetNumberShorthand(t *testing.T) {
+	if _, err := mtgmatcher.GetSet("PLST"); err != nil {
+		t.Skip("datastore not loaded")
+	}
+
+	findFilter := func(config SearchConfig, name string) *FilterElem {
+		for i := range config.CardFilters {
+			if config.CardFilters[i].Name == name {
+				return &config.CardFilters[i]
+			}
+		}
+		return nil
+	}
+
+	checkValues := func(t *testing.T, elem *FilterElem, filterName, want string) {
+		t.Helper()
+		if elem == nil {
+			t.Fatalf("missing %s filter", filterName)
+		}
+		if len(elem.Values) != 1 || elem.Values[0] != want {
+			t.Errorf("%s = %v, want [%s]", filterName, elem.Values, want)
+		}
+	}
+
+	t.Run("set code and number rewrite to filters", func(t *testing.T) {
+		config := parseSearchOptionsNG("neo 234", nil, nil, nil)
+		checkValues(t, findFilter(config, "edition"), "edition", "NEO")
+		checkValues(t, findFilter(config, "number"), "number", "234")
+		if config.CleanQuery != "" {
+			t.Errorf("CleanQuery = %q, want empty", config.CleanQuery)
+		}
+	})
+
+	t.Run("PLST prefixed numbers stay in one piece", func(t *testing.T) {
+		config := parseSearchOptionsNG("plst c16-177", nil, nil, nil)
+		checkValues(t, findFilter(config, "edition"), "edition", "PLST")
+		checkValues(t, findFilter(config, "number"), "number", "c16-177")
+	})
+
+	t.Run("set reading wins over prefix reading", func(t *testing.T) {
+		config := parseSearchOptionsNG("c16 177", nil, nil, nil)
+		checkValues(t, findFilter(config, "edition"), "edition", "C16")
+		checkValues(t, findFilter(config, "number"), "number", "177")
+	})
+
+	t.Run("ascending numbers still parse as a range", func(t *testing.T) {
+		config := parseSearchOptionsNG("neo 1-10", nil, nil, nil)
+		checkValues(t, findFilter(config, "edition"), "edition", "NEO")
+		elem := findFilter(config, "number_less_than")
+		checkValues(t, elem, "number_less_than", "10")
+		if len(elem.Subfilters) != 1 || elem.Subfilters[0].Name != "number_greater_than" {
+			t.Fatalf("subfilters = %+v, want a single number_greater_than", elem.Subfilters)
+		}
+	})
+
+	t.Run("shorthand composes with other filters", func(t *testing.T) {
+		config := parseSearchOptionsNG("neo 234 f:foil", nil, nil, nil)
+		checkValues(t, findFilter(config, "edition"), "edition", "NEO")
+		checkValues(t, findFilter(config, "number"), "number", "234")
+		checkValues(t, findFilter(config, "finish"), "finish", "foil")
+	})
+
+	t.Run("unknown set code keeps the name search", func(t *testing.T) {
+		config := parseSearchOptionsNG("lightning 148", nil, nil, nil)
+		if findFilter(config, "edition") != nil {
+			t.Error("unexpected edition filter")
+		}
+		if config.CleanQuery != "lightning 148" {
+			t.Errorf("CleanQuery = %q, want %q", config.CleanQuery, "lightning 148")
+		}
+	})
+
+	t.Run("non numeric second token keeps the name search", func(t *testing.T) {
+		config := parseSearchOptionsNG("neo dragon", nil, nil, nil)
+		if findFilter(config, "edition") != nil {
+			t.Error("unexpected edition filter")
+		}
+		if config.CleanQuery != "neo dragon" {
+			t.Errorf("CleanQuery = %q, want %q", config.CleanQuery, "neo dragon")
+		}
+	})
+
+	t.Run("explicit search mode disables the shorthand", func(t *testing.T) {
+		config := parseSearchOptionsNG("neo 234 sm:prefix", nil, nil, nil)
+		if findFilter(config, "edition") != nil {
+			t.Error("unexpected edition filter")
+		}
+		if config.CleanQuery != "neo 234" {
+			t.Errorf("CleanQuery = %q, want %q", config.CleanQuery, "neo 234")
+		}
+	})
+}


### PR DESCRIPTION
<img width="1244" height="146" alt="image" src="https://github.com/user-attachments/assets/a0768eb9-3084-4e0a-839a-d05ba2d1a10f" />

Queries like neo 234 or plst c16-177 now resolve as set + collector number instead of a doomed name search.

When a query is exactly two tokens, the first validates as a set code, and the second looks like a collector number, the parser rewrites it to s:CODE cn:NUMBER and reuses the existing filter path, so ranges (neo 1-10), PLST-style prefixed numbers, and extra filters (neo 234 f:foil) all behave identically to the operator syntax.

Anything that doesn't match (unknown set code, non-numeric second token, explicit sm:) falls through to the normal name search unchanged. Covered by TestSetNumberShorthand.

Since it lives in the parser, it works on every entry point for free: website search, sealed, the API, the Discord bot, and palette-submitted queries.