### PR TITLE
charts: Lorcana price history graphs from tcg_prices

### DIFF
--- a/api_chart.go
+++ b/api_chart.go
@@ -47,7 +47,7 @@ func ChartDataAPI(w http.ResponseWriter, r *http.Request) {
 	lb := chartLookback(sig)
 	maxDays := lb.Days()
 
-	earliest, _ := PricesArchiveDB.GetEarliestDate(r.Context(), co.UUID, co.Foil, co.Etched, lb)
+	earliest := chartEarliestDate(r.Context(), uuid, lb)
 
 	if rangeStr := r.FormValue("range"); rangeStr != "" {
 		if days, err := strconv.Atoi(rangeStr); err == nil && days > 0 {

--- a/chart.go
+++ b/chart.go
@@ -168,30 +168,72 @@ func buildDataset(results map[string]timeseries.PriceRow, labels []string, confi
 	}
 }
 
-// gameTCGCategory maps the deployment's game to the TCGplayer category whose
-// tcgplayer_nonmagic_product_prices history backs its price charts, and reports
-// whether such charts exist for it. Magic keeps its history in product_prices
-// keyed by mtgjson uuid (the default getDatasets path), so it is not listed
-// here; only games ingested from TCGCSV by product id are. Adding a game is one
-// case here plus a partition in schema_tcg.sql.
-func gameTCGCategory() (int, bool) {
-	switch Config.Game {
-	case "lorcana":
-		return tcgcsv.CategoryLorcana, true
-	}
-	return 0, false
+// tcgChartGame describes how one TCGCSV-backed game plugs into the chart
+// pipeline: which TCGplayer category holds its price history, and which
+// tcgplayer_nonmagic_product_prices sub_type_name values back a card's non-foil
+// and foil printing. mtgmatcher only tracks foil vs non-foil, so those two lists
+// are the whole finish model; each is in preference order — the earliest entry
+// present on a given date wins, so a line stays on one printing even where a
+// product switched sub-types over time.
+type tcgChartGame struct {
+	Category int
+	NonFoil  []string
+	Foil     []string
 }
 
-// tcgSubTypesForFinish lists the tcgcsv sub-types that back a card's finish, in
-// preference order. mtgmatcher only tracks foil vs non-foil, but TCGplayer files
-// a Lorcana card's non-foil printing under "Normal" and its foil printing under
-// "Cold Foil" (older and special products use "Holofoil"), so a foil card
-// accepts either foil sub-type and the earliest/best-populated one wins.
-func tcgSubTypesForFinish(foil bool) []string {
-	if foil {
-		return []string{"Cold Foil", "Holofoil"}
+// tcgChartGames is the registry of TCGCSV-backed games that render price charts,
+// keyed by Config.Game. Magic is absent on purpose: it charts from product_prices
+// by mtgjson uuid (the default getDatasets path), not from
+// tcgplayer_nonmagic_product_prices.
+//
+// Adding a game is one entry here. Everything else is already game-agnostic:
+// ingestion (tcgcsv_config.games), storage and schema partitions (schema_tcg.sql,
+// with EnsureTCGCategoryPartition as a runtime backstop), the Market/Low chart
+// lines (tcgChartRefs), curated checkpoints, and the chart UI. The one external
+// prerequisite this file can't encode is card data: mtgmatcher must resolve the
+// game's cards to a tcgplayerProductId (as it does for Lorcana), or charts render
+// empty.
+//
+// Sub-type names are TCGplayer's own and differ per game, so confirm them against
+// the live tcgcsv feed before adding one — observed names (mapping foil vs
+// non-foil is the adder's call): Pokemon has Normal / Holofoil / Reverse Holofoil,
+// One Piece has Normal / Foil. A game with more than a foil/non-foil split (e.g.
+// Pokemon's Reverse Holofoil as its own printing) needs this finish model
+// revisited once mtgmatcher exposes that distinction.
+var tcgChartGames = map[string]tcgChartGame{
+	"lorcana": {
+		Category: tcgcsv.CategoryLorcana,
+		NonFoil:  []string{"Normal"},
+		Foil:     []string{"Cold Foil", "Holofoil"},
+	},
+}
+
+// gameTCGCategory reports the TCGplayer category whose
+// tcgplayer_nonmagic_product_prices history backs the deployment's chart, and
+// whether the game charts off product ids at all. It is the single dispatch that
+// routes getDatasets, chartEarliestDate, genPageNav's DisableChart, and the
+// checkpoint set/reprint gate onto the TCG path.
+func gameTCGCategory() (int, bool) {
+	g, ok := tcgChartGames[Config.Game]
+	if !ok {
+		return 0, false
 	}
-	return []string{"Normal"}
+	return g.Category, true
+}
+
+// tcgSubTypesForFinish lists the tcgcsv sub-types that back the current game's
+// card finish, in preference order. It returns nil for a game with no chart
+// entry; in practice it is only reached on the TCG path, where Config.Game is a
+// registered game.
+func tcgSubTypesForFinish(foil bool) []string {
+	g, ok := tcgChartGames[Config.Game]
+	if !ok {
+		return nil
+	}
+	if foil {
+		return g.Foil
+	}
+	return g.NonFoil
 }
 
 // tcgChartRefs are the price lines a TCG (product-id) chart draws, one per

--- a/chart.go
+++ b/chart.go
@@ -181,30 +181,85 @@ type tcgChartGame struct {
 	Foil     []string
 }
 
-// tcgChartGames is the registry of TCGCSV-backed games that render price charts,
-// keyed by Config.Game. Magic is absent on purpose: it charts from product_prices
-// by mtgjson uuid (the default getDatasets path), not from
+// tcgChartGames is the registry of TCGCSV-backed games that can render price
+// charts, keyed by Config.Game. Magic is absent on purpose: it charts from
+// product_prices by mtgjson uuid (the default getDatasets path), not from
 // tcgplayer_nonmagic_product_prices.
 //
-// Adding a game is one entry here. Everything else is already game-agnostic:
-// ingestion (tcgcsv_config.games), storage and schema partitions (schema_tcg.sql,
-// with EnsureTCGCategoryPartition as a runtime backstop), the Market/Low chart
-// lines (tcgChartRefs), curated checkpoints, and the chart UI. The one external
-// prerequisite this file can't encode is card data: mtgmatcher must resolve the
-// game's cards to a tcgplayerProductId (as it does for Lorcana), or charts render
-// empty.
+// Adding a game is one entry here; ingestion (tcgcsv_config.games), schema
+// partitions (schema_tcg.sql, with EnsureTCGCategoryPartition as a runtime
+// backstop), the Market/Low lines (tcgChartRefs), curated checkpoints, and the
+// chart UI are all game-agnostic. The one prerequisite this file can't encode is
+// card data: mtgmatcher must resolve the game's cards to a tcgplayerProductId.
+// Today only Magic and Lorcana have a mtgmatcher loader, so every entry except
+// lorcana is dormant — its sub-types are recorded and ready, but its charts stay
+// empty until mtgmatcher can resolve that game's cards. Keys are the lowercase
+// Config.Game string a future deployment would set; rename if the loader lands
+// under a different identifier.
 //
-// Sub-type names are TCGplayer's own and differ per game, so confirm them against
-// the live tcgcsv feed before adding one — observed names (mapping foil vs
-// non-foil is the adder's call): Pokemon has Normal / Holofoil / Reverse Holofoil,
-// One Piece has Normal / Foil. A game with more than a foil/non-foil split (e.g.
-// Pokemon's Reverse Holofoil as its own printing) needs this finish model
-// revisited once mtgmatcher exposes that distinction.
+// Sub-type names are TCGplayer's own, taken from the live tcgcsv feed. NonFoil
+// and Foil each list every sub_type_name that backs that finish, in preference
+// order; a product carries exactly one sub-type, so listing several just lets one
+// entry cover all of a game's printings. The split is exact for the Normal/Foil
+// games and Lorcana, and approximate where TCGplayer's sub-types aren't a clean
+// foil axis (revisit these when their cards actually load):
+//   - pokemon: Holofoil and Reverse Holofoil are two distinct foil finishes
+//     folded into "foil".
+//   - fleshandblood: only the base finishes; the 1st Edition / Unlimited Edition
+//     variants are not modeled.
+//   - yugioh: sub-types are editions (1st Edition/Unlimited/Limited), not
+//     finishes, so all map to NonFoil and there is no foil line.
+//   - vanguard: the feed exposes no foil sub-type.
 var tcgChartGames = map[string]tcgChartGame{
 	"lorcana": {
 		Category: tcgcsv.CategoryLorcana,
 		NonFoil:  []string{"Normal"},
 		Foil:     []string{"Cold Foil", "Holofoil"},
+	},
+	"onepiece": {
+		Category: tcgcsv.CategoryOnePiece,
+		NonFoil:  []string{"Normal"},
+		Foil:     []string{"Foil"},
+	},
+	"dragonball": {
+		Category: tcgcsv.CategoryDragonBallSuper,
+		NonFoil:  []string{"Normal"},
+		Foil:     []string{"Foil"},
+	},
+	"digimon": {
+		Category: tcgcsv.CategoryDigimon,
+		NonFoil:  []string{"Normal"},
+		Foil:     []string{"Foil"},
+	},
+	"starwars": {
+		Category: tcgcsv.CategoryStarWarsUnlimited,
+		NonFoil:  []string{"Normal"},
+		Foil:     []string{"Foil"},
+	},
+	"riftbound": {
+		Category: tcgcsv.CategoryRiftbound,
+		NonFoil:  []string{"Normal"},
+		Foil:     []string{"Foil"},
+	},
+	"pokemon": {
+		Category: tcgcsv.CategoryPokemon,
+		NonFoil:  []string{"Normal"},
+		Foil:     []string{"Holofoil", "Reverse Holofoil"},
+	},
+	"fleshandblood": {
+		Category: tcgcsv.CategoryFleshAndBlood,
+		NonFoil:  []string{"Normal"},
+		Foil:     []string{"Rainbow Foil", "Cold Foil"},
+	},
+	"vanguard": {
+		Category: tcgcsv.CategoryVanguard,
+		NonFoil:  []string{"Normal"},
+		// The tcgcsv feed exposes no foil sub-type for Vanguard.
+	},
+	"yugioh": {
+		Category: tcgcsv.CategoryYuGiOh,
+		// Sub-types are editions, not finishes, so there is no foil line.
+		NonFoil: []string{"1st Edition", "Unlimited", "Limited", "Normal"},
 	},
 }
 

--- a/chart.go
+++ b/chart.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/mtgban/go-mtgban/mtgmatcher"
+	"github.com/mtgban/mtgban-website/tcgcsv"
 	"github.com/mtgban/mtgban-website/timeseries"
 )
 
@@ -97,6 +98,13 @@ func getDatasets(ctx context.Context, cardId string, sealed bool, keys []string,
 		return nil
 	}
 
+	// Games without an mtgjson uuid (Lorcana, ...) keep their price history in
+	// tcgplayer_nonmagic_product_prices keyed by TCGplayer product id, so route
+	// them to the TCG builder instead of the product_prices/uuid path below.
+	if categoryID, ok := gameTCGCategory(); ok {
+		return getTCGDatasets(ctx, categoryID, cardId, keys, lb)
+	}
+
 	// Pre-filter applicable configs so we don't pay for a DB round-trip
 	// or a UUID lookup when nothing will render.
 	var configs []DatasetConfig
@@ -158,6 +166,181 @@ func buildDataset(results map[string]timeseries.PriceRow, labels []string, confi
 		Color:     config.Color,
 		Reference: config.PublicName,
 	}
+}
+
+// gameTCGCategory maps the deployment's game to the TCGplayer category whose
+// tcgplayer_nonmagic_product_prices history backs its price charts, and reports
+// whether such charts exist for it. Magic keeps its history in product_prices
+// keyed by mtgjson uuid (the default getDatasets path), so it is not listed
+// here; only games ingested from TCGCSV by product id are. Adding a game is one
+// case here plus a partition in schema_tcg.sql.
+func gameTCGCategory() (int, bool) {
+	switch Config.Game {
+	case "lorcana":
+		return tcgcsv.CategoryLorcana, true
+	}
+	return 0, false
+}
+
+// tcgSubTypesForFinish lists the tcgcsv sub-types that back a card's finish, in
+// preference order. mtgmatcher only tracks foil vs non-foil, but TCGplayer files
+// a Lorcana card's non-foil printing under "Normal" and its foil printing under
+// "Cold Foil" (older and special products use "Holofoil"), so a foil card
+// accepts either foil sub-type and the earliest/best-populated one wins.
+func tcgSubTypesForFinish(foil bool) []string {
+	if foil {
+		return []string{"Cold Foil", "Holofoil"}
+	}
+	return []string{"Normal"}
+}
+
+// tcgChartRefs are the price lines a TCG (product-id) chart draws, one per
+// tcgplayer_nonmagic_product_prices column worth plotting. Names and colors
+// mirror the Magic timeseries_config so a TCGplayer line looks the same across
+// games. Market leads Low because it's the headline number; both render as gaps
+// (Number.NaN) on the days TCGCSV reported null.
+var tcgChartRefs = []struct {
+	Name  string
+	Color string
+	Pick  func(timeseries.TCGPriceRow) *float64
+}{
+	{"TCGplayer Market", "rgb(255, 159, 64)", func(r timeseries.TCGPriceRow) *float64 { return r.MarketPrice }},
+	{"TCGplayer Low", "rgb(255, 99, 132)", func(r timeseries.TCGPriceRow) *float64 { return r.LowPrice }},
+}
+
+// tcgProductForCard resolves a card id to its TCGplayer product id (as an int)
+// and foil finish, the two inputs a TCG chart query needs. ok is false when the
+// card doesn't resolve or carries no usable product id.
+func tcgProductForCard(cardId string) (productID int, foil bool, ok bool) {
+	co, err := mtgmatcher.GetUUID(cardId)
+	if err != nil {
+		return 0, false, false
+	}
+	pid, err := strconv.Atoi(tcgProductIdForCO(co, cardId))
+	if err != nil {
+		return 0, false, false
+	}
+	return pid, co.Foil, true
+}
+
+// getTCGEarliest returns the oldest date, within the lookback window, that the
+// card's TCGplayer product has price history for. When the product doesn't
+// resolve or has no rows it falls back to the lookback floor (lb.Since()), never
+// a zero time — getDateAxisValues walks day-by-day from today back to whatever
+// it's handed, so a zero earliest would build a ~740k-entry axis back to year
+// one. This mirrors GetEarliestDate, which clamps the Magic uuid path to the
+// same floor.
+func getTCGEarliest(ctx context.Context, categoryID int, cardId string, lb timeseries.Lookback) time.Time {
+	if PricesArchiveDB == nil {
+		return lb.Since()
+	}
+	pid, foil, ok := tcgProductForCard(cardId)
+	if !ok {
+		return lb.Since()
+	}
+	d, found, err := PricesArchiveDB.GetTCGProductEarliestDate(ctx, categoryID, pid, tcgSubTypesForFinish(foil), lb.Since())
+	if err != nil {
+		log.Println(err)
+		return lb.Since()
+	}
+	if !found {
+		return lb.Since()
+	}
+	return d
+}
+
+// getTCGDatasets is the TCG (product-id) counterpart to the product_prices fan-
+// out in getDatasets: it fetches one card's history from
+// tcgplayer_nonmagic_product_prices and projects each tcgChartRefs column onto
+// the shared date axis. A card's foil printing may live under more than one
+// sub-type; the highest-preference sub-type present on a given date wins, so the
+// line stays continuous even where a product switched from "Holofoil" to
+// "Cold Foil". Reference lines with no data on any axis date are dropped.
+func getTCGDatasets(ctx context.Context, categoryID int, cardId string, labels []string, lb timeseries.Lookback) []Dataset {
+	pid, foil, ok := tcgProductForCard(cardId)
+	if !ok {
+		return nil
+	}
+
+	subTypes := tcgSubTypesForFinish(foil)
+	rows, err := PricesArchiveDB.GetTCGPriceHistorySince(ctx, categoryID, pid, subTypes, lb.Since())
+	if err != nil {
+		log.Println(err)
+		return nil
+	}
+	return buildTCGDatasets(rows, subTypes, labels)
+}
+
+// buildTCGDatasets folds TCG price rows onto one row per date and projects each
+// tcgChartRefs column onto the labels axis — the product-id counterpart to
+// buildDataset. When a date carries more than one sub-type (a product listed
+// under both "Cold Foil" and "Holofoil"), the earlier entry in subTypes wins so
+// the line stays on one printing. Missing dates and null prices render as
+// Number.NaN so the chart draws a gap; a reference with no value on any axis
+// date is dropped so it doesn't clutter the legend/reference picker.
+func buildTCGDatasets(rows []timeseries.TCGPriceRow, subTypes []string, labels []string) []Dataset {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	priority := make(map[string]int, len(subTypes))
+	for i, s := range subTypes {
+		priority[s] = i
+	}
+	byDate := make(map[string]timeseries.TCGPriceRow, len(rows))
+	for _, row := range rows {
+		if cur, seen := byDate[row.Date]; !seen || priority[row.SubTypeName] < priority[cur.SubTypeName] {
+			byDate[row.Date] = row
+		}
+	}
+
+	datasets := make([]Dataset, 0, len(tcgChartRefs))
+	for _, ref := range tcgChartRefs {
+		data := make([]string, len(labels))
+		hasData := false
+		for i, label := range labels {
+			if row, found := byDate[label]; found {
+				if price := ref.Pick(row); price != nil {
+					data[i] = fmt.Sprintf("%g", *price)
+					hasData = true
+					continue
+				}
+			}
+			data[i] = "Number.NaN"
+		}
+		if !hasData {
+			continue
+		}
+		datasets = append(datasets, Dataset{
+			Name:      ref.Name,
+			Data:      data,
+			Color:     ref.Color,
+			Reference: ref.Name,
+		})
+	}
+	return datasets
+}
+
+// chartEarliestDate returns the oldest chartable date for a card within the
+// lookback window, dispatching to the TCG product-id history for games that use
+// it and to the product_prices/mtgjson-uuid history for Magic. It gives the
+// chart handlers a single earliest-date call that works for either game family.
+// It never returns a zero time: the fallbacks clamp to the lookback floor so a
+// single-card caller can hand the result straight to getDateAxisValues without
+// it walking the axis back to year one.
+func chartEarliestDate(ctx context.Context, cardId string, lb timeseries.Lookback) time.Time {
+	if PricesArchiveDB == nil {
+		return lb.Since()
+	}
+	if categoryID, ok := gameTCGCategory(); ok {
+		return getTCGEarliest(ctx, categoryID, cardId, lb)
+	}
+	co, err := mtgmatcher.GetUUID(cardId)
+	if err != nil {
+		return lb.Since()
+	}
+	earliest, _ := PricesArchiveDB.GetEarliestDate(ctx, co.UUID, co.Foil, co.Etched, lb)
+	return earliest
 }
 
 // multiCardInput is one card's contribution to a multi-card chart: the

--- a/chart_test.go
+++ b/chart_test.go
@@ -292,13 +292,50 @@ func TestGameTCGCategory(t *testing.T) {
 }
 
 func TestTCGSubTypesForFinish(t *testing.T) {
+	saved := Config.Game
+	defer func() { Config.Game = saved }()
+
+	Config.Game = "lorcana"
 	if got := tcgSubTypesForFinish(false); !reflect.DeepEqual(got, []string{"Normal"}) {
 		t.Errorf("non-foil = %v, want [Normal]", got)
 	}
 	// Foil accepts either foil sub-type, Cold Foil first so it wins ties.
-	got := tcgSubTypesForFinish(true)
-	if !reflect.DeepEqual(got, []string{"Cold Foil", "Holofoil"}) {
+	if got := tcgSubTypesForFinish(true); !reflect.DeepEqual(got, []string{"Cold Foil", "Holofoil"}) {
 		t.Errorf("foil = %v, want [Cold Foil, Holofoil]", got)
+	}
+	// A game with no chart entry has no sub-types — the TCG path is never taken
+	// for it, so this only guards against a stray lookup returning garbage.
+	Config.Game = "magic"
+	if got := tcgSubTypesForFinish(true); got != nil {
+		t.Errorf("unregistered game foil = %v, want nil", got)
+	}
+}
+
+// TestTCGChartGamesWellFormed guards the registry that makes adding a game a
+// single entry: every game must name a real TCGplayer category and at least one
+// sub-type per finish, or its charts would silently render empty.
+func TestTCGChartGamesWellFormed(t *testing.T) {
+	for game, cfg := range tcgChartGames {
+		if game == "" {
+			t.Error("registry has an empty game key")
+		}
+		if cfg.Category <= 0 {
+			t.Errorf("%s: non-positive category %d", game, cfg.Category)
+		}
+		if len(cfg.NonFoil) == 0 {
+			t.Errorf("%s: no non-foil sub-types", game)
+		}
+		if len(cfg.Foil) == 0 {
+			t.Errorf("%s: no foil sub-types", game)
+		}
+	}
+
+	// The wired game stays reachable through the public dispatch.
+	saved := Config.Game
+	defer func() { Config.Game = saved }()
+	Config.Game = "lorcana"
+	if cat, ok := gameTCGCategory(); !ok || cat != tcgChartGames["lorcana"].Category {
+		t.Errorf("lorcana dispatch = (%d, %v), want (%d, true)", cat, ok, tcgChartGames["lorcana"].Category)
 	}
 }
 

--- a/chart_test.go
+++ b/chart_test.go
@@ -278,6 +278,12 @@ func TestGameTCGCategory(t *testing.T) {
 	if cat, ok := gameTCGCategory(); !ok || cat != 71 {
 		t.Errorf("lorcana -> (%d, %v), want (71, true)", cat, ok)
 	}
+	// A registered non-Lorcana game routes to the TCG path too (dormant until its
+	// cards load, but the dispatch is live).
+	Config.Game = "pokemon"
+	if cat, ok := gameTCGCategory(); !ok || cat != 3 {
+		t.Errorf("pokemon -> (%d, %v), want (3, true)", cat, ok)
+	}
 	// Magic charts off product_prices (mtgjson uuid), so it must NOT route to
 	// the TCG path here — that keeps DisableChart and getDatasets on their
 	// existing Magic behavior.
@@ -285,7 +291,8 @@ func TestGameTCGCategory(t *testing.T) {
 	if _, ok := gameTCGCategory(); ok {
 		t.Error("magic should not have a TCG category")
 	}
-	Config.Game = "pokemon"
+	// A game with no registry entry stays off the TCG path entirely.
+	Config.Game = "notarealgame"
 	if _, ok := gameTCGCategory(); ok {
 		t.Error("an unwired game should not report a TCG category")
 	}
@@ -312,21 +319,28 @@ func TestTCGSubTypesForFinish(t *testing.T) {
 }
 
 // TestTCGChartGamesWellFormed guards the registry that makes adding a game a
-// single entry: every game must name a real TCGplayer category and at least one
-// sub-type per finish, or its charts would silently render empty.
+// single entry: every game must name a real TCGplayer category, carry at least
+// one non-foil sub-type (the base finish that always charts), and use a lowercase
+// single-token key so it can match Config.Game. Foil may be empty for a game with
+// no foil finish (Yu-Gi-Oh, Vanguard).
 func TestTCGChartGamesWellFormed(t *testing.T) {
+	seenCategory := map[int]string{}
 	for game, cfg := range tcgChartGames {
 		if game == "" {
 			t.Error("registry has an empty game key")
 		}
+		if game != strings.ToLower(game) || strings.ContainsAny(game, " \t") {
+			t.Errorf("game key %q must be a lowercase single token (it must equal Config.Game)", game)
+		}
 		if cfg.Category <= 0 {
 			t.Errorf("%s: non-positive category %d", game, cfg.Category)
 		}
-		if len(cfg.NonFoil) == 0 {
-			t.Errorf("%s: no non-foil sub-types", game)
+		if prev, dup := seenCategory[cfg.Category]; dup {
+			t.Errorf("category %d mapped by both %q and %q", cfg.Category, prev, game)
 		}
-		if len(cfg.Foil) == 0 {
-			t.Errorf("%s: no foil sub-types", game)
+		seenCategory[cfg.Category] = game
+		if len(cfg.NonFoil) == 0 {
+			t.Errorf("%s: no non-foil sub-types (the base finish would never chart)", game)
 		}
 	}
 

--- a/chart_test.go
+++ b/chart_test.go
@@ -1,13 +1,17 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/mtgban/go-mtgban/mtgmatcher"
+	"github.com/mtgban/mtgban-website/timeseries"
 )
+
+func fptr(f float64) *float64 { return &f }
 
 // nRealUUIDs returns n distinct UUIDs from the loaded mtgmatcher pool, or skips
 // the test when fewer are available. parseChartIDs is the only branch that
@@ -263,6 +267,129 @@ func TestMergeMultiCardDatasetsReferenceOrderFirstSeen(t *testing.T) {
 	want := []string{"TCG Low", "CK Buy", "TCG Market"}
 	if !reflect.DeepEqual(refs, want) {
 		t.Errorf("refs = %v, want %v", refs, want)
+	}
+}
+
+func TestGameTCGCategory(t *testing.T) {
+	saved := Config.Game
+	defer func() { Config.Game = saved }()
+
+	Config.Game = "lorcana"
+	if cat, ok := gameTCGCategory(); !ok || cat != 71 {
+		t.Errorf("lorcana -> (%d, %v), want (71, true)", cat, ok)
+	}
+	// Magic charts off product_prices (mtgjson uuid), so it must NOT route to
+	// the TCG path here — that keeps DisableChart and getDatasets on their
+	// existing Magic behavior.
+	Config.Game = "magic"
+	if _, ok := gameTCGCategory(); ok {
+		t.Error("magic should not have a TCG category")
+	}
+	Config.Game = "pokemon"
+	if _, ok := gameTCGCategory(); ok {
+		t.Error("an unwired game should not report a TCG category")
+	}
+}
+
+func TestTCGSubTypesForFinish(t *testing.T) {
+	if got := tcgSubTypesForFinish(false); !reflect.DeepEqual(got, []string{"Normal"}) {
+		t.Errorf("non-foil = %v, want [Normal]", got)
+	}
+	// Foil accepts either foil sub-type, Cold Foil first so it wins ties.
+	got := tcgSubTypesForFinish(true)
+	if !reflect.DeepEqual(got, []string{"Cold Foil", "Holofoil"}) {
+		t.Errorf("foil = %v, want [Cold Foil, Holofoil]", got)
+	}
+}
+
+func TestBuildTCGDatasetsEmpty(t *testing.T) {
+	if got := buildTCGDatasets(nil, []string{"Normal"}, []string{"2024-01-01"}); got != nil {
+		t.Errorf("expected nil for no rows, got %v", got)
+	}
+}
+
+// The dataset order and names must track tcgChartRefs (Market then Low) so this
+// test doubles as a guard on that config.
+func TestBuildTCGDatasetsProjectsColumnsOntoAxis(t *testing.T) {
+	labels := []string{"2024-01-03", "2024-01-02", "2024-01-01"}
+	rows := []timeseries.TCGPriceRow{
+		{Date: "2024-01-03", SubTypeName: "Normal", MarketPrice: fptr(3), LowPrice: fptr(2.5)},
+		{Date: "2024-01-01", SubTypeName: "Normal", MarketPrice: fptr(1), LowPrice: fptr(0.5)},
+		// 2024-01-02 intentionally absent -> gap on both lines.
+	}
+	out := buildTCGDatasets(rows, []string{"Normal"}, labels)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 datasets (Market, Low), got %d: %+v", len(out), out)
+	}
+	if out[0].Name != "TCGplayer Market" || out[1].Name != "TCGplayer Low" {
+		t.Fatalf("dataset order/names off: %q, %q", out[0].Name, out[1].Name)
+	}
+	wantMarket := []string{"3", "Number.NaN", "1"}
+	if !reflect.DeepEqual(out[0].Data, wantMarket) {
+		t.Errorf("Market data = %v, want %v", out[0].Data, wantMarket)
+	}
+	wantLow := []string{"2.5", "Number.NaN", "0.5"}
+	if !reflect.DeepEqual(out[1].Data, wantLow) {
+		t.Errorf("Low data = %v, want %v", out[1].Data, wantLow)
+	}
+	if out[0].Reference != "TCGplayer Market" || out[0].Color == "" {
+		t.Errorf("Reference/Color not set: %+v", out[0])
+	}
+}
+
+func TestBuildTCGDatasetsDropsAllNullReference(t *testing.T) {
+	labels := []string{"2024-01-01"}
+	// Market is null everywhere -> its line is dropped; Low survives.
+	rows := []timeseries.TCGPriceRow{
+		{Date: "2024-01-01", SubTypeName: "Normal", MarketPrice: nil, LowPrice: fptr(4)},
+	}
+	out := buildTCGDatasets(rows, []string{"Normal"}, labels)
+	if len(out) != 1 {
+		t.Fatalf("expected only the Low dataset, got %d: %+v", len(out), out)
+	}
+	if out[0].Name != "TCGplayer Low" {
+		t.Errorf("kept the wrong dataset: %q", out[0].Name)
+	}
+}
+
+func TestBuildTCGDatasetsPrefersEarlierSubType(t *testing.T) {
+	labels := []string{"2024-01-01"}
+	// Same date under both foil sub-types; "Cold Foil" precedes "Holofoil" in the
+	// preference list, so its price must win.
+	rows := []timeseries.TCGPriceRow{
+		{Date: "2024-01-01", SubTypeName: "Holofoil", MarketPrice: fptr(99)},
+		{Date: "2024-01-01", SubTypeName: "Cold Foil", MarketPrice: fptr(10)},
+	}
+	out := buildTCGDatasets(rows, []string{"Cold Foil", "Holofoil"}, labels)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 dataset (Market), got %d: %+v", len(out), out)
+	}
+	if !reflect.DeepEqual(out[0].Data, []string{"10"}) {
+		t.Errorf("expected Cold Foil price 10 to win, got %v", out[0].Data)
+	}
+}
+
+// chartEarliestDate feeds getDateAxisValues, which walks day-by-day from today
+// back to the earliest it's handed — a zero time there builds a ~740k-entry axis
+// back to year one. So the earliest must never be zero; the no-data fallbacks
+// clamp to the lookback floor. Regression guard for the TCG path, which used to
+// return a zero time when a card had no history.
+func TestChartEarliestDateStaysBounded(t *testing.T) {
+	saved := Config.Game
+	defer func() { Config.Game = saved }()
+
+	lb := timeseries.Lookback(30)
+	// The Lorcana (TCG product-id) path and the Magic (uuid) path must both stay
+	// bounded when no history is available.
+	for _, game := range []string{"lorcana", "magic"} {
+		Config.Game = game
+		earliest := chartEarliestDate(context.Background(), "no-such-card-id", lb)
+		if earliest.IsZero() {
+			t.Fatalf("%s: chartEarliestDate returned a zero time", game)
+		}
+		if n := len(getDateAxisValues(earliest)); n > lb.Days()+2 {
+			t.Errorf("%s: axis has %d labels, want a window-bounded count (<= %d)", game, n, lb.Days()+2)
+		}
 	}
 }
 

--- a/checkpoints.go
+++ b/checkpoints.go
@@ -114,23 +114,28 @@ func currentCheckpointsJSON() (string, error) {
 }
 
 // relevantCheckpoints returns the checkpoint markers that apply to a chart for
-// the given card. Bans are curated; releases and reprints both come from
-// SealedEditionsList — the same source that used to feed the keyrune-at-top
-// renderer — so the two systems can't drift apart.
+// the given card. Curated ban/unban/format events are matched by card name and
+// apply to every game — they carry no Magic assumptions, and each deployment
+// loads its own checkpoints.json. Release and reprint markers, by contrast, are
+// derived from SealedEditionsList (MTGJSON set metadata) and rendered with
+// Keyrune set glyphs, neither of which exists for a game charted off TCGplayer
+// product ids, so they are appended only for the mtgmatcher-backed game (Magic).
 func relevantCheckpoints(cardName string, earliest time.Time) []ChartCheckpoint {
 	if cardName == "" {
 		return nil
 	}
 
-	printingSet := map[string]bool{}
-	if codes, err := mtgmatcher.Printings4Card(cardName); err == nil {
-		for _, c := range codes {
-			printingSet[strings.ToUpper(c)] = true
-		}
-	}
-
 	out := curatedCheckpoints(cardName, earliest)
-	out = append(out, setCheckpointsFromEditions(cardName, earliest, printingSet)...)
+
+	if _, isTCG := gameTCGCategory(); !isTCG {
+		printingSet := map[string]bool{}
+		if codes, err := mtgmatcher.Printings4Card(cardName); err == nil {
+			for _, c := range codes {
+				printingSet[strings.ToUpper(c)] = true
+			}
+		}
+		out = append(out, setCheckpointsFromEditions(cardName, earliest, printingSet)...)
+	}
 
 	sort.SliceStable(out, func(i, j int) bool {
 		return out[i].Date < out[j].Date

--- a/checkpoints_test.go
+++ b/checkpoints_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// Curated ban/unban/format events are matched purely by card name and carry no
+// Magic assumptions, so they must surface for a TCGplayer-product-id game
+// (Lorcana) exactly as they do for Magic. Only the MTGJSON/Keyrune-derived
+// release & reprint markers are Magic-gated. Regression guard against the
+// earlier "checkpoints are Magic-only" gate that suppressed bans wholesale.
+func TestCuratedCheckpointsApplyToAllGames(t *testing.T) {
+	savedGame := Config.Game
+	savedEvents := checkpointsStore.Get()
+	defer func() {
+		Config.Game = savedGame
+		checkpointsStore.Set(savedEvents)
+	}()
+
+	const banned = "Bucky - Squirrel Squadron"
+	checkpointsStore.Set(checkpointsFile{Events: []CheckpointEvent{
+		{
+			ID:          "test-ban",
+			Type:        "ban",
+			Date:        "2024-11-15",
+			Format:      "Core Constructed",
+			Title:       "Q3 Banned & Restricted",
+			CardsBanned: []string{banned},
+		},
+	}})
+
+	earliest := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	for _, game := range []string{"lorcana", "magic"} {
+		Config.Game = game
+
+		bans := 0
+		for _, cp := range relevantCheckpoints(banned, earliest) {
+			if cp.Type == "ban" {
+				bans++
+			}
+		}
+		if bans != 1 {
+			t.Errorf("%s: got %d ban checkpoints, want 1 (curated bans apply to every game)", game, bans)
+		}
+
+		// A card not on any list gets nothing — the curated match is by name.
+		if got := relevantCheckpoints("Some Unlisted Card", earliest); len(got) != 0 {
+			t.Errorf("%s: unlisted card got %d checkpoints, want 0", game, len(got))
+		}
+	}
+}

--- a/checkpoints_test.go
+++ b/checkpoints_test.go
@@ -45,9 +45,19 @@ func TestCuratedCheckpointsApplyToAllGames(t *testing.T) {
 			t.Errorf("%s: got %d ban checkpoints, want 1 (curated bans apply to every game)", game, bans)
 		}
 
-		// A card not on any list gets nothing — the curated match is by name.
-		if got := relevantCheckpoints("Some Unlisted Card", earliest); len(got) != 0 {
-			t.Errorf("%s: unlisted card got %d checkpoints, want 0", game, len(got))
+		// A card on no curated list gets no curated markers — the match is by
+		// name. Magic still emits card-independent release markers from set
+		// metadata (they annotate every chart in the window), so count only the
+		// curated types here rather than the full set.
+		curated := 0
+		for _, cp := range relevantCheckpoints("Some Unlisted Card", earliest) {
+			switch cp.Type {
+			case "ban", "unban", "format":
+				curated++
+			}
+		}
+		if curated != 0 {
+			t.Errorf("%s: unlisted card got %d curated checkpoints, want 0", game, curated)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -685,8 +685,12 @@ func genPageNav(activeTab, sig string) PageVars {
 		// Append which game this site is for
 		pageVars.Title += " - " + mtgmatcher.Title(Config.Game)
 
-		// Charts are available only for one game
-		pageVars.DisableChart = true
+		// Magic charts price history by mtgjson uuid; non-Magic games chart off
+		// TCGplayer product ids when we ingest their history (gameTCGCategory).
+		// Any other game has nothing to chart, so keep charts off for it.
+		if _, ok := gameTCGCategory(); !ok {
+			pageVars.DisableChart = true
+		}
 	}
 	if Config.OfflineKey != "" {
 		pageVars.DisableChart = true

--- a/search.go
+++ b/search.go
@@ -727,7 +727,7 @@ func Search(w http.ResponseWriter, r *http.Request) {
 			lb := chartLookback(sig)
 			pageVars.MaxLookbackDays = lb.Days()
 
-			earliest, _ := PricesArchiveDB.GetEarliestDate(r.Context(), co.UUID, co.Foil, co.Etched, lb)
+			earliest := chartEarliestDate(r.Context(), chartId, lb)
 
 			pageVars.AxisLabels = getDateAxisValues(earliest)
 			pageVars.Datasets = getDatasets(r.Context(), chartId, co.Sealed, pageVars.AxisLabels, lb)
@@ -749,10 +749,12 @@ func Search(w http.ResponseWriter, r *http.Request) {
 					continue
 				}
 				chartNames = append(chartNames, co.Name)
-				e, _ := PricesArchiveDB.GetEarliestDate(r.Context(), co.UUID, co.Foil, co.Etched, lb)
-				if e.IsZero() {
-					continue
-				}
+				// chartEarliestDate clamps to the lookback floor rather than
+				// returning a zero time, so a card with no history widens the axis
+				// to the full window (as the Magic path already does) instead of
+				// being dropped; earliest.IsZero() below is only the accumulator's
+				// unset state before the first card.
+				e := chartEarliestDate(r.Context(), id, lb)
 				if earliest.IsZero() || e.Before(earliest) {
 					earliest = e
 				}

--- a/templates/search.html
+++ b/templates/search.html
@@ -475,10 +475,16 @@
                                     {{end}}
                                 </p>
                                 {{if .Checkpoints}}
+                                {{$hasReprint := false}}{{$hasRelease := false}}{{$hasBan := false}}
+                                {{range .Checkpoints}}
+                                    {{if eq .Type "reprint"}}{{$hasReprint = true}}{{end}}
+                                    {{if or (eq .Type "release") (eq .Type "format")}}{{$hasRelease = true}}{{end}}
+                                    {{if or (eq .Type "ban") (eq .Type "unban")}}{{$hasBan = true}}{{end}}
+                                {{end}}
                                 <p class="chart-checkpoint-toggles">
-                                    <label class="cp-pill cp-pill-reprint"><input type="checkbox" id="cpToggleReprint" checked onchange="toggleCheckpointType('reprint', this.checked)"> Reprints</label>
-                                    <label class="cp-pill cp-pill-release"><input type="checkbox" id="cpToggleRelease" checked onchange="toggleCheckpointType('release', this.checked)"> Releases</label>
-                                    <label class="cp-pill cp-pill-ban"><input type="checkbox" id="cpToggleBan" checked onchange="toggleCheckpointType('ban', this.checked)"> Bans</label>
+                                    {{if $hasReprint}}<label class="cp-pill cp-pill-reprint"><input type="checkbox" id="cpToggleReprint" checked onchange="toggleCheckpointType('reprint', this.checked)"> Reprints</label>{{end}}
+                                    {{if $hasRelease}}<label class="cp-pill cp-pill-release"><input type="checkbox" id="cpToggleRelease" checked onchange="toggleCheckpointType('release', this.checked)"> Releases</label>{{end}}
+                                    {{if $hasBan}}<label class="cp-pill cp-pill-ban"><input type="checkbox" id="cpToggleBan" checked onchange="toggleCheckpointType('ban', this.checked)"> Bans</label>{{end}}
                                 </p>
                                 {{end}}
                                 {{if and .IsMultiChart .ChartReferences}}

--- a/timeseries/tcg_prices.go
+++ b/timeseries/tcg_prices.go
@@ -149,6 +149,73 @@ func (c *Client) GetLatestTCGPrice(ctx context.Context, categoryID, productID in
 	return scanTCGRow(c.db.QueryRowContext(ctx, q, categoryID, productID, subTypeName))
 }
 
+// tcgSubTypeInClause builds a "sub_type_name IN ($n,...)" fragment for the given
+// sub-types, appending their values to args, and returns the fragment. Callers
+// pass the already-bound leading args (category, product, ...) so the
+// placeholders continue their numbering. It assumes len(subTypes) > 0.
+func tcgSubTypeInClause(subTypes []string, args *[]any) string {
+	placeholders := make([]string, len(subTypes))
+	for i, s := range subTypes {
+		*args = append(*args, s)
+		placeholders[i] = fmt.Sprintf("$%d", len(*args))
+	}
+	return "sub_type_name IN (" + strings.Join(placeholders, ",") + ")"
+}
+
+// GetTCGPriceHistorySince returns every stored price for a product across the
+// given sub-types on or after `since`, newest first. Accepting more than one
+// sub-type lets a caller fold a card's alternate foil printings (Lorcana lists a
+// foil card under "Cold Foil" or "Holofoil") into one query; the caller picks
+// which sub-type wins per date. Returns nil when no sub-types are requested.
+func (c *Client) GetTCGPriceHistorySince(ctx context.Context, categoryID, productID int, subTypes []string, since time.Time) ([]TCGPriceRow, error) {
+	if len(subTypes) == 0 {
+		return nil, nil
+	}
+	args := []any{categoryID, productID, since}
+	inClause := tcgSubTypeInClause(subTypes, &args)
+	q := `SELECT` + tcgSelectColumns + `
+		FROM tcgplayer_nonmagic_product_prices
+		WHERE category_id = $1 AND product_id = $2 AND date >= $3 AND ` + inClause + `
+		ORDER BY date DESC`
+	rows, err := c.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []TCGPriceRow
+	for rows.Next() {
+		row, err := scanTCGRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, row)
+	}
+	return result, rows.Err()
+}
+
+// GetTCGProductEarliestDate returns the oldest date stored for a product within
+// the given sub-types on or after `since`. The bool is false (with a zero time)
+// when there are no matching rows. It scopes a single card's chart axis the way
+// GetEarliestDate does for a Magic uuid.
+func (c *Client) GetTCGProductEarliestDate(ctx context.Context, categoryID, productID int, subTypes []string, since time.Time) (time.Time, bool, error) {
+	if len(subTypes) == 0 {
+		return time.Time{}, false, nil
+	}
+	args := []any{categoryID, productID, since}
+	inClause := tcgSubTypeInClause(subTypes, &args)
+	q := `SELECT MIN(date) FROM tcgplayer_nonmagic_product_prices
+		WHERE category_id = $1 AND product_id = $2 AND date >= $3 AND ` + inClause
+	var d sql.NullTime
+	if err := c.db.QueryRowContext(ctx, q, args...).Scan(&d); err != nil {
+		return time.Time{}, false, err
+	}
+	if !d.Valid {
+		return time.Time{}, false, nil
+	}
+	return d.Time, true, nil
+}
+
 // GetTCGEarliestDate returns the oldest date stored for a category. The bool is
 // false (with a zero time) when the category has no rows yet.
 func (c *Client) GetTCGEarliestDate(ctx context.Context, categoryID int) (time.Time, bool, error) {

--- a/timeseries/tcg_prices_live_test.go
+++ b/timeseries/tcg_prices_live_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"testing"
+	"time"
 )
 
 // TestTCGPricesLive exercises the tcgplayer_nonmagic_product_prices code paths end to end against a
@@ -124,6 +125,37 @@ func TestTCGPricesLive(t *testing.T) {
 	}
 	if got := newest.Format("2006-01-02"); got != "2024-02-09" {
 		t.Errorf("latest date = %s, want 2024-02-09", got)
+	}
+
+	// Lookback-scoped history for the chart path: both Normal rows on or after
+	// 02-08, newest first; the since bound then trims the older one.
+	day08 := time.Date(2024, 2, 8, 0, 0, 0, 0, time.UTC)
+	day09 := time.Date(2024, 2, 9, 0, 0, 0, 0, time.UTC)
+	since08, err := c.GetTCGPriceHistorySince(ctx, liveSentinelCategory, product, []string{"Normal"}, day08)
+	if err != nil {
+		t.Fatalf("GetTCGPriceHistorySince: %v", err)
+	}
+	if len(since08) != 2 || since08[0].Date != "2024-02-09" || since08[1].Date != "2024-02-08" {
+		t.Errorf("since 02-08 = %+v, want the two Normal rows newest-first", since08)
+	}
+	// Multiple sub-types fold into one query; the since bound drops 02-08 so only
+	// the 02-09 Normal row survives (Foil exists only on 02-08).
+	since09, err := c.GetTCGPriceHistorySince(ctx, liveSentinelCategory, product, []string{"Normal", "Cold Foil", "Foil"}, day09)
+	if err != nil {
+		t.Fatalf("GetTCGPriceHistorySince (since 09): %v", err)
+	}
+	if len(since09) != 1 || since09[0].Date != "2024-02-09" || since09[0].SubTypeName != "Normal" {
+		t.Errorf("since 02-09 = %+v, want only the 02-09 Normal row", since09)
+	}
+
+	// Per-product earliest within the sub-types and window.
+	earliestN, ok, err := c.GetTCGProductEarliestDate(ctx, liveSentinelCategory, product, []string{"Normal"}, day08)
+	if err != nil || !ok || earliestN.Format("2006-01-02") != "2024-02-08" {
+		t.Errorf("GetTCGProductEarliestDate(Normal) = (%v, ok=%v, err=%v), want 2024-02-08", earliestN, ok, err)
+	}
+	// Foil only exists on 02-08, so a 02-09 floor yields no data.
+	if _, ok, err := c.GetTCGProductEarliestDate(ctx, liveSentinelCategory, product, []string{"Foil"}, day09); err != nil || ok {
+		t.Errorf("earliest Foil since 02-09 = (ok=%v, err=%v), want ok=false", ok, err)
 	}
 
 	// Re-upserting is idempotent (no duplicate rows) and overwrites in place.

--- a/timeseries/tcg_prices_test.go
+++ b/timeseries/tcg_prices_test.go
@@ -69,6 +69,23 @@ func TestDedupeTCGPriceRows(t *testing.T) {
 	}
 }
 
+func TestTCGSubTypeInClause(t *testing.T) {
+	// Leading bound args (category, product, since) keep placeholder numbering
+	// continuing from $4, matching the queries that call this.
+	args := []any{71, 12345, "2024-02-08"}
+	clause := tcgSubTypeInClause([]string{"Cold Foil", "Holofoil"}, &args)
+
+	if clause != "sub_type_name IN ($4,$5)" {
+		t.Errorf("clause = %q, want sub_type_name IN ($4,$5)", clause)
+	}
+	if len(args) != 5 {
+		t.Fatalf("args len = %d, want 5", len(args))
+	}
+	if args[3] != "Cold Foil" || args[4] != "Holofoil" {
+		t.Errorf("appended sub-types = %v, %v; want Cold Foil, Holofoil", args[3], args[4])
+	}
+}
+
 // A read-only client must never touch the database: these calls short-circuit
 // before dereferencing the (nil) connection.
 func TestTCGWritesReadOnly(t *testing.T) {

--- a/utils.go
+++ b/utils.go
@@ -319,7 +319,12 @@ func findTCGproductId(cardId string) string {
 	if err != nil {
 		return ""
 	}
+	return tcgProductIdForCO(co, cardId)
+}
 
+// tcgProductIdForCO is findTCGproductId's core for callers that already resolved
+// the card, so they don't pay for a second GetUUID.
+func tcgProductIdForCO(co *mtgmatcher.CardObject, cardId string) string {
 	tcgId := co.Identifiers["tcgplayerProductId"]
 	if co.Etched {
 		id, found := co.Identifiers["tcgplayerEtchedProductId"]


### PR DESCRIPTION
## Summary

Adds price-history charts for TCGCSV-sourced games, keyed by TCGplayer product id, alongside Magic's existing uuid charts. A deployment's `Config.Game` selects the backend:

- **Magic** → the existing `product_prices` / mtgjson-uuid path (unchanged).
- A game in the `tcgChartGames` registry → the new `tcgplayer_nonmagic_product_prices` / product-id path.
- Any other game → charts stay disabled.

Lorcana is live end to end. The registry is pre-populated for every game already ingested into `tcgplayer_nonmagic_product_prices`, so each becomes chartable the moment mtgmatcher can resolve its cards — with no further code change.

## What changed, by commit

- **timeseries: query TCG price history by product** — `GetTCGPriceHistorySince` / `GetTCGProductEarliestDate` read a product's history across a set of sub-types, plus a shared `sub_type_name IN (...)` builder that continues the caller's placeholder numbering. Accepting multiple sub-types lets one query fold a card's alternate foil printings.
- **charts: render Lorcana price history from tcg_prices** — `getTCGDatasets` / `buildTCGDatasets` project the Market and Low columns onto the shared date axis, folding a card's foil sub-types onto one line per date. `chartEarliestDate` dispatches by game family and never returns a zero time (no-data clamps to the lookback floor, so the axis can't walk back to year one). `genPageNav` enables charts for a registered game; `tcgProductIdForCO` is factored out of `findTCGproductId` to avoid a second `GetUUID`.
- **checkpoints: apply curated ban/unban checkpoints to non-Magic games** — curated ban/unban/format events are matched by card name and now surface for any game. Only the MTGJSON/Keyrune-derived release and reprint markers stay Magic-gated, since neither exists for a product-id game.
- **charts: gate checkpoint toggle pills to present marker types** — each Reprints/Releases/Bans pill renders only when a checkpoint it controls is present (grouping mirrors `checkpointToggleKey` in `chartopts.js`), so a chart never shows a pill that toggles nothing.
- **charts: make TCGCSV chart games a single registry entry** — replaces the two game-specific spots (a `gameTCGCategory` switch and a Lorcana-hardcoded `tcgSubTypesForFinish`) with one `tcgChartGames` registry keyed by `Config.Game`, each entry naming the TCGplayer category and the non-foil/foil `sub_type_name` lists. Adding a game is now a single map entry.
- **charts: populate the chart-game registry for all ingested games** — fills the registry with all ten ingested games (see table), with sub-type names taken from the live tcgcsv feed.

## The chart-game registry

Everything but the registry is game-agnostic: ingestion (`tcgcsv_config.games`), schema partitions (`schema_tcg.sql`, with `EnsureTCGCategoryPartition` as a runtime backstop), the Market/Low lines, curated checkpoints, and the chart UI. The one thing the code can't encode is card data — mtgmatcher must resolve a game's cards to a `tcgplayerProductId`.

Today mtgmatcher's `LoadDatastore` only recognizes Magic (AllPrintings) and Lorcana, so of the ten entries **only Lorcana is live**; the other nine are dormant (the dispatch routes, but cards resolve empty until a loader lands). Keys are the lowercase `Config.Game` a deployment would set; a loader arriving under a different identifier is a one-word rename.

| Key | Category | Non-foil | Foil | Fit |
|---|---|---|---|---|
| `lorcana` | 71 | Normal | Cold Foil, Holofoil | exact (live) |
| `onepiece` | 68 | Normal | Foil | exact |
| `dragonball` | 27 | Normal | Foil | exact |
| `digimon` | 63 | Normal | Foil | exact |
| `starwars` | 79 | Normal | Foil | exact |
| `riftbound` | 89 | Normal | Foil | exact |
| `pokemon` | 3 | Normal | Holofoil, Reverse Holofoil | approx — two foil finishes folded |
| `fleshandblood` | 62 | Normal | Rainbow Foil, Cold Foil | approx — 1st Ed / Unlimited variants not modeled |
| `vanguard` | 16 | Normal | — | no foil sub-type in the feed |
| `yugioh` | 2 | 1st Edition, Unlimited, Limited, Normal | — | sub-types are editions, not finishes |

The four approximate/edge cases are flagged in the registry doc comment for revisiting when their cards actually load. mtgmatcher tracks only foil vs non-foil, so a game with more than that split (Pokemon's Reverse Holofoil, Flesh & Blood's editions) will want the finish model extended then.

## Testing

- Unit tests: column projection, all-null-reference drop, sub-type preference, bounded earliest-date, `sub_type_name IN (...)` placeholder numbering, cross-game curated checkpoints, checkpoint-pill gating (render-tested across scenarios), and a well-formed-ness guard on every registry entry (valid category, non-foil coverage, unique category, lowercase-token key). Env-gated live test covers the new queries against a real DB.
- **Magic verified end to end**: ran the server in Magic mode against a real datastore and prices DB and rendered a single-card chart — all nine Magic price sources, a real date axis, release checkpoints, and the pill gating correctly showing only pills with data. No regression.
- Lorcana's sub-type names were verified against the live TCGCSV API across all 20 Lorcana groups (`Normal` / `Cold Foil` / `Holofoil` are the only values that exist); the same sweep sourced every other game's sub-types.

## Notes

- **Adding a game** is one `tcgChartGames` entry (category + verified sub-types). No other code, config, or schema change is needed once the game is ingested.
- The nine dormant games do nothing until mtgmatcher can resolve their cards; a deployment for one can't currently boot (its datastore wouldn't load), so the entries are inert rather than harmful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRnJaFXJFugswb7fqh7eBz
