### PR TITLE
userstate: fix localStorage sync never running on Firefox

### DIFF
--- a/js/user-state.js
+++ b/js/user-state.js
@@ -346,12 +346,25 @@
     }
 
     // setItem shim: write through, mark dirty, schedule a debounced sync.
+    // Override Storage.prototype.setItem, not the localStorage instance:
+    // `localStorage.setItem = fn` does not shadow the method in Firefox - the
+    // Storage named-property setter stores a "setItem" key instead - so the
+    // instance override silently never ran there and nothing ever synced.
     function installSetItemShim() {
-        localStorage.setItem = function(key, value) {
-            rawSetItem(key, value);
-            var section = sectionForKey(key);
-            if (section) { markDirty(); schedule(section); }
+        var proto = window.Storage && window.Storage.prototype;
+        if (!proto || proto._mtgbanSyncShim) return;
+        proto._mtgbanSyncShim = true;
+        var nativeSetItem = proto.setItem;
+        proto.setItem = function(key, value) {
+            nativeSetItem.call(this, key, value);
+            if (this === window.localStorage) {
+                var section = sectionForKey(key);
+                if (section) { markDirty(); schedule(section); }
+            }
         };
+        // Remove the stray "setItem" key the old instance assignment stored in
+        // localStorage on Firefox.
+        try { window.localStorage.removeItem('setItem'); } catch (e) {}
     }
 
     function hydrate() {


### PR DESCRIPTION
Cross-device sync (recents/pins, favorites, theme, chart settings) never worked on **Firefox** — changes save to `localStorage` but never `PATCH` to the server, so the next hydrate overwrites them with the server copy.

## Cause
`installSetItemShim` intercepts writes by assigning to the instance:

```js
localStorage.setItem = function (key, value) { ... markDirty(); schedule(section); };
```

Firefox does **not** shadow the method this way. `Storage` has a named-property setter, so `localStorage.setItem = fn` stores a `localStorage` **key** called `"setItem"` and leaves the real method untouched. Confirmed on Firefox 152:

```
> !/\[native code\]/.test(localStorage.setItem.toString())   // shim active?
false
> localStorage.getItem("setItem")
"function(key, value) { rawSetItem(key, value); ... }"       // stored as a key!
```

So the shim never runs → no write ever marks dirty or schedules a push → nothing syncs.

## Fix
Override `Storage.prototype.setItem` instead (idempotent, guarded to the `localStorage` instance), which intercepts reliably across browsers. `rawSetItem` was captured before the override, so internal writes still bypass the shim. Also removes the stray `"setItem"` key the old code left in affected profiles.

Repro: on Firefox, pin a recent search, reload — the pin is gone. After this, it persists and a `PATCH /api/userstate/recents` fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)