### PR TITLE
fix: return to the current page after Patreon login

### DIFF
--- a/templates/mobile/search.html
+++ b/templates/mobile/search.html
@@ -25,6 +25,16 @@
     <script type="text/javascript" src="/js/cookies.js?hash={{.Hash}}"></script>
     <script type="text/javascript" src="/js/copy2clip.js?hash={{.Hash}}"></script>
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+    {{if .PatreonLogin}}
+    <script>
+        // Build the Patreon OAuth URL at click time so the current page rides
+        // along in the state param; the Auth callback redirects back to it after
+        // authorizing, instead of dropping the user on the homepage.
+        function getPatreonURL(patreonId, client) {
+            return "https://www.patreon.com/oauth2/authorize?response_type=code&client_id=" + patreonId + "&redirect_uri={{.PatreonURL}}&scope=identity%20identity%5Bemail%5D%20campaigns%20campaigns.members&state=" + encodeURIComponent(window.location.href + ";" + client);
+        }
+    </script>
+    {{end}}
 {{end}}
 
 {{define "content"}}
@@ -350,7 +360,7 @@
                                     <span class="m-vendor-name dim">{{$entry.ScraperName}}</span>
                                     <span class="m-locked-cta">
                                         <a class="m-locked-btn" href="https://www.patreon.com/MTGBAN" target="_blank">Join</a>
-                                        {{range $ref, $id := $.PatreonIds}}<a class="m-locked-btn m-locked-btn-login" href="https://www.patreon.com/oauth2/authorize?response_type=code&client_id={{$id}}&redirect_uri={{$.PatreonURL}}&scope=identity%20identity%5Bemail%5D%20campaigns%20campaigns.members&state={{$ref}}">Log in</a>{{end}}
+                                        {{range $ref, $id := $.PatreonIds}}<a class="m-locked-btn m-locked-btn-login" href="javascript:window.location = getPatreonURL('{{$id}}', '{{$ref}}')">Log in</a>{{end}}
                                     </span>
                                 </div>
                                 {{else}}
@@ -374,7 +384,7 @@
                                     <span class="m-vendor-name dim">{{$entry.ScraperName}} {{$entry.Country}}</span>
                                     <span class="m-locked-cta">
                                         <a class="m-locked-btn" href="https://www.patreon.com/MTGBAN" target="_blank">Join</a>
-                                        {{range $ref, $id := $.PatreonIds}}<a class="m-locked-btn m-locked-btn-login" href="https://www.patreon.com/oauth2/authorize?response_type=code&client_id={{$id}}&redirect_uri={{$.PatreonURL}}&scope=identity%20identity%5Bemail%5D%20campaigns%20campaigns.members&state={{$ref}}">Log in</a>{{end}}
+                                        {{range $ref, $id := $.PatreonIds}}<a class="m-locked-btn m-locked-btn-login" href="javascript:window.location = getPatreonURL('{{$id}}', '{{$ref}}')">Log in</a>{{end}}
                                     </span>
                                 </div>
                                 {{else}}
@@ -437,7 +447,7 @@
                                     <span class="m-vendor-name dim">{{$entry.ScraperName}}</span>
                                     <span class="m-locked-cta">
                                         <a class="m-locked-btn" href="https://www.patreon.com/MTGBAN" target="_blank">Join</a>
-                                        {{range $ref, $id := $.PatreonIds}}<a class="m-locked-btn m-locked-btn-login" href="https://www.patreon.com/oauth2/authorize?response_type=code&client_id={{$id}}&redirect_uri={{$.PatreonURL}}&scope=identity%20identity%5Bemail%5D%20campaigns%20campaigns.members&state={{$ref}}">Log in</a>{{end}}
+                                        {{range $ref, $id := $.PatreonIds}}<a class="m-locked-btn m-locked-btn-login" href="javascript:window.location = getPatreonURL('{{$id}}', '{{$ref}}')">Log in</a>{{end}}
                                     </span>
                                 </div>
                                 {{else}}
@@ -461,7 +471,7 @@
                                     <span class="m-vendor-name dim">{{$entry.ScraperName}} {{$entry.Country}}</span>
                                     <span class="m-locked-cta">
                                         <a class="m-locked-btn" href="https://www.patreon.com/MTGBAN" target="_blank">Join</a>
-                                        {{range $ref, $id := $.PatreonIds}}<a class="m-locked-btn m-locked-btn-login" href="https://www.patreon.com/oauth2/authorize?response_type=code&client_id={{$id}}&redirect_uri={{$.PatreonURL}}&scope=identity%20identity%5Bemail%5D%20campaigns%20campaigns.members&state={{$ref}}">Log in</a>{{end}}
+                                        {{range $ref, $id := $.PatreonIds}}<a class="m-locked-btn m-locked-btn-login" href="javascript:window.location = getPatreonURL('{{$id}}', '{{$ref}}')">Log in</a>{{end}}
                                     </span>
                                 </div>
                                 {{else}}

--- a/templates/search.html
+++ b/templates/search.html
@@ -51,6 +51,16 @@
     <script type="text/javascript" src="/js/recent-searches.js?hash={{.Hash}}"></script>
     <script type="text/javascript" src="/js/favorites.js?hash={{.Hash}}"></script>
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+    {{if .PatreonLogin}}
+    <script>
+        // Build the Patreon OAuth URL at click time so the current page rides
+        // along in the state param; the Auth callback redirects back to it after
+        // authorizing, instead of dropping the user on the homepage.
+        function getPatreonURL(patreonId, client) {
+            return "https://www.patreon.com/oauth2/authorize?response_type=code&client_id=" + patreonId + "&redirect_uri={{.PatreonURL}}&scope=identity%20identity%5Bemail%5D%20campaigns%20campaigns.members&state=" + encodeURIComponent(window.location.href + ";" + client);
+        }
+    </script>
+    {{end}}
     {{if .CanFixSearch}}
     <script>
         // Admin Fix mode: the per-result toggle shows a Fix link on each store
@@ -1093,7 +1103,7 @@
                                                         <span class="locked-cta">
                                                             <a class="locked-btn locked-btn-join" href="https://www.patreon.com/MTGBAN" target="_blank">Join</a>
                                                             {{range $ref, $id := $.PatreonIds}}
-                                                                <a class="locked-btn" href="https://www.patreon.com/oauth2/authorize?response_type=code&client_id={{$id}}&redirect_uri={{$.PatreonURL}}&scope=identity%20identity%5Bemail%5D%20campaigns%20campaigns.members&state={{$ref}}">Log in</a>
+                                                                <a class="locked-btn" href="javascript:window.location = getPatreonURL('{{$id}}', '{{$ref}}')">Log in</a>
                                                             {{end}}
                                                         </span>
                                                     {{else if eq .URL ""}}
@@ -1149,7 +1159,7 @@
                                                         <span class="locked-cta">
                                                             <a class="locked-btn locked-btn-join" href="https://www.patreon.com/MTGBAN" target="_blank">Join</a>
                                                             {{range $ref, $id := $.PatreonIds}}
-                                                                <a class="locked-btn" href="https://www.patreon.com/oauth2/authorize?response_type=code&client_id={{$id}}&redirect_uri={{$.PatreonURL}}&scope=identity%20identity%5Bemail%5D%20campaigns%20campaigns.members&state={{$ref}}">Log in</a>
+                                                                <a class="locked-btn" href="javascript:window.location = getPatreonURL('{{$id}}', '{{$ref}}')">Log in</a>
                                                             {{end}}
                                                         </span>
                                                     {{else}}
@@ -1225,7 +1235,7 @@
                                                     <span class="locked-cta">
                                                         <a class="locked-btn locked-btn-join" href="https://www.patreon.com/MTGBAN" target="_blank">Join</a>
                                                         {{range $ref, $id := $.PatreonIds}}
-                                                            <a class="locked-btn" href="https://www.patreon.com/oauth2/authorize?response_type=code&client_id={{$id}}&redirect_uri={{$.PatreonURL}}&scope=identity%20identity%5Bemail%5D%20campaigns%20campaigns.members&state={{$ref}}">Log in</a>
+                                                            <a class="locked-btn" href="javascript:window.location = getPatreonURL('{{$id}}', '{{$ref}}')">Log in</a>
                                                         {{end}}
                                                     </span>
                                                 {{else}}


### PR DESCRIPTION
## Problem

Clicking **Log in** from a locked store row (a gated price behind Patreon), then authorizing the app, drops the user on the **homepage** instead of returning them to the search they were viewing — on both desktop and mobile.

## Root cause

The `Auth` callback derives its post-login redirect from the OAuth `state` param:

```go
redir := strings.Split(r.FormValue("state"), ";")[0]  // auth.go
if redir == "" || strings.Contains(redir, "errmsg=logout") {
    redir = ServerURL // homepage
}
```

The **landing page** buttons pack the current URL into `state` (`window.location.href + ";" + ref`), so they round-trip correctly. But the **search** locked-row buttons (desktop `templates/search.html`, mobile `templates/mobile/search.html`) sent only `state={{$ref}}` — no return URL — so `state[0]` was the ref, and the callback fell back to the homepage.

## Fix

Mirror the landing page: define a `getPatreonURL()` helper once per template (in `extra-head`, guarded by `{{if .PatreonLogin}}`) that builds the OAuth URL at click time and packs `window.location.href` into `state`. All 7 locked-row login buttons (3 desktop + 4 mobile) now use it, so the callback returns the user to the exact page — query and all — they logged in from.

## Verification

- `TestTemplatesParse` passes (parses every template via the production funcMap).
- Confirmed `html/template` renders the `javascript:` href intact (no `#ZgotmplZ` neutralization) — the literal scheme is trusted and only the interpolated args are JS-escaped, same as the landing page which already ships this pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
