### PR TITLE
fix: surface foil/etched rows in variant-qualified searches

### DIFF
--- a/search.go
+++ b/search.go
@@ -1294,6 +1294,19 @@ func editionsForSearch(allKeys []string) []EditionEntry {
 	return out
 }
 
+// addFinishVariants appends id's foil and etched finishes to uuids, skipping
+// any that don't exist, equal id, or are already present.
+func addFinishVariants(uuids []string, id string) []string {
+	foilId, _ := mtgmatcher.MatchId(id, true)
+	etchedId, _ := mtgmatcher.MatchId(id, false, true)
+	for _, otherFinishId := range []string{foilId, etchedId} {
+		if otherFinishId != "" && otherFinishId != id && !slices.Contains(uuids, otherFinishId) {
+			uuids = append(uuids, otherFinishId)
+		}
+	}
+	return uuids
+}
+
 func searchScryfall(query string) ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(time.Second*30))
 	defer cancel()
@@ -1323,17 +1336,10 @@ func searchScryfall(query string) ([]string, error) {
 			if id == "" {
 				continue
 			}
-			out = append(out, id)
-
-			foilId, err := mtgmatcher.MatchId(id, true)
-			if err == nil && foilId != id {
-				out = append(out, foilId)
+			if !slices.Contains(out, id) {
+				out = append(out, id)
 			}
-
-			etchedId, err := mtgmatcher.MatchId(id, false, true)
-			if err == nil && etchedId != id {
-				out = append(out, etchedId)
-			}
+			out = addFinishVariants(out, id)
 		}
 
 		// Exit the loop when there are no more results
@@ -1367,23 +1373,8 @@ func attemptMatch(query string) ([]string, error) {
 
 	// Repeat for foil and etched (only add if not previously found)
 	// Add as needed depending on the previous query result
-	for _, tag := range []string{"Foil", "Etched"} {
-		uuid, suberr := mtgmatcher.Match(&mtgmatcher.InputCard{
-			Name:      query,
-			Variation: tag,
-		})
-		if err != nil && suberr != nil {
-			var alias *mtgmatcher.AliasingError
-			if errors.As(suberr, &alias) {
-				for _, extra := range alias.Probe() {
-					if !slices.Contains(uuids, extra) {
-						uuids = append(uuids, extra)
-					}
-				}
-			}
-		} else if !slices.Contains(uuids, uuid) {
-			uuids = append(uuids, uuid)
-		}
+	for _, id := range uuids {
+		uuids = addFinishVariants(uuids, id)
 	}
 
 	return uuids, nil

--- a/search_test.go
+++ b/search_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -63,6 +64,49 @@ func TestMain(m *testing.M) {
 
 func parseSearchOptionsWrapper(input string) SearchConfig {
 	return parseSearchOptionsNG(input, nil, nil, nil)
+}
+
+// datastoreLoaded reports whether the mtgmatcher card datastore is available,
+// so data-dependent tests can skip when it isn't loaded locally or in CI.
+func datastoreLoaded() bool {
+	_, err := mtgmatcher.Match(&mtgmatcher.InputCard{Name: "Forest"})
+	var alias *mtgmatcher.AliasingError
+	return err == nil || errors.As(err, &alias)
+}
+
+// A variant-qualified name (e.g. "(Borderless)") skips the plain-name search
+// index and falls back to attemptMatch, which must still surface every finish
+// of the matched printing. Regression guard: the foil used to be dropped
+// because the variant already in the name clobbered the "Foil" match hint.
+func TestAttemptMatchVariantIncludesFoil(t *testing.T) {
+	if !datastoreLoaded() {
+		t.Skip("mtgmatcher datastore not loaded")
+	}
+
+	const query = "Meren of Clan Nel Toth (Borderless)"
+	uuids, err := attemptMatch(query)
+	if err != nil {
+		t.Fatalf("attemptMatch(%q): %v", query, err)
+	}
+
+	var haveNonfoil, haveFoil bool
+	for _, id := range uuids {
+		co, err := mtgmatcher.GetUUID(id)
+		if err != nil || co.Etched {
+			continue
+		}
+		if co.Foil {
+			haveFoil = true
+		} else {
+			haveNonfoil = true
+		}
+	}
+	if !haveNonfoil {
+		t.Errorf("attemptMatch(%q) = %v: missing the nonfoil printing", query, uuids)
+	}
+	if !haveFoil {
+		t.Errorf("attemptMatch(%q) = %v: missing the foil printing", query, uuids)
+	}
 }
 
 func BenchmarkRegexp(b *testing.B) {


### PR DESCRIPTION
## Problem

Searching a card by a **variant-qualified name** drops the foil (and etched) rows. For example, [`/search?q=Meren of Clan Nel Toth (Borderless)`](https://mtgban.com/search?q=Meren+of+Clan+Nel+Toth+(Borderless)) returns only the nonfoil borderless printing, even though the borderless foil exists and shows up fine in the plain `Meren of Clan Nel Toth` search.

## Root cause

A name that already contains a variant (`(Borderless)`, `(Showcase)`, `(Extended Art)`, …) isn't in mtgmatcher's plain-name hash index, so the query falls through to `attemptMatch`. There, the extra finishes were pulled in by re-matching with `Variation:"Foil"`/`"Etched"` — but since the variant is already baked into the *name*, the matcher folds it into the variant field and the `"Foil"`/`"Etched"` hint is lost. Those re-matches collapse back to the same nonfoil printing and get deduped away, so the foil silently vanishes.

## Fix

Expand each matched printing to its exact `_f`/`_e` sibling with `mtgmatcher.MatchId(id, true)` / `MatchId(id, false, true)`, the same technique `searchScryfall` already uses. `MatchId` resolves a finish sibling from a known printing id, so it can't be clobbered by an in-name variant.

## Test

`TestAttemptMatchVariantIncludesFoil` runs the real `Meren … (Borderless)` query and asserts both the nonfoil and foil printings come back (skips when the local card datastore isn't present, matching the existing benchmarks). Verified it **fails before** the fix (returns `[86d800bc… ]`, foil missing) and **passes after**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
