### PR TITLE
timeseries: drop sealed prices over $50k at ingest

### DIFF
--- a/chart.go
+++ b/chart.go
@@ -297,6 +297,12 @@ func IsStashingInProgress() bool {
 	return stashingInProgress.Load()
 }
 
+// sealedPriceCeiling caps sealed-product prices entering the archive. Rare
+// sealed products (vintage boxes, Secret Lairs) sometimes carry a single
+// mispriced five/six-figure listing upstream; anything above this is treated
+// as noise and dropped. Applies to sealed only — real singles exceed it.
+const sealedPriceCeiling = 50000.0
+
 func stashInTimeseries() {
 	// Only one stash may run at a time. The cron fires every 12h and the
 	// admin button can fire at any moment; CompareAndSwap is the real gate.
@@ -346,6 +352,15 @@ func stashInTimeseries() {
 					continue
 				}
 
+				// Drop mispriced five/six-figure sealed listings so they never
+				// enter the archive. Upstream marketplaces occasionally carry a
+				// lone $100k+ listing for a rare sealed product; anything above
+				// the ceiling is dropped rather than stored. Singles are exempt —
+				// they legitimately exceed this (e.g. an Alpha Black Lotus).
+				if card.Sealed && price > sealedPriceCeiling {
+					continue
+				}
+
 				row := getRow(accumulated, card.UUID, card.Foil, card.Etched, card.IsAlternative, card.Language, date)
 				row.SetPriceForDataset(config.Index, price)
 			}
@@ -371,6 +386,15 @@ func stashInTimeseries() {
 				card, err := mtgmatcher.GetUUID(id)
 				if err != nil {
 					log.Println("Error getting card for", id, err)
+					continue
+				}
+
+				// Drop mispriced five/six-figure sealed listings so they never
+				// enter the archive. Upstream marketplaces occasionally carry a
+				// lone $100k+ listing for a rare sealed product; anything above
+				// the ceiling is dropped rather than stored. Singles are exempt —
+				// they legitimately exceed this (e.g. an Alpha Black Lotus).
+				if card.Sealed && price > sealedPriceCeiling {
 					continue
 				}
 


### PR DESCRIPTION
## What this does

Adds a `$50k` ceiling on **sealed-product** prices entering the price archive. In `stashInTimeseries`, both the retail and buylist loops now skip any sealed price above the ceiling, gated on mtgmatcher's `CardObject.Sealed` so singles are unaffected (a real Alpha Black Lotus legitimately exceeds it).

```go
const sealedPriceCeiling = 50000.0
...
if card.Sealed && price > sealedPriceCeiling {
    continue
}
```

## Why

Rare sealed products occasionally carry a lone mispriced five/six-figure listing upstream — e.g. an Alpha Starter Deck quoted at $200k, an Antiquities booster box at $85k. Those flow into `product_prices` on every 12h stash and skew sealed price history.

## Context (the rest was done as one-time DB ops, not in this PR)

This came out of a sealed price-history effort:

- **Live collection** already writes sealed to `product_prices` (earliest data 2025-02-14) — unchanged by this PR.
- **Backfill** — prepended ~1 year of pre-collection sealed history (2024-02-08 → 2025-02-13, ~888k rows) from TCGCSV daily archives, mapped via `sealedProduct[].identifiers.tcgplayerProductId`. One-time, already applied.
- **Prune** — nulled the 1,001 existing sealed rows over $50k (9 products: Alpha Starter Deck, Antiquities/Tempest/Stronghold boxes, LTR & Bloomburrow cases, a few single-day misprices). Already applied.

This PR is the **going-forward guard** so that prune doesn't get undone on the next stash.

## Scope / testing

- Sealed only; singles exempt.
- `go build ./...` passes.