### PR TITLE
mobile: feature parity — locked-row Log in + content-warning blur

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -445,3 +445,18 @@ body.mobile:has(.m-home) .m-nav-home {
         animation: none;
     }
 }
+
+/* Portrait phones: fit the whole landing page in the visible viewport so the
+   login/join footer sits at the bottom without scrolling. dvh tracks the real
+   visible height, unlike vh which counts the area behind the mobile address
+   bar and pushed the footer off-screen. Center the brand/search block in the
+   space above the footer (which keeps its own margin-top:auto). Landscape,
+   with no vertical room to spare, is intentionally left as-is. */
+@media (orientation: portrait) {
+    .m-home {
+        min-height: calc(100dvh - 48px);
+    }
+    .m-home-brand {
+        margin-top: auto;
+    }
+}

--- a/css/search-mobile.css
+++ b/css/search-mobile.css
@@ -631,6 +631,11 @@
     min-height: 48px;
 }
 
+.m-locked-cta {
+    display: flex;
+    align-items: center;
+    gap: 0.4em;
+}
 .m-locked-btn {
     font-size: 0.75rem;
     font-weight: 600;
@@ -639,6 +644,14 @@
     background: var(--dodgerblue);
     color: white;
     text-decoration: none;
+    white-space: nowrap;
+}
+/* Log in reads as the secondary action next to the solid Join button. */
+.m-locked-btn-login {
+    background: transparent;
+    color: var(--dodgerblue);
+    border: 1px solid var(--dodgerblue);
+    padding: calc(0.3em - 1px) calc(0.75em - 1px);
 }
 
 /* Pagination */

--- a/templates/mobile/search.html
+++ b/templates/mobile/search.html
@@ -202,7 +202,7 @@
                  data-has-warning="{{$card.HasContentWarning}}"
                  data-crop-url="{{$card.CropURL}}"
                  data-setcode="{{$card.SetCode}}"
-                 onclick="showCardDrawer({{$card.ImageURL}}, '{{$card.Name}}')">
+                 onclick="showCardDrawer({{$card.ImageURL}}, '{{$card.Name}}', {{$card.HasContentWarning}})">
                 <div class="m-card-icon">
                     {{if $card.Keyrune}}
                         <i class="ss {{$card.Keyrune}} ss-fw"></i>
@@ -813,7 +813,7 @@
     <div class="m-drawer" id="m-drawer">
         <div class="m-drawer-handle" onclick="hideCardDrawer()"><span></span></div>
         <div class="m-drawer-content">
-            <img class="m-drawer-img" id="m-drawer-img" src="" alt="">
+            <img class="m-drawer-img" id="m-drawer-img" src="" alt="" onclick="this.classList.add('cw-revealed')">
             <span class="m-drawer-name" id="m-drawer-name"></span>
         </div>
     </div>
@@ -931,13 +931,17 @@ window.addEventListener('scroll', closeActionsMenus, { passive: true });
 window.addEventListener('resize', closeActionsMenus);
 
 // Card image drawer
-function showCardDrawer(imgUrl, name) {
+function showCardDrawer(imgUrl, name, hasWarning) {
     var overlay = document.getElementById('m-drawer-overlay');
     var drawer = document.getElementById('m-drawer');
     var img = document.getElementById('m-drawer-img');
     var nameEl = document.getElementById('m-drawer-name');
     img.src = imgUrl;
     img.alt = name;
+    // Blur content-warning art until tapped, matching desktop. Reset the
+    // revealed state each open so a fresh card starts blurred again.
+    img.classList.toggle('content-warning', !!hasWarning);
+    img.classList.remove('cw-revealed');
     nameEl.textContent = name;
     overlay.classList.add('open');
     drawer.classList.add('open');

--- a/templates/mobile/search.html
+++ b/templates/mobile/search.html
@@ -348,7 +348,10 @@
                                 {{if $entry.Locked}}
                                 <div class="m-vendor-row m-vendor-locked">
                                     <span class="m-vendor-name dim">{{$entry.ScraperName}}</span>
-                                    <a class="m-locked-btn" href="https://www.patreon.com/MTGBAN" target="_blank">Join</a>
+                                    <span class="m-locked-cta">
+                                        <a class="m-locked-btn" href="https://www.patreon.com/MTGBAN" target="_blank">Join</a>
+                                        {{range $ref, $id := $.PatreonIds}}<a class="m-locked-btn m-locked-btn-login" href="https://www.patreon.com/oauth2/authorize?response_type=code&client_id={{$id}}&redirect_uri={{$.PatreonURL}}&scope=identity%20identity%5Bemail%5D%20campaigns%20campaigns.members&state={{$ref}}">Log in</a>{{end}}
+                                    </span>
                                 </div>
                                 {{else}}
                                 <div class="m-vendor-row m-vendor-flat">
@@ -369,7 +372,10 @@
                                 {{if $entry.Locked}}
                                 <div class="m-vendor-row m-vendor-locked">
                                     <span class="m-vendor-name dim">{{$entry.ScraperName}} {{$entry.Country}}</span>
-                                    <a class="m-locked-btn" href="https://www.patreon.com/MTGBAN" target="_blank">Join</a>
+                                    <span class="m-locked-cta">
+                                        <a class="m-locked-btn" href="https://www.patreon.com/MTGBAN" target="_blank">Join</a>
+                                        {{range $ref, $id := $.PatreonIds}}<a class="m-locked-btn m-locked-btn-login" href="https://www.patreon.com/oauth2/authorize?response_type=code&client_id={{$id}}&redirect_uri={{$.PatreonURL}}&scope=identity%20identity%5Bemail%5D%20campaigns%20campaigns.members&state={{$ref}}">Log in</a>{{end}}
+                                    </span>
                                 </div>
                                 {{else}}
                                 {{$hasDetail := $entry.Credit}}
@@ -429,7 +435,10 @@
                                 {{if $entry.Locked}}
                                 <div class="m-vendor-row m-vendor-locked">
                                     <span class="m-vendor-name dim">{{$entry.ScraperName}}</span>
-                                    <a class="m-locked-btn" href="https://www.patreon.com/MTGBAN" target="_blank">Join</a>
+                                    <span class="m-locked-cta">
+                                        <a class="m-locked-btn" href="https://www.patreon.com/MTGBAN" target="_blank">Join</a>
+                                        {{range $ref, $id := $.PatreonIds}}<a class="m-locked-btn m-locked-btn-login" href="https://www.patreon.com/oauth2/authorize?response_type=code&client_id={{$id}}&redirect_uri={{$.PatreonURL}}&scope=identity%20identity%5Bemail%5D%20campaigns%20campaigns.members&state={{$ref}}">Log in</a>{{end}}
+                                    </span>
                                 </div>
                                 {{else}}
                                 <div class="m-vendor-row m-vendor-flat">
@@ -450,7 +459,10 @@
                                 {{if $entry.Locked}}
                                 <div class="m-vendor-row m-vendor-locked">
                                     <span class="m-vendor-name dim">{{$entry.ScraperName}} {{$entry.Country}}</span>
-                                    <a class="m-locked-btn" href="https://www.patreon.com/MTGBAN" target="_blank">Join</a>
+                                    <span class="m-locked-cta">
+                                        <a class="m-locked-btn" href="https://www.patreon.com/MTGBAN" target="_blank">Join</a>
+                                        {{range $ref, $id := $.PatreonIds}}<a class="m-locked-btn m-locked-btn-login" href="https://www.patreon.com/oauth2/authorize?response_type=code&client_id={{$id}}&redirect_uri={{$.PatreonURL}}&scope=identity%20identity%5Bemail%5D%20campaigns%20campaigns.members&state={{$ref}}">Log in</a>{{end}}
+                                    </span>
                                 </div>
                                 {{else}}
                                 {{$hasDetail := or $entry.Credit $entry.MarketCredit (and $entry.Ratio (eq $conditions "NM"))}}


### PR DESCRIPTION
Two mobile↔desktop feature-parity fixes, one commit each.

### Log in on locked search rows
Desktop shows both **Join** and a Patreon **Log in** button on every locked price row; mobile showed only Join, so an existing patron browsing on mobile had no way to authenticate from search results. Adds the same OAuth Log in link beside Join — grouped in an `m-locked-cta` wrapper and styled as the secondary action (outline vs. the solid Join). Applies to all four locked-row variants.

### Content-warning blur in the card drawer
The inline landscape image already blurred content-warning art, but the tap-to-open card drawer showed the full image unblurred. Passes the warning flag through `showCardDrawer`, toggles the shared `.content-warning` class on the drawer image (reset on each open so a fresh card starts blurred), and reveals it on tap — mirroring the desktop behaviour.

---

- `main.css` (which carries the `.content-warning` blur rules) is already loaded on the mobile base template, so no new CSS was needed for the blur itself.
- Templates parse (`go test -run Template`). Not verified in a live mobile view — worth a spot-check on a locked-price search and a content-warning card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
