### PR TITLE
Long-form price storage + game-agnostic charts (flag-gated)

### DIFF
--- a/api_chart.go
+++ b/api_chart.go
@@ -36,6 +36,14 @@ func ChartDataAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Long-form reads unlock charting by any id (ban:, tcg:, scryfall:, mtgjson:,
+	// bare uuid/number) and non-Magic products. The legacy path below stays
+	// mtgjson-uuid only.
+	if Config.TimeseriesConfig.LongFormReads {
+		chartDataAPILong(w, r, uuid)
+		return
+	}
+
 	co, err := mtgmatcher.GetUUID(uuid)
 	if err != nil {
 		errorResponse(w, http.StatusNotFound, "card not found")
@@ -81,6 +89,67 @@ func ChartDataAPI(w http.ResponseWriter, r *http.Request) {
 		AxisLabels:      axisLabels,
 		Datasets:        apiDatasets,
 		Checkpoints:     relevantCheckpoints(co.Name, earliest),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// chartDataAPILong serves the chart for any resolvable id (ban:, tcg:, scryfall:,
+// mtgjson:, or a bare uuid/number), including non-Magic products, from the long
+// tables. Reached only when long-form reads are enabled.
+func chartDataAPILong(w http.ResponseWriter, r *http.Request, rawID string) {
+	target, err := resolveChartTarget(r.Context(), rawID)
+	if err != nil {
+		errorResponse(w, http.StatusNotFound, "card not found")
+		return
+	}
+
+	sig := r.FormValue("sig")
+	lb := chartLookback(sig)
+	maxDays := lb.Days()
+
+	earliest, _ := chartTargetEarliest(r.Context(), target, lb)
+
+	if rangeStr := r.FormValue("range"); rangeStr != "" {
+		if days, err := strconv.Atoi(rangeStr); err == nil && days > 0 {
+			if days > maxDays {
+				days = maxDays
+			}
+			cutoff := time.Now().AddDate(0, 0, -days)
+			if cutoff.After(earliest) {
+				earliest = cutoff
+			}
+		}
+	}
+
+	axisLabels := getDateAxisValues(earliest)
+	datasets := getDatasetsForTarget(r.Context(), target, axisLabels, lb)
+
+	var apiDatasets []ChartAPIDataset
+	for _, ds := range datasets {
+		if len(ds.Data) == 0 {
+			continue
+		}
+		apiDatasets = append(apiDatasets, ChartAPIDataset{
+			Name:  ds.Name,
+			Data:  ds.Data,
+			Color: ds.Color,
+		})
+	}
+
+	// Checkpoints (set releases etc.) are Magic-only.
+	var checkpoints []ChartCheckpoint
+	if target.IsMagic {
+		checkpoints = relevantCheckpoints(target.Name, earliest)
+	}
+
+	resp := ChartAPIResponse{
+		MaxLookbackDays: maxDays,
+		AxisLabels:      axisLabels,
+		Datasets:        apiDatasets,
+		Checkpoints:     checkpoints,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/api_chart.go
+++ b/api_chart.go
@@ -47,7 +47,7 @@ func ChartDataAPI(w http.ResponseWriter, r *http.Request) {
 	lb := chartLookback(sig)
 	maxDays := lb.Days()
 
-	earliest, _ := PricesArchiveDB.GetEarliestDate(r.Context(), co.UUID, co.Foil, co.Etched, lb)
+	earliest, _ := earliestChartDate(r.Context(), co.UUID, co.Foil, co.Etched, lb)
 
 	if rangeStr := r.FormValue("range"); rangeStr != "" {
 		if days, err := strconv.Atoi(rangeStr); err == nil && days > 0 {

--- a/api_chart.go
+++ b/api_chart.go
@@ -125,7 +125,7 @@ func chartDataAPILong(w http.ResponseWriter, r *http.Request, rawID string) {
 	}
 
 	axisLabels := getDateAxisValues(earliest)
-	datasets := getDatasetsForTarget(r.Context(), target, axisLabels, lb)
+	datasets := getChartDatasets(r.Context(), target, axisLabels, lb)
 
 	var apiDatasets []ChartAPIDataset
 	for _, ds := range datasets {
@@ -139,17 +139,12 @@ func chartDataAPILong(w http.ResponseWriter, r *http.Request, rawID string) {
 		})
 	}
 
-	// Checkpoints (set releases etc.) are Magic-only.
-	var checkpoints []ChartCheckpoint
-	if target.IsMagic {
-		checkpoints = relevantCheckpoints(target.Name, earliest)
-	}
-
+	// Checkpoints match set releases by card name; a non-Magic name matches none.
 	resp := ChartAPIResponse{
 		MaxLookbackDays: maxDays,
 		AxisLabels:      axisLabels,
 		Datasets:        apiDatasets,
-		Checkpoints:     checkpoints,
+		Checkpoints:     relevantCheckpoints(target.Name, earliest),
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/chart.go
+++ b/chart.go
@@ -195,7 +195,7 @@ var providerRegistry []providerDisplay
 // it once after the config is parsed.
 func buildProviderRegistry() {
 	seen := map[int16]bool{}
-	registry := make([]providerDisplay, 0, len(Config.TimeseriesConfig.Datasets)+3)
+	registry := make([]providerDisplay, 0, len(Config.TimeseriesConfig.Datasets)+5)
 	for _, d := range Config.TimeseriesConfig.Datasets {
 		if d.Provider == 0 || seen[d.Provider] {
 			continue
@@ -203,8 +203,12 @@ func buildProviderRegistry() {
 		seen[d.Provider] = true
 		registry = append(registry, providerDisplay{d.Provider, d.PublicName, d.Color})
 	}
-	// TCGplayer metrics that have no dataset config (used by non-Magic games).
+	// Shared TCGplayer metrics, so a game whose config omits them (or a whole
+	// non-Magic deployment) still charts every column the ingest writes. A real
+	// dataset entry wins its name/color via seen[]; these only fill the gaps.
 	for _, extra := range []providerDisplay{
+		{timeseries.ProviderTCGLow, "TCGplayer Low", "rgb(255, 99, 132)"},
+		{timeseries.ProviderTCGMarket, "TCGplayer Market", "rgb(255, 159, 64)"},
 		{timeseries.ProviderTCGMid, "TCGplayer Mid", "rgb(255, 206, 86)"},
 		{timeseries.ProviderTCGHigh, "TCGplayer High", "rgb(75, 192, 192)"},
 		{timeseries.ProviderTCGDirectLow, "TCGplayer Direct Low", "rgb(153, 102, 255)"},

--- a/chart.go
+++ b/chart.go
@@ -176,20 +176,44 @@ func getDatasets(ctx context.Context, cardId string, sealed bool, keys []string,
 	return datasets
 }
 
-// nonMagicDatasetSpecs are the TCGplayer metrics rendered for a non-Magic
-// (tcgcsv) product chart. Magic uses the dataset config; non-Magic games have
-// no per-provider config, so their display name/color live here. The Low/Market
-// colors match the Magic config for visual consistency.
-var nonMagicDatasetSpecs = []struct {
+// providerDisplay is one provider's chart display: its name and color.
+type providerDisplay struct {
 	Provider int16
 	Name     string
 	Color    string
-}{
-	{timeseries.ProviderTCGLow, "TCGplayer Low", "rgb(255, 99, 132)"},
-	{timeseries.ProviderTCGMarket, "TCGplayer Market", "rgb(54, 162, 235)"},
-	{timeseries.ProviderTCGMid, "TCGplayer Mid", "rgb(255, 206, 86)"},
-	{timeseries.ProviderTCGHigh, "TCGplayer High", "rgb(75, 192, 192)"},
-	{timeseries.ProviderTCGDirectLow, "TCGplayer Direct Low", "rgb(153, 102, 255)"},
+}
+
+// providerRegistry is the ordered, game-agnostic list of chart providers. A chart
+// renders one dataset per provider that actually has data for the card, in this
+// order, so a new game (which reuses the shared TCGplayer providers) charts with
+// no extra code. Built once at startup from the dataset config (preserving the
+// existing display: names, colors, order) plus the TCGplayer metrics that have no
+// per-provider config.
+var providerRegistry []providerDisplay
+
+// buildProviderRegistry (re)builds providerRegistry from the loaded config. Call
+// it once after the config is parsed.
+func buildProviderRegistry() {
+	seen := map[int16]bool{}
+	registry := make([]providerDisplay, 0, len(Config.TimeseriesConfig.Datasets)+3)
+	for _, d := range Config.TimeseriesConfig.Datasets {
+		if d.Provider == 0 || seen[d.Provider] {
+			continue
+		}
+		seen[d.Provider] = true
+		registry = append(registry, providerDisplay{d.Provider, d.PublicName, d.Color})
+	}
+	// TCGplayer metrics that have no dataset config (used by non-Magic games).
+	for _, extra := range []providerDisplay{
+		{timeseries.ProviderTCGMid, "TCGplayer Mid", "rgb(255, 206, 86)"},
+		{timeseries.ProviderTCGHigh, "TCGplayer High", "rgb(75, 192, 192)"},
+		{timeseries.ProviderTCGDirectLow, "TCGplayer Direct Low", "rgb(153, 102, 255)"},
+	} {
+		if !seen[extra.Provider] {
+			registry = append(registry, extra)
+		}
+	}
+	providerRegistry = registry
 }
 
 // chartTargetEarliest returns the oldest on-record date for a resolved target:
@@ -201,11 +225,12 @@ func chartTargetEarliest(ctx context.Context, target *chartTarget, lb timeseries
 	return PricesArchiveDB.GetEarliestDateLong(ctx, target.UUID, target.Foil, target.Etched, lb)
 }
 
-// getDatasetsForTarget builds the chart datasets for a resolved target. It fetches
-// the pivoted series once (by exact ban_id when precise, else the Magic canonical
-// path) and projects the Magic dataset config or the non-Magic TCG providers.
-// Long-form reads only; the legacy path stays in ChartDataAPI.
-func getDatasetsForTarget(ctx context.Context, target *chartTarget, labels []string, lb timeseries.Lookback) []Dataset {
+// getChartDatasets builds a card's chart datasets, game-agnostic: it fetches the
+// series once (by exact ban_id, else the canonical uuid path) and emits one
+// dataset per registry provider that has data, in registry order. Adding a game
+// needs no code here — its providers just show up. Long-form reads only; the
+// legacy path stays in getDatasets.
+func getChartDatasets(ctx context.Context, target *chartTarget, labels []string, lb timeseries.Lookback) []Dataset {
 	if PricesArchiveDB == nil {
 		return nil
 	}
@@ -221,51 +246,38 @@ func getDatasetsForTarget(ctx context.Context, target *chartTarget, labels []str
 		return nil
 	}
 
-	if !target.IsMagic {
-		return buildNonMagicDatasets(results, labels)
+	// Only providers with data for this card render — that is what makes it
+	// game-agnostic and also drops sealed-vs-single applicability out of config
+	// (e.g. Sealed EV only has data for sealed products, so it only shows there).
+	present := map[int16]bool{}
+	for _, pp := range results {
+		for provider := range pp {
+			present[provider] = true
+		}
 	}
-
-	var datasets []Dataset
-	for _, config := range Config.TimeseriesConfig.Datasets {
-		if target.Sealed && !config.HasSealed {
-			continue
+	datasets := make([]Dataset, 0, len(present))
+	for _, pd := range providerRegistry {
+		if present[pd.Provider] {
+			datasets = append(datasets, buildProviderDataset(results, labels, pd))
 		}
-		if !target.Sealed && config.OnlySealed {
-			continue
-		}
-		datasets = append(datasets, buildDatasetLong(results, labels, config))
 	}
 	return datasets
 }
 
-// buildNonMagicDatasets projects the five TCGplayer providers out of a non-Magic
-// product's pivoted series, one dataset per metric.
-func buildNonMagicDatasets(results map[string]timeseries.ProviderPrices, labels []string) []Dataset {
-	datasets := make([]Dataset, 0, len(nonMagicDatasetSpecs))
-	for _, spec := range nonMagicDatasetSpecs {
-		var data []string
-		if len(results) > 0 {
-			data = make([]string, len(labels))
-			for i, label := range labels {
-				if pp, ok := results[label]; ok {
-					if price, ok := pp[spec.Provider]; ok {
-						data[i] = fmt.Sprintf("%g", price)
-					} else {
-						data[i] = "Number.NaN"
-					}
-				} else {
-					data[i] = "Number.NaN"
-				}
+// buildProviderDataset projects one provider's series across the label dates.
+// Missing dates and missing prices both render as Number.NaN so the chart gaps.
+func buildProviderDataset(results map[string]timeseries.ProviderPrices, labels []string, pd providerDisplay) Dataset {
+	data := make([]string, len(labels))
+	for i, label := range labels {
+		if pp, ok := results[label]; ok {
+			if price, ok := pp[pd.Provider]; ok {
+				data[i] = fmt.Sprintf("%g", price)
+				continue
 			}
 		}
-		datasets = append(datasets, Dataset{
-			Name:      spec.Name,
-			Data:      data,
-			Color:     spec.Color,
-			Reference: spec.Name,
-		})
+		data[i] = "Number.NaN"
 	}
-	return datasets
+	return Dataset{Name: pd.Name, Data: data, Color: pd.Color, Reference: pd.Name}
 }
 
 // buildDatasetLong is buildDataset for the long-form read: it projects one

--- a/chart.go
+++ b/chart.go
@@ -15,6 +15,14 @@ import (
 
 type TimeseriesConfig struct {
 	Datasets []DatasetConfig `json:"datasets"`
+
+	// LongFormWrites dual-writes each snapshot into the new long tables
+	// (variants + prices) alongside the legacy wide tables. LongFormReads
+	// serves charts/analytics from the long tables instead of the wide ones.
+	// The cutover is: deploy with writes on + reads off, confirm parity, then
+	// flip reads on, then (later) drop the legacy write path. See db_migration/.
+	LongFormWrites bool `json:"long_form_writes,omitempty"`
+	LongFormReads  bool `json:"long_form_reads,omitempty"`
 }
 
 type DatasetConfig struct {
@@ -22,9 +30,33 @@ type DatasetConfig struct {
 	Buylist    []string `json:"buylist,omitempty"`
 	PublicName string   `json:"public_name"`
 	Index      int      `json:"index"`
-	Color      string   `json:"color"`
-	HasSealed  bool     `json:"has_sealed,omitempty"`
-	OnlySealed bool     `json:"only_sealed,omitempty"`
+	// Provider is the id in the providers lookup table this dataset maps to
+	// (long form). Replaces the positional Index once the legacy path is dropped.
+	Provider   int16  `json:"provider"`
+	Color      string `json:"color"`
+	HasSealed  bool   `json:"has_sealed,omitempty"`
+	OnlySealed bool   `json:"only_sealed,omitempty"`
+}
+
+// providerForDatasetIndex resolves a legacy dataset Index to its provider id via
+// the config. Used by the read callers (aggregate stats, movers) that still take
+// an index. Returns false if no dataset carries that index or its provider is unset.
+func providerForDatasetIndex(index int) (int16, bool) {
+	for _, c := range Config.TimeseriesConfig.Datasets {
+		if c.Index == index {
+			return c.Provider, c.Provider != 0
+		}
+	}
+	return 0, false
+}
+
+// earliestChartDate returns the oldest on-record date for a card (bounded by the
+// lookback), reading from the long tables or the legacy wide table per the flag.
+func earliestChartDate(ctx context.Context, uuid string, isFoil, isEtched bool, lb timeseries.Lookback) (time.Time, error) {
+	if Config.TimeseriesConfig.LongFormReads {
+		return PricesArchiveDB.GetEarliestDateLong(ctx, uuid, isFoil, isEtched, lb)
+	}
+	return PricesArchiveDB.GetEarliestDate(ctx, uuid, isFoil, isEtched, lb)
 }
 
 type Dataset struct {
@@ -119,17 +151,56 @@ func getDatasets(ctx context.Context, cardId string, sealed bool, keys []string,
 		return nil
 	}
 
+	datasets := make([]Dataset, 0, len(configs))
+
+	if Config.TimeseriesConfig.LongFormReads {
+		results, err := PricesArchiveDB.HGetAllLong(ctx, co.UUID, co.Foil, co.Etched, lb)
+		if err != nil {
+			log.Println(err)
+			return nil
+		}
+		for _, config := range configs {
+			datasets = append(datasets, buildDatasetLong(results, keys, config))
+		}
+		return datasets
+	}
+
 	results, err := PricesArchiveDB.HGetAll(ctx, co.UUID, co.Foil, co.Etched, nil, lb)
 	if err != nil {
 		log.Println(err)
 		return nil
 	}
-
-	datasets := make([]Dataset, 0, len(configs))
 	for _, config := range configs {
 		datasets = append(datasets, buildDataset(results, keys, config))
 	}
 	return datasets
+}
+
+// buildDatasetLong is buildDataset for the long-form read: it projects one
+// provider out of the pivoted date -> (provider -> price) result. Missing dates
+// and missing providers both render as Number.NaN so the chart leaves a gap.
+func buildDatasetLong(results map[string]timeseries.ProviderPrices, labels []string, config DatasetConfig) Dataset {
+	var data []string
+	if len(results) > 0 {
+		data = make([]string, len(labels))
+		for i, label := range labels {
+			if pp, ok := results[label]; ok {
+				if price, ok := pp[config.Provider]; ok {
+					data[i] = fmt.Sprintf("%g", price)
+				} else {
+					data[i] = "Number.NaN"
+				}
+			} else {
+				data[i] = "Number.NaN"
+			}
+		}
+	}
+	return Dataset{
+		Name:      config.PublicName,
+		Data:      data,
+		Color:     config.Color,
+		Reference: config.PublicName,
+	}
 }
 
 // buildDataset projects a single column out of the shared HGetAll result
@@ -393,7 +464,61 @@ func stashInTimeseries() {
 		ServerNotify("timeseries", fmt.Sprintf("batch upsert error: %s", err))
 	}
 
+	// Dual-write the same snapshot into the long form (variants + prices).
+	// Best-effort: a long-form failure is logged but does not fail the stash,
+	// since the legacy wide upsert above already persisted this snapshot.
+	if Config.TimeseriesConfig.LongFormWrites {
+		if n, lerr := stashLongForm(context.Background(), accumulated); lerr != nil {
+			ServerNotify("timeseries", fmt.Sprintf("long-form dual-write error: %s", lerr))
+		} else {
+			log.Printf("long-form dual-write: %d price rows", n)
+		}
+	}
+
 	SetLastStashUpdate(time.Now())
 	msg := fmt.Sprintf("Snapshot completed in %s: %d upserted, %d errors", time.Since(start), upserted, errCount)
 	ServerNotify("timeseries", msg)
+}
+
+// stashLongForm mirrors the accumulated wide rows into the long prices table. It
+// warms the variant cache once, resolves each row's ban_id (minting new
+// printings on the fly), and emits one LongPrice per set provider column with a
+// positive price (zeros are omitted, matching the backfill). Returns the number
+// of price rows upserted.
+func stashLongForm(ctx context.Context, accumulated map[string]*timeseries.PriceRow) (int, error) {
+	if err := PricesArchiveDB.WarmVariantCache(ctx); err != nil {
+		return 0, fmt.Errorf("warm variant cache: %w", err)
+	}
+	longRows := make([]timeseries.LongPrice, 0, len(accumulated)*4)
+	for _, row := range accumulated {
+		lang := ""
+		if row.Language != nil {
+			lang = *row.Language
+		}
+		banID, err := PricesArchiveDB.ResolveMagicBanID(ctx, timeseries.MagicVariant{
+			MtgjsonUUID: row.MtgjsonUUID,
+			IsFoil:      row.IsFoil,
+			IsEtched:    row.IsEtched,
+			IsAlt:       row.IsAlt,
+			Language:    lang,
+		})
+		if err != nil {
+			log.Println("long-form: resolve ban_id:", err)
+			continue
+		}
+		for _, ds := range Config.TimeseriesConfig.Datasets {
+			if ds.Provider == 0 {
+				continue
+			}
+			if p := row.PriceForDataset(ds.Index); p != nil && *p > 0 {
+				longRows = append(longRows, timeseries.LongPrice{
+					BanID:    banID,
+					Date:     row.Date,
+					Provider: ds.Provider,
+					Price:    *p,
+				})
+			}
+		}
+	}
+	return PricesArchiveDB.UpsertLongPrices(ctx, longRows, 0)
 }

--- a/chart.go
+++ b/chart.go
@@ -176,6 +176,98 @@ func getDatasets(ctx context.Context, cardId string, sealed bool, keys []string,
 	return datasets
 }
 
+// nonMagicDatasetSpecs are the TCGplayer metrics rendered for a non-Magic
+// (tcgcsv) product chart. Magic uses the dataset config; non-Magic games have
+// no per-provider config, so their display name/color live here. The Low/Market
+// colors match the Magic config for visual consistency.
+var nonMagicDatasetSpecs = []struct {
+	Provider int16
+	Name     string
+	Color    string
+}{
+	{timeseries.ProviderTCGLow, "TCGplayer Low", "rgb(255, 99, 132)"},
+	{timeseries.ProviderTCGMarket, "TCGplayer Market", "rgb(54, 162, 235)"},
+	{timeseries.ProviderTCGMid, "TCGplayer Mid", "rgb(255, 206, 86)"},
+	{timeseries.ProviderTCGHigh, "TCGplayer High", "rgb(75, 192, 192)"},
+	{timeseries.ProviderTCGDirectLow, "TCGplayer Direct Low", "rgb(153, 102, 255)"},
+}
+
+// chartTargetEarliest returns the oldest on-record date for a resolved target:
+// a precise ban_id, or the Magic canonical (uuid, foil, etched) path.
+func chartTargetEarliest(ctx context.Context, target *chartTarget, lb timeseries.Lookback) (time.Time, error) {
+	if target.BanID != 0 {
+		return PricesArchiveDB.GetEarliestDateByBanID(ctx, target.BanID, lb)
+	}
+	return PricesArchiveDB.GetEarliestDateLong(ctx, target.UUID, target.Foil, target.Etched, lb)
+}
+
+// getDatasetsForTarget builds the chart datasets for a resolved target. It fetches
+// the pivoted series once (by exact ban_id when precise, else the Magic canonical
+// path) and projects the Magic dataset config or the non-Magic TCG providers.
+// Long-form reads only; the legacy path stays in ChartDataAPI.
+func getDatasetsForTarget(ctx context.Context, target *chartTarget, labels []string, lb timeseries.Lookback) []Dataset {
+	if PricesArchiveDB == nil {
+		return nil
+	}
+	var results map[string]timeseries.ProviderPrices
+	var err error
+	if target.BanID != 0 {
+		results, err = PricesArchiveDB.HGetAllByBanID(ctx, target.BanID, lb)
+	} else {
+		results, err = PricesArchiveDB.HGetAllLong(ctx, target.UUID, target.Foil, target.Etched, lb)
+	}
+	if err != nil {
+		log.Println(err)
+		return nil
+	}
+
+	if !target.IsMagic {
+		return buildNonMagicDatasets(results, labels)
+	}
+
+	var datasets []Dataset
+	for _, config := range Config.TimeseriesConfig.Datasets {
+		if target.Sealed && !config.HasSealed {
+			continue
+		}
+		if !target.Sealed && config.OnlySealed {
+			continue
+		}
+		datasets = append(datasets, buildDatasetLong(results, labels, config))
+	}
+	return datasets
+}
+
+// buildNonMagicDatasets projects the five TCGplayer providers out of a non-Magic
+// product's pivoted series, one dataset per metric.
+func buildNonMagicDatasets(results map[string]timeseries.ProviderPrices, labels []string) []Dataset {
+	datasets := make([]Dataset, 0, len(nonMagicDatasetSpecs))
+	for _, spec := range nonMagicDatasetSpecs {
+		var data []string
+		if len(results) > 0 {
+			data = make([]string, len(labels))
+			for i, label := range labels {
+				if pp, ok := results[label]; ok {
+					if price, ok := pp[spec.Provider]; ok {
+						data[i] = fmt.Sprintf("%g", price)
+					} else {
+						data[i] = "Number.NaN"
+					}
+				} else {
+					data[i] = "Number.NaN"
+				}
+			}
+		}
+		datasets = append(datasets, Dataset{
+			Name:      spec.Name,
+			Data:      data,
+			Color:     spec.Color,
+			Reference: spec.Name,
+		})
+	}
+	return datasets
+}
+
 // buildDatasetLong is buildDataset for the long-form read: it projects one
 // provider out of the pivoted date -> (provider -> price) result. Missing dates
 // and missing providers both render as Number.NaN so the chart leaves a gap.

--- a/chart_resolve.go
+++ b/chart_resolve.go
@@ -111,7 +111,7 @@ func matcherTarget(ctx context.Context, id string) (*chartTarget, error) {
 		// product leaves BanID 0 and the canonical uuid path takes over.
 		return &chartTarget{
 			UUID: co.UUID, Foil: co.Foil, Etched: co.Etched, Name: co.Name,
-			BanID: cachedBanIDForCard(ctx, co),
+			BanID: resolveBanIDForCard(ctx, co),
 		}, nil
 	}
 
@@ -132,12 +132,14 @@ func matcherTarget(ctx context.Context, id string) (*chartTarget, error) {
 	return nil, errChartIDNotFound
 }
 
-// cachedBanIDForCard maps a resolved mtgmatcher card to our surrogate ban_id
-// using whichever identity the variants table keys on for its game: the mtgjson
-// uuid for Magic (in-memory cache, no round-trip), otherwise the card's TCGplayer
-// product id for non-Magic games (Lorcana, Pokemon, ...), which have no uuid.
-// Returns 0 when nothing matches, so the caller charts by the canonical uuid path.
-func cachedBanIDForCard(ctx context.Context, co *mtgmatcher.CardObject) int64 {
+// cachedBanIDForCard maps a resolved mtgmatcher card to our surrogate ban_id from
+// the in-memory variant caches, game-agnostically and with no DB round-trip, using
+// whichever identity the variants table keys on for its game: the mtgjson uuid for
+// Magic, otherwise the card's TCGplayer product id for non-Magic games (Lorcana,
+// Pokemon, ...), which have no uuid. Returns 0 when nothing is cached (cold cache /
+// new printing), so a caller can fall back to the game-native id. Safe to call per
+// card while rendering a results page.
+func cachedBanIDForCard(co *mtgmatcher.CardObject) int64 {
 	if PricesArchiveDB == nil {
 		return 0
 	}
@@ -147,14 +149,44 @@ func cachedBanIDForCard(ctx context.Context, co *mtgmatcher.CardObject) int64 {
 	}); ok {
 		return banID
 	}
-	if pidStr, ok := co.Identifiers["tcgplayerProductId"]; ok {
-		if pid, err := strconv.Atoi(pidStr); err == nil {
-			if vi, ok, err := PricesArchiveDB.LookupTCGBanID(ctx, pid); err == nil && ok {
-				return vi.BanID
-			}
+	if pid, ok := tcgProductID(co); ok {
+		if banID, ok := PricesArchiveDB.CachedTCGBanID(pid); ok {
+			return banID
 		}
 	}
 	return 0
+}
+
+// resolveBanIDForCard is cachedBanIDForCard for the single chart-open path, where a
+// DB round-trip is affordable: on an in-memory miss it resolves a non-Magic product
+// against the variants table, so a cold cache (or a product ingested since warm-up)
+// still charts precisely. A Magic miss stays 0 — the canonical uuid path covers it.
+func resolveBanIDForCard(ctx context.Context, co *mtgmatcher.CardObject) int64 {
+	if banID := cachedBanIDForCard(co); banID != 0 {
+		return banID
+	}
+	if PricesArchiveDB == nil {
+		return 0
+	}
+	if pid, ok := tcgProductID(co); ok {
+		if vi, ok, err := PricesArchiveDB.LookupTCGBanID(ctx, pid); err == nil && ok {
+			return vi.BanID
+		}
+	}
+	return 0
+}
+
+// tcgProductID extracts a card's TCGplayer product id from its identifiers.
+func tcgProductID(co *mtgmatcher.CardObject) (int, bool) {
+	pidStr, ok := co.Identifiers["tcgplayerProductId"]
+	if !ok {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil {
+		return 0, false
+	}
+	return pid, true
 }
 
 // targetFromTCGID resolves a TCGplayer product id: Magic first (mtgmatcher knows
@@ -165,7 +197,7 @@ func targetFromTCGID(ctx context.Context, tcgID int) (*chartTarget, error) {
 		if co, err := mtgmatcher.GetUUID(matched); err == nil {
 			return &chartTarget{
 				UUID: co.UUID, Foil: co.Foil, Etched: co.Etched, Name: co.Name,
-				BanID: cachedBanIDForCard(ctx, co),
+				BanID: resolveBanIDForCard(ctx, co),
 			}, nil
 		}
 	}

--- a/chart_resolve.go
+++ b/chart_resolve.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/mtgban/go-mtgban/mtgmatcher"
+	"github.com/mtgban/mtgban-website/timeseries"
+)
+
+// errChartIDNotFound means a syntactically valid id resolved to no chartable card.
+var errChartIDNotFound = errors.New("chart id not found")
+
+// nonMagicChartProviders are the TCGplayer metrics a non-Magic (tcgcsv) product
+// can chart: Low, Market, Mid, High, Direct Low. Magic uses the dataset config.
+var nonMagicChartProviders = []int16{
+	timeseries.ProviderTCGLow, timeseries.ProviderTCGMarket, timeseries.ProviderTCGMid,
+	timeseries.ProviderTCGHigh, timeseries.ProviderTCGDirectLow,
+}
+
+// chartTarget is a resolved chart identity that unifies Magic (mtgmatcher-backed)
+// and non-Magic (tcg_products-backed) cards. The read mode is:
+//   - BanID != 0: chart this exact variant via HGetAllByBanID (a ban: id, or a
+//     resolved TCGplayer product). Precise about language/finish/alt/sub-type.
+//   - BanID == 0: Magic canonical path via (UUID, Foil, Etched) through HGetAllLong.
+type chartTarget struct {
+	BanID   int64
+	UUID    string // mtgjson uuid, for the Magic canonical path and display
+	Foil    bool
+	Etched  bool
+	Sealed  bool
+	Name    string
+	IsMagic bool
+	// Providers to render for a non-Magic target; nil means use the Magic
+	// dataset config in getDatasets.
+	Providers []int16
+}
+
+// resolveChartTarget turns any supported id string into a chartable target.
+// Supported forms:
+//   - ban:<n>                 our surrogate ban_id (Magic or non-Magic)
+//   - tcg:<n> or a bare <n>   a TCGplayer product id (Magic via mtgmatcher, else non-Magic)
+//   - scryfall:<uuid>         a Scryfall id (via mtgmatcher's external map)
+//   - mtgjson:<uuid> or bare  an mtgjson uuid / mtgmatcher variant string
+//
+// A bare integer is a TCGplayer id (mtgmatcher's existing convention); ban_ids
+// must carry the ban: marker because the two integer spaces overlap.
+func resolveChartTarget(ctx context.Context, raw string) (*chartTarget, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, errChartIDNotFound
+	}
+	prefix, val := splitIDPrefix(raw)
+	switch prefix {
+	case "ban":
+		n, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			return nil, errChartIDNotFound
+		}
+		return targetFromBanID(ctx, n)
+	case "tcg":
+		n, err := strconv.Atoi(val)
+		if err != nil {
+			return nil, errChartIDNotFound
+		}
+		return targetFromTCGID(ctx, n)
+	case "", "mtgjson", "scryfall":
+		// A bare integer is a TCGplayer id; everything else is a uuid / external id.
+		if n, err := strconv.Atoi(val); err == nil {
+			return targetFromTCGID(ctx, n)
+		}
+		return magicTargetFromCardID(ctx, val)
+	default:
+		return nil, errChartIDNotFound
+	}
+}
+
+// splitIDPrefix splits a "<prefix>:<value>" id. Bare uuids and integers have no
+// colon, so they return an empty prefix and the whole string as the value.
+func splitIDPrefix(raw string) (prefix, val string) {
+	if i := strings.IndexByte(raw, ':'); i > 0 {
+		return strings.ToLower(raw[:i]), raw[i+1:]
+	}
+	return "", raw
+}
+
+// maybeUUIDString reports whether s has the shape of a UUID (36 chars, 4 dashes).
+func maybeUUIDString(s string) bool {
+	return len(s) == 36 && strings.Count(s, "-") == 4
+}
+
+// magicTargetFromCardID resolves a Magic card id (mtgjson uuid, mtgmatcher
+// variant string, or a Scryfall id) to a chart target. If mtgmatcher does not
+// know the id but it is an mtgjson uuid still present in our price history (e.g.
+// retired from the datastore), it falls back to charting that variant by ban_id.
+func magicTargetFromCardID(ctx context.Context, id string) (*chartTarget, error) {
+	co, err := mtgmatcher.GetUUID(id)
+	if err != nil {
+		// Not a direct mtgmatcher id; try the external id map (Scryfall/TCGplayer).
+		if matched, merr := mtgmatcher.MatchId(id); merr == nil {
+			co, err = mtgmatcher.GetUUID(matched)
+		}
+	}
+	if err == nil {
+		return &chartTarget{
+			UUID:    co.UUID,
+			Foil:    co.Foil,
+			Etched:  co.Etched,
+			Sealed:  co.Sealed,
+			Name:    co.Name,
+			IsMagic: true,
+		}, nil
+	}
+
+	// Datastore fallback: a uuid we have prices for but mtgmatcher no longer knows.
+	if maybeUUIDString(id) {
+		if banID, ok, lerr := PricesArchiveDB.LookupMagicBanIDByUUID(ctx, id); lerr == nil && ok {
+			return &chartTarget{BanID: banID, UUID: id, IsMagic: true}, nil
+		}
+	}
+	return nil, errChartIDNotFound
+}
+
+// targetFromTCGID resolves a TCGplayer product id: Magic first (mtgmatcher knows
+// Magic TCGplayer ids), otherwise a non-Magic product in the variants table.
+func targetFromTCGID(ctx context.Context, tcgID int) (*chartTarget, error) {
+	idStr := strconv.Itoa(tcgID)
+	if matched, err := mtgmatcher.MatchId(idStr); err == nil {
+		if co, err := mtgmatcher.GetUUID(matched); err == nil {
+			return &chartTarget{
+				UUID: co.UUID, Foil: co.Foil, Etched: co.Etched,
+				Sealed: co.Sealed, Name: co.Name, IsMagic: true,
+			}, nil
+		}
+	}
+	vi, ok, err := PricesArchiveDB.LookupTCGBanID(ctx, tcgID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, errChartIDNotFound
+	}
+	return nonMagicTarget(ctx, vi), nil
+}
+
+// targetFromBanID resolves our surrogate ban_id via the variants table, to the
+// exact printing (Magic or non-Magic).
+func targetFromBanID(ctx context.Context, banID int64) (*chartTarget, error) {
+	vi, ok, err := PricesArchiveDB.LookupVariant(ctx, banID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, errChartIDNotFound
+	}
+	if vi.IsMagic() {
+		t := &chartTarget{
+			BanID:   banID,
+			UUID:    vi.MtgjsonUUID,
+			Foil:    vi.IsFoil,
+			Etched:  vi.IsEtched,
+			IsMagic: true,
+		}
+		// Name/sealed for display come from mtgmatcher; the base uuid suffices
+		// since the name is finish-independent (the chart uses BanID for data).
+		if co, err := mtgmatcher.GetUUID(vi.MtgjsonUUID); err == nil {
+			t.Name = co.Name
+			t.Sealed = co.Sealed
+		}
+		return t, nil
+	}
+	return nonMagicTarget(ctx, vi), nil
+}
+
+// nonMagicTarget builds a non-Magic chart target, resolving the display name from
+// the tcg_products catalog and tagging the printing's sub-type when it is not the
+// base ("Normal").
+func nonMagicTarget(ctx context.Context, vi timeseries.VariantInfo) *chartTarget {
+	t := &chartTarget{
+		BanID:     vi.BanID,
+		IsMagic:   false,
+		Providers: nonMagicChartProviders,
+	}
+	if p, ok, _ := PricesArchiveDB.GetTCGProduct(ctx, vi.TCGProductID); ok {
+		t.Name = p.Name
+		if vi.TCGSubType != "" && vi.TCGSubType != "Normal" {
+			t.Name += " (" + vi.TCGSubType + ")"
+		}
+	}
+	return t
+}

--- a/chart_resolve.go
+++ b/chart_resolve.go
@@ -30,13 +30,18 @@ type chartTarget struct {
 
 // resolveChartTarget turns any supported id string into a chartable target.
 // Supported forms:
-//   - ban:<n>                 our surrogate ban_id (Magic or non-Magic)
-//   - tcg:<n> or a bare <n>   a TCGplayer product id (Magic via mtgmatcher, else non-Magic)
-//   - scryfall:<uuid>         a Scryfall id (via mtgmatcher's external map)
-//   - mtgjson:<uuid> or bare  an mtgjson uuid / mtgmatcher variant string
+//   - ban:<n>            our surrogate ban_id (Magic or non-Magic) — forced
+//   - tcg:<n>            a TCGplayer product id — forced
+//   - scryfall:<uuid>    a Scryfall id (via mtgmatcher's external map)
+//   - mtgjson:<uuid>     an mtgjson uuid
+//   - a bare <n>/<uuid>  resolved by trying each id space in turn (below)
 //
-// A bare integer is a TCGplayer id (mtgmatcher's existing convention); ban_ids
-// must carry the ban: marker because the two integer spaces overlap.
+// The integer id spaces overlap — a ban_id, a TCGplayer product id, and a game's
+// own numeric id (e.g. LorcanaJSON) can all be the same number — so a bare integer
+// is resolved most-specific first: our ban_id, then the game-native id through
+// mtgmatcher (a LorcanaJSON id matches directly, a TCGplayer id via the external
+// map), then a non-Magic product in the variants table. Prefix ban: or tcg: to
+// force one interpretation.
 func resolveChartTarget(ctx context.Context, raw string) (*chartTarget, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -57,11 +62,16 @@ func resolveChartTarget(ctx context.Context, raw string) (*chartTarget, error) {
 		}
 		return targetFromTCGID(ctx, n)
 	case "", "mtgjson", "scryfall":
-		// A bare integer is a TCGplayer id; everything else is a uuid / external id.
-		if n, err := strconv.Atoi(val); err == nil {
-			return targetFromTCGID(ctx, n)
+		// A bare integer tries our ban_id first (the internal primary key); on a
+		// miss it falls through to the game-native / product resolution below.
+		if n, err := strconv.ParseInt(val, 10, 64); err == nil {
+			if t, berr := targetFromBanID(ctx, n); berr == nil {
+				return t, nil
+			} else if !errors.Is(berr, errChartIDNotFound) {
+				return nil, berr
+			}
 		}
-		return magicTargetFromCardID(ctx, val)
+		return matcherTarget(ctx, val)
 	default:
 		return nil, errChartIDNotFound
 	}
@@ -81,11 +91,13 @@ func maybeUUIDString(s string) bool {
 	return len(s) == 36 && strings.Count(s, "-") == 4
 }
 
-// magicTargetFromCardID resolves a Magic card id (mtgjson uuid, mtgmatcher
-// variant string, or a Scryfall id) to a chart target. If mtgmatcher does not
-// know the id but it is an mtgjson uuid still present in our price history (e.g.
-// retired from the datastore), it falls back to charting that variant by ban_id.
-func magicTargetFromCardID(ctx context.Context, id string) (*chartTarget, error) {
+// matcherTarget resolves a game-native card id through mtgmatcher — an mtgjson
+// uuid or mtgmatcher variant string (Magic), a LorcanaJSON id (Lorcana), or an
+// external id (Scryfall / TCGplayer) via the matcher's id map. mtgmatcher holds
+// whichever game the deployment serves, so this is game-agnostic. When mtgmatcher
+// doesn't know the id it falls back to our own price history: a retired Magic
+// uuid, or a non-Magic TCGplayer product id.
+func matcherTarget(ctx context.Context, id string) (*chartTarget, error) {
 	co, err := mtgmatcher.GetUUID(id)
 	if err != nil {
 		// Not a direct mtgmatcher id; try the external id map (Scryfall/TCGplayer).
@@ -94,28 +106,55 @@ func magicTargetFromCardID(ctx context.Context, id string) (*chartTarget, error)
 		}
 	}
 	if err == nil {
-		t := &chartTarget{UUID: co.UUID, Foil: co.Foil, Etched: co.Etched, Name: co.Name}
-		// Prefer the cached ban_id so the chart reads the exact variant (skips the
-		// canonical resolution HGetAllLong does in SQL). Falls back to the uuid
-		// path when the cache is cold.
-		if PricesArchiveDB != nil {
-			if id, ok := PricesArchiveDB.CachedMagicBanID(timeseries.MagicVariant{
-				MtgjsonUUID: co.UUID, IsFoil: co.Foil, IsEtched: co.Etched,
-				IsAlt: co.IsAlternative, Language: co.Language,
-			}); ok {
-				t.BanID = id
-			}
-		}
-		return t, nil
+		// Prefer the resolved ban_id so the chart reads the exact variant (skips
+		// the canonical resolution HGetAllLong does in SQL); a cold cache / unknown
+		// product leaves BanID 0 and the canonical uuid path takes over.
+		return &chartTarget{
+			UUID: co.UUID, Foil: co.Foil, Etched: co.Etched, Name: co.Name,
+			BanID: cachedBanIDForCard(ctx, co),
+		}, nil
 	}
 
-	// Datastore fallback: a uuid we have prices for but mtgmatcher no longer knows.
+	// mtgmatcher doesn't know the id — fall back to our own price history.
 	if maybeUUIDString(id) {
+		// A Magic uuid we have prices for but the datastore retired.
 		if banID, ok, lerr := PricesArchiveDB.LookupMagicBanIDByUUID(ctx, id); lerr == nil && ok {
 			return &chartTarget{BanID: banID, UUID: id}, nil
 		}
+		return nil, errChartIDNotFound
+	}
+	// A bare integer mtgmatcher can't map is a non-Magic product id in variants.
+	if n, aerr := strconv.Atoi(id); aerr == nil {
+		if vi, ok, lerr := PricesArchiveDB.LookupTCGBanID(ctx, n); lerr == nil && ok {
+			return nonMagicTarget(ctx, vi), nil
+		}
 	}
 	return nil, errChartIDNotFound
+}
+
+// cachedBanIDForCard maps a resolved mtgmatcher card to our surrogate ban_id
+// using whichever identity the variants table keys on for its game: the mtgjson
+// uuid for Magic (in-memory cache, no round-trip), otherwise the card's TCGplayer
+// product id for non-Magic games (Lorcana, Pokemon, ...), which have no uuid.
+// Returns 0 when nothing matches, so the caller charts by the canonical uuid path.
+func cachedBanIDForCard(ctx context.Context, co *mtgmatcher.CardObject) int64 {
+	if PricesArchiveDB == nil {
+		return 0
+	}
+	if banID, ok := PricesArchiveDB.CachedMagicBanID(timeseries.MagicVariant{
+		MtgjsonUUID: co.UUID, IsFoil: co.Foil, IsEtched: co.Etched,
+		IsAlt: co.IsAlternative, Language: co.Language,
+	}); ok {
+		return banID
+	}
+	if pidStr, ok := co.Identifiers["tcgplayerProductId"]; ok {
+		if pid, err := strconv.Atoi(pidStr); err == nil {
+			if vi, ok, err := PricesArchiveDB.LookupTCGBanID(ctx, pid); err == nil && ok {
+				return vi.BanID
+			}
+		}
+	}
+	return 0
 }
 
 // targetFromTCGID resolves a TCGplayer product id: Magic first (mtgmatcher knows
@@ -126,6 +165,7 @@ func targetFromTCGID(ctx context.Context, tcgID int) (*chartTarget, error) {
 		if co, err := mtgmatcher.GetUUID(matched); err == nil {
 			return &chartTarget{
 				UUID: co.UUID, Foil: co.Foil, Etched: co.Etched, Name: co.Name,
+				BanID: cachedBanIDForCard(ctx, co),
 			}, nil
 		}
 	}

--- a/chart_resolve.go
+++ b/chart_resolve.go
@@ -13,29 +13,19 @@ import (
 // errChartIDNotFound means a syntactically valid id resolved to no chartable card.
 var errChartIDNotFound = errors.New("chart id not found")
 
-// nonMagicChartProviders are the TCGplayer metrics a non-Magic (tcgcsv) product
-// can chart: Low, Market, Mid, High, Direct Low. Magic uses the dataset config.
-var nonMagicChartProviders = []int16{
-	timeseries.ProviderTCGLow, timeseries.ProviderTCGMarket, timeseries.ProviderTCGMid,
-	timeseries.ProviderTCGHigh, timeseries.ProviderTCGDirectLow,
-}
-
-// chartTarget is a resolved chart identity that unifies Magic (mtgmatcher-backed)
-// and non-Magic (tcg_products-backed) cards. The read mode is:
+// chartTarget is a resolved, game-agnostic chart identity. The read mode is:
 //   - BanID != 0: chart this exact variant via HGetAllByBanID (a ban: id, or a
 //     resolved TCGplayer product). Precise about language/finish/alt/sub-type.
-//   - BanID == 0: Magic canonical path via (UUID, Foil, Etched) through HGetAllLong.
+//   - BanID == 0: canonical uuid path via (UUID, Foil, Etched) through HGetAllLong.
+//
+// Datasets are derived from whichever providers have data (see getChartDatasets),
+// so the target carries no game flag or provider list — a new game just works.
 type chartTarget struct {
-	BanID   int64
-	UUID    string // mtgjson uuid, for the Magic canonical path and display
-	Foil    bool
-	Etched  bool
-	Sealed  bool
-	Name    string
-	IsMagic bool
-	// Providers to render for a non-Magic target; nil means use the Magic
-	// dataset config in getDatasets.
-	Providers []int16
+	BanID  int64
+	UUID   string // mtgjson uuid, for the canonical path and display
+	Foil   bool
+	Etched bool
+	Name   string
 }
 
 // resolveChartTarget turns any supported id string into a chartable target.
@@ -104,20 +94,25 @@ func magicTargetFromCardID(ctx context.Context, id string) (*chartTarget, error)
 		}
 	}
 	if err == nil {
-		return &chartTarget{
-			UUID:    co.UUID,
-			Foil:    co.Foil,
-			Etched:  co.Etched,
-			Sealed:  co.Sealed,
-			Name:    co.Name,
-			IsMagic: true,
-		}, nil
+		t := &chartTarget{UUID: co.UUID, Foil: co.Foil, Etched: co.Etched, Name: co.Name}
+		// Prefer the cached ban_id so the chart reads the exact variant (skips the
+		// canonical resolution HGetAllLong does in SQL). Falls back to the uuid
+		// path when the cache is cold.
+		if PricesArchiveDB != nil {
+			if id, ok := PricesArchiveDB.CachedMagicBanID(timeseries.MagicVariant{
+				MtgjsonUUID: co.UUID, IsFoil: co.Foil, IsEtched: co.Etched,
+				IsAlt: co.IsAlternative, Language: co.Language,
+			}); ok {
+				t.BanID = id
+			}
+		}
+		return t, nil
 	}
 
 	// Datastore fallback: a uuid we have prices for but mtgmatcher no longer knows.
 	if maybeUUIDString(id) {
 		if banID, ok, lerr := PricesArchiveDB.LookupMagicBanIDByUUID(ctx, id); lerr == nil && ok {
-			return &chartTarget{BanID: banID, UUID: id, IsMagic: true}, nil
+			return &chartTarget{BanID: banID, UUID: id}, nil
 		}
 	}
 	return nil, errChartIDNotFound
@@ -130,8 +125,7 @@ func targetFromTCGID(ctx context.Context, tcgID int) (*chartTarget, error) {
 	if matched, err := mtgmatcher.MatchId(idStr); err == nil {
 		if co, err := mtgmatcher.GetUUID(matched); err == nil {
 			return &chartTarget{
-				UUID: co.UUID, Foil: co.Foil, Etched: co.Etched,
-				Sealed: co.Sealed, Name: co.Name, IsMagic: true,
+				UUID: co.UUID, Foil: co.Foil, Etched: co.Etched, Name: co.Name,
 			}, nil
 		}
 	}
@@ -157,17 +151,15 @@ func targetFromBanID(ctx context.Context, banID int64) (*chartTarget, error) {
 	}
 	if vi.IsMagic() {
 		t := &chartTarget{
-			BanID:   banID,
-			UUID:    vi.MtgjsonUUID,
-			Foil:    vi.IsFoil,
-			Etched:  vi.IsEtched,
-			IsMagic: true,
+			BanID:  banID,
+			UUID:   vi.MtgjsonUUID,
+			Foil:   vi.IsFoil,
+			Etched: vi.IsEtched,
 		}
-		// Name/sealed for display come from mtgmatcher; the base uuid suffices
-		// since the name is finish-independent (the chart uses BanID for data).
+		// Display name comes from mtgmatcher; the base uuid suffices since the
+		// name is finish-independent (the chart uses BanID for data).
 		if co, err := mtgmatcher.GetUUID(vi.MtgjsonUUID); err == nil {
 			t.Name = co.Name
-			t.Sealed = co.Sealed
 		}
 		return t, nil
 	}
@@ -178,11 +170,7 @@ func targetFromBanID(ctx context.Context, banID int64) (*chartTarget, error) {
 // the tcg_products catalog and tagging the printing's sub-type when it is not the
 // base ("Normal").
 func nonMagicTarget(ctx context.Context, vi timeseries.VariantInfo) *chartTarget {
-	t := &chartTarget{
-		BanID:     vi.BanID,
-		IsMagic:   false,
-		Providers: nonMagicChartProviders,
-	}
+	t := &chartTarget{BanID: vi.BanID}
 	if p, ok, _ := PricesArchiveDB.GetTCGProduct(ctx, vi.TCGProductID); ok {
 		t.Name = p.Name
 		if vi.TCGSubType != "" && vi.TCGSubType != "Normal" {

--- a/chart_resolve_test.go
+++ b/chart_resolve_test.go
@@ -1,0 +1,21 @@
+package main
+
+import "testing"
+
+func TestSplitIDPrefix(t *testing.T) {
+	cases := []struct{ in, prefix, val string }{
+		{"ban:123", "ban", "123"},
+		{"tcg:454233", "tcg", "454233"},
+		{"scryfall:abc-def-123", "scryfall", "abc-def-123"},
+		{"mtgjson:7c3ea479-e463-58e7-b1b0-b217c77dae79", "mtgjson", "7c3ea479-e463-58e7-b1b0-b217c77dae79"},
+		{"7c3ea479-e463-58e7-b1b0-b217c77dae79", "", "7c3ea479-e463-58e7-b1b0-b217c77dae79"},
+		{"454233", "", "454233"},
+		{"BAN:5", "ban", "5"}, // prefix is lowercased
+	}
+	for _, tc := range cases {
+		p, v := splitIDPrefix(tc.in)
+		if p != tc.prefix || v != tc.val {
+			t.Errorf("splitIDPrefix(%q) = (%q, %q), want (%q, %q)", tc.in, p, v, tc.prefix, tc.val)
+		}
+	}
+}

--- a/db_migration/.gitignore
+++ b/db_migration/.gitignore
@@ -1,0 +1,3 @@
+# Transient run logs and Python cache from executing the migration.
+*.log
+__pycache__/

--- a/db_migration/01_schema.sql
+++ b/db_migration/01_schema.sql
@@ -1,0 +1,118 @@
+-- card_prices redesign — schema (build alongside the existing tables).
+-- Idempotent: safe to re-run. Creates providers, variants, prices (+partitions),
+-- and the migration progress/checkpoint objects. Does NOT touch product_prices
+-- or tcgplayer_nonmagic_product_prices.
+--
+-- Reference: ~/Desktop/card_prices_redesign_plan.md (consolidated DDL 17.9).
+-- Load-speed note: prices is created WITHOUT its PK / secondary index / FKs so the
+-- bulk backfill runs fast; those are added afterward by 05_indexes.sql.
+
+-- ---------------------------------------------------------------------------
+-- Checkpoint / progress tracking (its own schema so `public` stays clean).
+-- ---------------------------------------------------------------------------
+CREATE SCHEMA IF NOT EXISTS migration;
+
+CREATE TABLE IF NOT EXISTS migration.progress (
+    phase        text        NOT NULL,   -- 'variants_magic' | 'variants_nonmagic' | 'prices_magic' | 'prices_nonmagic'
+    chunk_key    text        NOT NULL,   -- 'YYYY-MM' (magic) | 'cat<id>-YYYY-MM' (non-magic) | 'all'
+    status       text        NOT NULL DEFAULT 'pending',   -- pending | running | done | error
+    rows_written bigint,
+    started_at   timestamptz,
+    finished_at  timestamptz,
+    error_msg    text,
+    PRIMARY KEY (phase, chunk_key)
+);
+
+-- Human-readable rollup: one line per phase.
+CREATE OR REPLACE VIEW migration.status AS
+SELECT phase,
+       count(*) FILTER (WHERE status = 'done')    AS chunks_done,
+       count(*) FILTER (WHERE status = 'running') AS chunks_running,
+       count(*) FILTER (WHERE status = 'error')   AS chunks_error,
+       count(*)                                   AS chunks_total,
+       round(100.0 * count(*) FILTER (WHERE status = 'done') / NULLIF(count(*), 0), 1) AS pct_done,
+       coalesce(sum(rows_written) FILTER (WHERE status = 'done'), 0) AS rows_written,
+       min(started_at)  AS first_started,
+       max(finished_at) AS last_finished
+FROM migration.progress
+GROUP BY phase
+ORDER BY phase;
+
+-- ---------------------------------------------------------------------------
+-- providers: 13-row lookup. kind is informational (plan 17.6).
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.providers (
+    id          smallint    PRIMARY KEY,
+    shorthand   text        NOT NULL UNIQUE,
+    public_name text        NOT NULL,
+    kind        text        NOT NULL,               -- 'retail' | 'buylist' | 'derived'
+    currency    char(3)     NOT NULL DEFAULT 'USD'
+);
+
+-- ---------------------------------------------------------------------------
+-- variants: one row per identity. ban_id is bigint (plan 17.1). A variant is
+-- either Magic (mtgjson_uuid set, tcgp_* null) or non-Magic (tcgp_* set,
+-- mtgjson_uuid null); the CHECK enforces that split and guarantees a non-Magic
+-- variant never has a NULL sub_type (so partial-index NULL-distinctness can't
+-- admit duplicates — plan 17.2 / section 12 note).
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.variants (
+    ban_id           bigint  GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    mtgjson_uuid     uuid,                            -- NULL for non-Magic
+    is_foil          boolean NOT NULL DEFAULT false,
+    is_etched        boolean NOT NULL DEFAULT false,
+    is_alt           boolean NOT NULL DEFAULT false,
+    language         text    NOT NULL DEFAULT '',
+    tcgp_category_id integer,                         -- NOT NULL for non-Magic
+    tcgp_product_id  integer,                         -- NOT NULL for non-Magic
+    tcgp_sub_type    text,                            -- NOT NULL ('' if none) for non-Magic
+    CONSTRAINT variants_identity_ck CHECK (
+        (mtgjson_uuid IS NOT NULL
+             AND tcgp_category_id IS NULL AND tcgp_product_id IS NULL AND tcgp_sub_type IS NULL)
+        OR
+        (mtgjson_uuid IS NULL
+             AND tcgp_category_id IS NOT NULL AND tcgp_product_id IS NOT NULL AND tcgp_sub_type IS NOT NULL)
+    )
+);
+
+-- Magic identity (partial: excludes non-Magic rows). Also the backfill join key.
+CREATE UNIQUE INDEX IF NOT EXISTS variants_mtg_uk ON public.variants
+    (mtgjson_uuid, is_foil, is_etched, is_alt, language)
+    WHERE mtgjson_uuid IS NOT NULL;
+
+-- Non-Magic identity (partial). Also the backfill join key.
+CREATE UNIQUE INDEX IF NOT EXISTS variants_tcg_uk ON public.variants
+    (tcgp_category_id, tcgp_product_id, tcgp_sub_type)
+    WHERE tcgp_product_id IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- prices: long fact table, monthly RANGE partitions (D2). Zeros omitted (D3).
+-- Created WITHOUT PK / secondary index / FKs — added after the bulk load.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.prices (
+    ban_id   bigint        NOT NULL,
+    date     date          NOT NULL,
+    provider smallint      NOT NULL,
+    price    numeric(10,2) NOT NULL
+) PARTITION BY RANGE (date);
+
+-- Monthly partitions covering both source ranges (Magic 2020-09 →, non-Magic
+-- 2024-02 →) with future headroom. IF NOT EXISTS makes this re-runnable.
+DO $$
+DECLARE
+    m date;
+    part_name text;
+BEGIN
+    FOR m IN
+        SELECT generate_series('2020-09-01'::date, '2028-12-01'::date, interval '1 month')::date
+    LOOP
+        part_name := 'prices_' || to_char(m, 'YYYY_MM');
+        EXECUTE format(
+            'CREATE TABLE IF NOT EXISTS public.%I PARTITION OF public.prices FOR VALUES FROM (%L) TO (%L)',
+            part_name, m, (m + interval '1 month')::date
+        );
+    END LOOP;
+END $$;
+
+-- Catch-all so a stray date never errors a write.
+CREATE TABLE IF NOT EXISTS public.prices_default PARTITION OF public.prices DEFAULT;

--- a/db_migration/02_seed_providers.sql
+++ b/db_migration/02_seed_providers.sql
@@ -1,0 +1,22 @@
+-- Provider seed (plan section 4 / 17.5). Idempotent.
+-- Shared TCGplayer ids 3/4 across Magic (scraper) and non-Magic (tcgcsv) per D1.
+-- Cardmarket is EUR; everything else USD.
+INSERT INTO public.providers (id, shorthand, public_name, kind, currency) VALUES
+    (1,  'CKRetail',     'Card Kingdom Retail',      'retail',  'USD'),
+    (2,  'CKBuylist',    'Card Kingdom Buylist',     'buylist', 'USD'),
+    (3,  'TCGLow',       'TCGplayer Low',            'retail',  'USD'),
+    (4,  'TCGMarket',    'TCGplayer Market',         'retail',  'USD'),
+    (5,  'TCGMid',       'TCGplayer Mid',            'retail',  'USD'),
+    (6,  'TCGHigh',      'TCGplayer High',           'retail',  'USD'),
+    (7,  'TCGDirectLow', 'TCGplayer Direct Low',     'retail',  'USD'),
+    (8,  'MKMLow',       'Cardmarket Low',           'retail',  'EUR'),
+    (9,  'MKMTrend',     'Cardmarket Trend',         'retail',  'EUR'),
+    (10, 'SCGBuylist',   'Star City Games Buylist',  'buylist', 'USD'),
+    (11, 'ABUBuylist',   'ABU Games Buylist',        'buylist', 'USD'),
+    (12, 'CSIBuylist',   'Cool Stuff Inc Buylist',   'buylist', 'USD'),
+    (13, 'SealedEV',     'Sealed EV (TCG Low)',      'derived', 'USD')
+ON CONFLICT (id) DO UPDATE
+    SET shorthand   = EXCLUDED.shorthand,
+        public_name = EXCLUDED.public_name,
+        kind        = EXCLUDED.kind,
+        currency    = EXCLUDED.currency;

--- a/db_migration/05_indexes.sql
+++ b/db_migration/05_indexes.sql
@@ -1,0 +1,57 @@
+-- Run AFTER the prices backfill completes (task: build indexes + FK).
+-- IDEMPOTENT: safe to re-run. If a build is interrupted mid-way, the incomplete
+-- object rolls back and re-running skips already-built objects and resumes.
+-- Safe to run while the old tables still serve all reads: nothing reads the new
+-- prices table until code cutover, so the ACCESS EXCLUSIVE locks are harmless.
+-- On a partitioned table each index/PK builds per-partition, so sort temp stays
+-- small (one partition at a time), not one giant sort.
+\timing on
+
+-- Session tuning for the build (all USERSET, no superuser needed). Parallel
+-- workers share maintenance_work_mem, so total memory stays ~1GB.
+SET maintenance_work_mem = '1GB';
+SET max_parallel_maintenance_workers = 2;
+SET synchronous_commit = off;
+
+-- Primary key (D6). Includes date because a range-partitioned unique constraint
+-- must contain the partition key. Also the definitive duplicate check: fails if
+-- any (ban_id, date, provider) is duplicated.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint
+                   WHERE conname='prices_pkey' AND conrelid='public.prices'::regclass) THEN
+        RAISE NOTICE 'building prices_pkey ...';
+        ALTER TABLE public.prices ADD CONSTRAINT prices_pkey PRIMARY KEY (ban_id, date, provider);
+    ELSE
+        RAISE NOTICE 'prices_pkey exists, skipping';
+    END IF;
+END $$;
+
+-- Per-provider analytics scans (D7): GetAggregatePriceStats / GetMovers scan one
+-- provider across many cards since a date. INCLUDE keeps it index-only.
+CREATE INDEX IF NOT EXISTS prices_provider_date ON public.prices (provider, date)
+    INCLUDE (ban_id, price);
+
+-- Provider FK: referenced table is 13 rows, validation is trivial — add validated.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint
+                   WHERE conname='prices_provider_fk' AND conrelid='public.prices'::regclass) THEN
+        ALTER TABLE public.prices ADD CONSTRAINT prices_provider_fk
+            FOREIGN KEY (provider) REFERENCES public.providers(id);
+    END IF;
+END $$;
+
+-- ban_id FK: NOT VALID now (new writes checked, backfill pays nothing); VALIDATE
+-- off-peak via 06_validate_fk.sql (D8).
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint
+                   WHERE conname='prices_ban_id_fk' AND conrelid='public.prices'::regclass) THEN
+        ALTER TABLE public.prices ADD CONSTRAINT prices_ban_id_fk
+            FOREIGN KEY (ban_id) REFERENCES public.variants(ban_id) NOT VALID;
+    END IF;
+END $$;
+
+ANALYZE public.prices;
+\echo === indexes/FKs done (remember to VALIDATE the ban_id FK off-peak) ===

--- a/db_migration/06_validate_fk.sql
+++ b/db_migration/06_validate_fk.sql
@@ -1,0 +1,6 @@
+-- Off-peak: validate the ban_id FK added NOT VALID by 05_indexes.sql (D8).
+-- Takes a SHARE UPDATE EXCLUSIVE lock (allows reads/writes) and scans prices once.
+\timing on
+\echo === VALIDATE prices_ban_id_fk ===
+ALTER TABLE public.prices VALIDATE CONSTRAINT prices_ban_id_fk;
+\echo === DONE ===

--- a/db_migration/07_verify.sql
+++ b/db_migration/07_verify.sql
@@ -1,0 +1,65 @@
+-- Backfill parity verification (plan 7.5 / 17.10). Heavy: full scans of both
+-- source tables + one scan of prices. Run after the backfill completes.
+-- Providers 3/4 are shared, so the new-side counts are scoped to Magic vs
+-- non-Magic via the variants join (mtgjson_uuid IS NOT NULL / tcgp_product_id IS NOT NULL).
+\timing on
+
+\echo === MAGIC parity: source non-null,>0 cells per provider vs prices rows ===
+WITH magic_src AS (
+    SELECT unnest(ARRAY[1,2,3,4,8,9,10,11,12,13]) AS provider,
+           unnest(ARRAY[
+               count(*) FILTER (WHERE cardkingdom_retail_price > 0),
+               count(*) FILTER (WHERE cardkingdom_buylist_price > 0),
+               count(*) FILTER (WHERE tcgplayer_low_price > 0),
+               count(*) FILTER (WHERE tcgplayer_market_price > 0),
+               count(*) FILTER (WHERE cardmarket_low_price > 0),
+               count(*) FILTER (WHERE cardmarket_trend_price > 0),
+               count(*) FILTER (WHERE starcitygames_buylist_price > 0),
+               count(*) FILTER (WHERE abu_buylist_price > 0),
+               count(*) FILTER (WHERE coolstuffinc_buylist_price > 0),
+               count(*) FILTER (WHERE tcgplayer_low_sealed_expected_value > 0)
+           ]) AS src_count
+    FROM public.product_prices
+),
+magic_new AS (
+    SELECT p.provider, count(*) AS new_count
+    FROM public.prices p
+    JOIN public.variants v ON v.ban_id = p.ban_id
+    WHERE v.mtgjson_uuid IS NOT NULL
+    GROUP BY p.provider
+)
+SELECT s.provider, pr.shorthand, s.src_count, coalesce(n.new_count,0) AS new_count,
+       coalesce(n.new_count,0) - s.src_count AS diff
+FROM magic_src s
+LEFT JOIN magic_new n USING (provider)
+JOIN public.providers pr ON pr.id = s.provider
+ORDER BY s.provider;
+
+\echo === NON-MAGIC parity: source non-null,>0 cells per provider vs prices rows ===
+WITH nm_src AS (
+    SELECT unnest(ARRAY[3,4,5,6,7]) AS provider,
+           unnest(ARRAY[
+               count(*) FILTER (WHERE low_price > 0),
+               count(*) FILTER (WHERE market_price > 0),
+               count(*) FILTER (WHERE mid_price > 0),
+               count(*) FILTER (WHERE high_price > 0),
+               count(*) FILTER (WHERE direct_low_price > 0)
+           ]) AS src_count
+    FROM public.tcgplayer_nonmagic_product_prices
+),
+nm_new AS (
+    SELECT p.provider, count(*) AS new_count
+    FROM public.prices p
+    JOIN public.variants v ON v.ban_id = p.ban_id
+    WHERE v.tcgp_product_id IS NOT NULL
+    GROUP BY p.provider
+)
+SELECT s.provider, pr.shorthand, s.src_count, coalesce(n.new_count,0) AS new_count,
+       coalesce(n.new_count,0) - s.src_count AS diff
+FROM nm_src s
+LEFT JOIN nm_new n USING (provider)
+JOIN public.providers pr ON pr.id = s.provider
+ORDER BY s.provider;
+
+\echo === totals ===
+SELECT 'prices_rows' AS metric, count(*) AS value FROM public.prices;

--- a/db_migration/08_catchup.sql
+++ b/db_migration/08_catchup.sql
@@ -1,0 +1,98 @@
+-- Reconciliation catch-up (run at cutover, before flipping reads).
+--
+-- The backfill is a point-in-time snapshot, but the live crons keep writing to
+-- product_prices / tcgplayer_nonmagic_product_prices during and after it. So the
+-- long tables drift behind by the rows added since the variants snapshot / each
+-- month chunk ran (e.g. new printings minted on the backfill's start day that the
+-- variant-join couldn't match). Parity verification (07) shows this as a small
+-- negative diff on the most-recently-written providers.
+--
+-- This script re-mints any new variants and re-inserts the recent window into
+-- prices with ON CONFLICT DO NOTHING, so only the missing rows are added. It is
+-- idempotent and safe to re-run. Set :since to comfortably before the backfill
+-- start (default 2026-07-01 covers the whole drift window as of the migration).
+--
+--   psql ... -v since=2026-07-01 -f 08_catchup.sql
+--
+-- Once long-form dual-write is enabled and has run a full cycle, drift stops and
+-- this only needs to close the one-time gap between backfill and dual-write.
+\if :{?since}
+\else
+  \set since '2026-07-01'
+\endif
+\timing on
+\echo Catch-up since :since
+SET synchronous_commit = off;
+SET work_mem = '256MB';
+
+-- 1) Re-mint any variants that appeared since the snapshot (idempotent).
+INSERT INTO public.variants (mtgjson_uuid, is_foil, is_etched, is_alt, language)
+SELECT DISTINCT mtgjson_uuid, is_foil, is_etched, is_alt, language
+FROM public.product_prices WHERE date >= DATE :'since'
+ON CONFLICT (mtgjson_uuid, is_foil, is_etched, is_alt, language)
+    WHERE mtgjson_uuid IS NOT NULL DO NOTHING;
+
+INSERT INTO public.variants (tcgp_category_id, tcgp_product_id, tcgp_sub_type)
+SELECT DISTINCT category_id, product_id, coalesce(sub_type_name,'')
+FROM public.tcgplayer_nonmagic_product_prices WHERE date >= DATE :'since'
+ON CONFLICT (tcgp_category_id, tcgp_product_id, tcgp_sub_type)
+    WHERE tcgp_product_id IS NOT NULL DO NOTHING;
+
+-- 2) Magic: re-insert the recent window, filling only missing (ban_id,date,provider).
+\echo Magic catch-up ...
+INSERT INTO public.prices (ban_id, date, provider, price)
+SELECT v.ban_id, src.date, u.provider, u.price
+FROM public.product_prices src
+JOIN public.variants v
+  ON v.mtgjson_uuid = src.mtgjson_uuid AND v.is_foil = src.is_foil
+ AND v.is_etched = src.is_etched AND v.is_alt = src.is_alt AND v.language = src.language
+CROSS JOIN LATERAL (VALUES
+    (1::smallint,  src.cardkingdom_retail_price),
+    (2::smallint,  src.cardkingdom_buylist_price),
+    (3::smallint,  src.tcgplayer_low_price),
+    (4::smallint,  src.tcgplayer_market_price),
+    (8::smallint,  src.cardmarket_low_price),
+    (9::smallint,  src.cardmarket_trend_price),
+    (10::smallint, src.starcitygames_buylist_price),
+    (11::smallint, src.abu_buylist_price),
+    (12::smallint, src.coolstuffinc_buylist_price),
+    (13::smallint, src.tcgplayer_low_sealed_expected_value)
+) AS u(provider, price)
+WHERE src.date >= DATE :'since' AND u.price > 0
+ON CONFLICT (ban_id, date, provider) DO NOTHING;
+
+-- 3) Non-Magic: same, per category so partition pruning + the (category,date)
+--    index keep the scan cheap. Loops all dedicated category partitions.
+--    :'since' is not substituted inside a $$-quoted DO body, so pass it through a
+--    session GUC and read it with current_setting().
+\echo Non-Magic catch-up ...
+SET catchup.since = :'since';
+DO $$
+DECLARE
+  cat int;
+  since_date text := current_setting('catchup.since');
+BEGIN
+  FOR cat IN
+    SELECT regexp_replace(c.relname,'^tcgplayer_nonmagic_product_prices_cat_','')::int
+    FROM pg_inherits i JOIN pg_class c ON c.oid=i.inhrelid
+    JOIN pg_class p ON p.oid=i.inhparent
+    WHERE p.relname='tcgplayer_nonmagic_product_prices' AND c.relname ~ '_cat_[0-9]+$'
+  LOOP
+    EXECUTE format($q$
+      INSERT INTO public.prices (ban_id, date, provider, price)
+      SELECT v.ban_id, src.date, u.provider, u.price
+      FROM public.tcgplayer_nonmagic_product_prices src
+      JOIN public.variants v
+        ON v.tcgp_category_id = src.category_id AND v.tcgp_product_id = src.product_id
+       AND v.tcgp_sub_type = src.sub_type_name
+      CROSS JOIN LATERAL (VALUES
+          (3::smallint, src.low_price), (4::smallint, src.market_price),
+          (5::smallint, src.mid_price), (6::smallint, src.high_price),
+          (7::smallint, src.direct_low_price)
+      ) AS u(provider, price)
+      WHERE src.category_id = %s AND src.date >= DATE %L AND u.price > 0
+      ON CONFLICT (ban_id, date, provider) DO NOTHING$q$, cat, since_date);
+  END LOOP;
+END $$;
+
+\echo Catch-up done. Re-run 07_verify.sql to confirm parity.

--- a/db_migration/CUTOVER.md
+++ b/db_migration/CUTOVER.md
@@ -1,0 +1,90 @@
+# Long-form cutover — operational runbook
+
+The Go branch `card-prices-long-form` implements the long-form read/write paths
+behind two config flags, so the cutover is a sequence of config flips with a
+verify gate between each. The legacy wide path stays intact until the end, so
+every step is reversible by flipping the flag back.
+
+## 1. config.json additions (NOT in git — config.json is gitignored)
+
+Add a `provider` id to every `timeseries_config.datasets` entry, and the two
+flags on `timeseries_config`. The index→provider mapping (plan 17.5):
+
+| dataset `index` | column | `provider` |
+|---|---|---|
+| 0 | cardkingdom_retail_price | 1 |
+| 1 | cardkingdom_buylist_price | 2 |
+| 2 | tcgplayer_low_price | 3 |
+| 3 | tcgplayer_market_price | 4 |
+| 4 | cardmarket_low_price | 8 |
+| 5 | cardmarket_trend_price | 9 |
+| 6 | starcitygames_buylist_price | 10 |
+| 7 | abu_buylist_price | 11 |
+| 8 | tcgplayer_low_sealed_expected_value | 13 |
+| 9 | coolstuffinc_buylist_price | 12 |
+
+```jsonc
+"timeseries_config": {
+    "long_form_writes": false,   // step 2 flips this on
+    "long_form_reads": false,    // step 4 flips this on
+    "datasets": [
+        { "public_name": "TCGplayer Low", "index": 2, "provider": 3, ... },
+        { "public_name": "TCGplayer Market", "index": 3, "provider": 4, ... },
+        // ... provider on every dataset ...
+    ]
+}
+```
+
+Non-Magic providers are wired in code, not config (tcgcsv columns low/market/mid/
+high/direct_low → providers 3/4/5/6/7).
+
+## 2. Turn on dual-write (`long_form_writes: true`), deploy
+
+Now every 12h stash and every daily tcgcsv ingest writes the legacy wide row AND
+the long row (variants + prices). Reads are still legacy. Startup also ensures the
+current+next month partitions exist and warms the variant→ban_id cache.
+
+A long-form write failure is logged (ServerNotify / log), never fatal — the legacy
+write already persisted the snapshot.
+
+## 3. Verify live-write parity
+
+After a stash and a tcgcsv run have both fired under dual-write, confirm the new
+rows match the legacy ones for the latest date:
+
+```sql
+-- Magic: legacy non-null,>0 cells vs long rows for the latest date, per provider.
+-- (Same shape as 07_verify.sql, scoped to the newest date.)
+```
+
+Re-run `07_verify.sql` (full history) as the primary gate; it already compares
+per-provider counts across the whole table. Spot-check a handful of cards' charts.
+
+**Closing backfill drift.** The initial backfill runs alongside the live crons, so
+the long tables lag behind by the rows product_prices gained since the variants
+snapshot (verification shows this as a small negative per-provider diff — e.g. new
+printings minted on the backfill's start day). Once dual-write is on this stops
+growing; to close the one-time gap, run `08_catchup.sql` (re-mints new variants +
+re-inserts the recent window with ON CONFLICT DO NOTHING). Re-run `07_verify.sql`
+after — the diffs should go to 0.
+
+## 4. Flip reads (`long_form_reads: true`), deploy
+
+Charts (`HGetAllLong`), earliest-date, buylist metrics (`GetAggregatePriceStatsLong`),
+and the screener (`GetMoversLong`) now serve from the long tables. Legacy writes
+continue (safety net). Watch charts / screener / buylist metrics for a day.
+
+Rollback at any point before this is trusted: set `long_form_reads: false`.
+
+## 5. Drop the legacy write path (follow-up PR, not this branch)
+
+Once reads are trusted on long form: stop writing the wide `product_prices` /
+`tcgplayer_nonmagic_product_prices`, delete `PriceForDataset` /
+`SetPriceForDataset` / `columnForDataset` and the wide `PriceRow` read methods,
+and drop the `index` field from datasets (provider fully replaces it). The old
+tables can then be archived/dropped when you're ready.
+
+## 6. Validate + finalize the FK
+
+Off-peak, run `06_validate_fk.sql` to VALIDATE the `prices_ban_id_fk` constraint
+that was added `NOT VALID`.

--- a/db_migration/README.md
+++ b/db_migration/README.md
@@ -1,0 +1,71 @@
+# card_prices redesign — migration workspace
+
+Implements `~/Desktop/card_prices_redesign_plan.md`: collapses the two wide price
+tables (`product_prices`, `tcgplayer_nonmagic_product_prices`) into a unified
+identity space (`variants`) + a long, date-partitioned `prices(ban_id, date,
+provider, price)` table, with a `providers` lookup.
+
+**Build-alongside:** the old tables are never altered. Reads stay on them until
+the Go rewrite (task #7) cuts over. Rollback = point code back at the old tables.
+
+## Checkpointing / resume
+
+All progress lives in the DB, in schema `migration`:
+- `migration.progress` — one row per unit of work (`phase`, `chunk_key`, `status`).
+- `migration.status` — per-phase rollup view.
+
+Every price chunk runs as a **single atomic statement** (the INSERT and its
+`status='done'` update commit together). So killing the driver — or a network
+drop — mid-chunk rolls the whole chunk back; nothing is half-written. Re-running
+the same command skips `done` chunks and resumes. Idempotent by construction.
+
+### To resume after a disconnect
+```bash
+cd db_migration
+python3 backfill.py status     # see where we are
+python3 backfill.py prices     # resume; re-runs any pending/running/error chunks
+```
+
+## Order of operations
+
+| # | Command | What it does | Cost |
+|---|---------|--------------|------|
+| 1 | `python3 backfill.py schema` | Apply `01_schema.sql` + `02_seed_providers.sql` (idempotent) | instant |
+| 2 | `python3 backfill.py variants` | Build Magic + non-Magic `variants` (2 full scans) | ~10-40 min |
+| 3 | `python3 backfill.py estimate` | Sample-based size/row estimate | seconds |
+| 4 | `python3 backfill.py prices` | Backfill all price chunks (resumable) | hours |
+| 5 | `psql -f 05_indexes.sql` | PK + `(provider,date)` index + FKs (ban_id FK NOT VALID) | long |
+| 6 | `psql -f 06_validate_fk.sql` | VALIDATE ban_id FK (off-peak) | medium |
+| 7 | `psql -f 07_verify.sql` | Per-provider parity: source cells == prices rows | heavy |
+
+`psql` connection: driver reads `../config.json` `sql_config`. For raw psql, set
+`PGHOST/PGPORT/PGUSER/PGPASSWORD/PGDATABASE/PGSSLMODE` from that block.
+
+## Key facts (measured 2026-07-27)
+
+- Magic `product_prices`: ~161M rows, 2020-09 → 2026-07 (~71 months), 35 GB.
+- Non-Magic: **~145M rows** (NOT the 2.97M the plan's stale `reltuples` implied),
+  2024-02 → 2026-07, LIST-partitioned by category across ~10 categories.
+- Full backfill ≈ **1.23B price rows ≈ 157 GB** (heap ~59 + PK ~49 + 2nd idx ~49).
+- `cat_1` partition is empty (droppable); `prices_default` catches strays.
+
+## Decisions (from plan section 0)
+
+Full backfill of **both** Magic and non-Magic. Zeros/nulls omitted (`price > 0`).
+Providers 3/4 (TCGLow/TCGMarket) shared across Magic+non-Magic. `ban_id` bigint.
+PK `(ban_id, date, provider)`; monthly range partitions. See the plan for D1-D10.
+
+## Chunking
+
+- Magic: one chunk per **month** (`product_prices` has an index on `date`).
+- Non-Magic: one chunk per **(category, month)** — the table is partitioned by
+  `category_id` with an index on `(category_id, date)`, so a date-only filter
+  would scan every partition. `cat<id>-YYYY-MM`.
+
+## Files
+
+- `01_schema.sql` — providers, variants (+partial UKs, identity CHECK), prices
+  (partitioned, no PK/indexes yet), `migration.progress` + `migration.status`.
+- `02_seed_providers.sql` — 13-provider seed.
+- `backfill.py` — the checkpointed driver (all commands above).
+- `05_indexes.sql` / `06_validate_fk.sql` / `07_verify.sql` — post-load steps.

--- a/db_migration/backfill.py
+++ b/db_migration/backfill.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""Checkpointed driver for the card_prices redesign backfill.
+
+Every unit of work is recorded in migration.progress. Each price chunk runs as a
+SINGLE atomic statement (the INSERT and its 'done' marker commit together), so a
+disconnect mid-chunk rolls the whole thing back and re-running resumes from the
+last committed chunk. Safe to kill and restart at any time.
+
+Usage:
+    python3 backfill.py schema      # apply 01_schema.sql + 02_seed_providers.sql (idempotent)
+    python3 backfill.py variants    # build Magic + non-Magic variants (skips if done)
+    python3 backfill.py seed        # seed migration.progress rows for all price chunks
+    python3 backfill.py prices      # run all pending/failed price chunks (resumable)
+    python3 backfill.py prices --explain-first   # EXPLAIN one magic + one nonmagic chunk, then run
+    python3 backfill.py status      # print migration.status + a per-phase chunk tally
+    python3 backfill.py estimate    # sample-based size/row estimate for the full backfill
+"""
+import json
+import os
+import subprocess
+import sys
+from datetime import date
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+CONFIG = os.path.join(os.path.dirname(HERE), "config.json")
+
+# source column -> provider id (plan 17.5)
+MAGIC_COLS = [
+    (1,  "cardkingdom_retail_price"),
+    (2,  "cardkingdom_buylist_price"),
+    (3,  "tcgplayer_low_price"),
+    (4,  "tcgplayer_market_price"),
+    (8,  "cardmarket_low_price"),
+    (9,  "cardmarket_trend_price"),
+    (10, "starcitygames_buylist_price"),
+    (11, "abu_buylist_price"),
+    (12, "coolstuffinc_buylist_price"),
+    (13, "tcgplayer_low_sealed_expected_value"),
+]
+NONMAGIC_COLS = [
+    (3, "low_price"),
+    (4, "market_price"),
+    (5, "mid_price"),
+    (6, "high_price"),
+    (7, "direct_low_price"),
+]
+
+# Session tuning applied to every load connection (all USERSET, no superuser needed).
+SESSION_SETUP = (
+    "SET synchronous_commit=off; SET work_mem='256MB'; "
+    "SET maintenance_work_mem='512MB'; SET statement_timeout=0;"
+)
+
+
+def pgenv():
+    with open(CONFIG) as f:
+        c = json.load(f)["sql_config"]
+    env = dict(os.environ)
+    env["PGHOST"] = str(c["host"])
+    env["PGPORT"] = str(c["port"])
+    env["PGUSER"] = str(c["user"])
+    env["PGPASSWORD"] = str(c["password"])
+    env["PGDATABASE"] = str(c["dbname"])
+    env["PGSSLMODE"] = str(c.get("sslmode", "require"))
+    return env
+
+
+ENV = pgenv()
+
+
+def psql(sql, capture=True, quiet=True):
+    """Run one SQL batch via psql stdin. Returns (rc, stdout)."""
+    args = ["psql", "-v", "ON_ERROR_STOP=1", "-X"]
+    if quiet:
+        args += ["-q"]
+    args += ["-f", "-"]
+    r = subprocess.run(args, input=sql, env=ENV, text=True,
+                       capture_output=capture)
+    if r.returncode != 0:
+        sys.stderr.write(r.stderr or "")
+    return r.returncode, (r.stdout or "")
+
+
+def query(sql):
+    """Run a query, return list of tab-split rows."""
+    r = subprocess.run(["psql", "-v", "ON_ERROR_STOP=1", "-X", "-tAF", "\t",
+                        "-c", sql], env=ENV, text=True, capture_output=True)
+    if r.returncode != 0:
+        raise RuntimeError(r.stderr)
+    return [line.split("\t") for line in r.stdout.strip().splitlines() if line]
+
+
+def run_file(fname):
+    path = os.path.join(HERE, fname)
+    with open(path) as f:
+        sql = f.read()
+    print(f"  applying {fname} ...", flush=True)
+    rc, _ = psql(sql, capture=True)
+    if rc != 0:
+        raise SystemExit(f"FAILED applying {fname}")
+
+
+def months(start_ym, end_ym):
+    """Inclusive list of first-of-month dates from start_ym to end_ym ('YYYY-MM')."""
+    sy, sm = map(int, start_ym.split("-"))
+    ey, em = map(int, end_ym.split("-"))
+    out = []
+    y, m = sy, sm
+    while (y, m) <= (ey, em):
+        out.append(date(y, m, 1))
+        m += 1
+        if m > 12:
+            m = 1
+            y += 1
+    return out
+
+
+def next_month(d):
+    return date(d.year + 1, 1, 1) if d.month == 12 else date(d.year, d.month + 1, 1)
+
+
+def source_range(table):
+    rows = query(f"SELECT to_char(min(date),'YYYY-MM'), to_char(max(date),'YYYY-MM') FROM {table}")
+    return rows[0][0], rows[0][1]
+
+
+def nonmagic_categories():
+    """Category ids that have a dedicated partition, cheaply from the catalog."""
+    rows = query(
+        "SELECT regexp_replace(c.relname, '^tcgplayer_nonmagic_product_prices_cat_', '')::int "
+        "FROM pg_inherits i JOIN pg_class c ON c.oid=i.inhrelid "
+        "JOIN pg_class p ON p.oid=i.inhparent "
+        "WHERE p.relname='tcgplayer_nonmagic_product_prices' "
+        "AND c.relname ~ '_cat_[0-9]+$' ORDER BY 1")
+    return [int(r[0]) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+
+def cmd_schema():
+    run_file("01_schema.sql")
+    run_file("02_seed_providers.sql")
+    print("schema + providers applied.")
+
+
+def cmd_variants():
+    for phase, sql in (("variants_magic", _variants_magic_sql()),
+                       ("variants_nonmagic", _variants_nonmagic_sql())):
+        done = query("SELECT status FROM migration.progress WHERE phase=%s AND chunk_key='all'"
+                     % _q(phase))
+        if done and done[0][0] == "done":
+            print(f"  {phase}: already done, skipping.")
+            continue
+        print(f"  {phase}: building (full-table scan, one pass) ...", flush=True)
+        rc, _ = psql(sql)
+        if rc != 0:
+            raise SystemExit(f"FAILED {phase}")
+        n = query("SELECT rows_written FROM migration.progress WHERE phase=%s AND chunk_key='all'"
+                  % _q(phase))
+        print(f"  {phase}: done, {n[0][0]} new variants.")
+    tot = query("SELECT count(*), count(*) FILTER (WHERE mtgjson_uuid IS NOT NULL), "
+                "count(*) FILTER (WHERE tcgp_product_id IS NOT NULL) FROM public.variants")
+    print(f"variants total={tot[0][0]}  magic={tot[0][1]}  nonmagic={tot[0][2]}")
+
+
+def _q(s):
+    return "'" + s.replace("'", "''") + "'"
+
+
+def _variants_magic_sql():
+    return f"""
+WITH ins AS (
+  INSERT INTO public.variants (mtgjson_uuid, is_foil, is_etched, is_alt, language)
+  SELECT DISTINCT mtgjson_uuid, is_foil, is_etched, is_alt, language
+  FROM public.product_prices
+  ON CONFLICT (mtgjson_uuid, is_foil, is_etched, is_alt, language)
+     WHERE mtgjson_uuid IS NOT NULL DO NOTHING
+  RETURNING 1
+)
+INSERT INTO migration.progress (phase, chunk_key, status, rows_written, started_at, finished_at)
+VALUES ('variants_magic','all','done',(SELECT count(*) FROM ins), now(), now())
+ON CONFLICT (phase, chunk_key) DO UPDATE
+  SET status='done', rows_written=EXCLUDED.rows_written, finished_at=now(), error_msg=NULL;
+"""
+
+
+def _variants_nonmagic_sql():
+    return f"""
+WITH ins AS (
+  INSERT INTO public.variants (tcgp_category_id, tcgp_product_id, tcgp_sub_type)
+  SELECT DISTINCT category_id, product_id, coalesce(sub_type_name,'')
+  FROM public.tcgplayer_nonmagic_product_prices
+  ON CONFLICT (tcgp_category_id, tcgp_product_id, tcgp_sub_type)
+     WHERE tcgp_product_id IS NOT NULL DO NOTHING
+  RETURNING 1
+)
+INSERT INTO migration.progress (phase, chunk_key, status, rows_written, started_at, finished_at)
+VALUES ('variants_nonmagic','all','done',(SELECT count(*) FROM ins), now(), now())
+ON CONFLICT (phase, chunk_key) DO UPDATE
+  SET status='done', rows_written=EXCLUDED.rows_written, finished_at=now(), error_msg=NULL;
+"""
+
+
+def build_chunks():
+    """Return ordered list of (phase, chunk_key, sql) for every price chunk."""
+    chunks = []
+    # Magic: one chunk per month.
+    mmin, mmax = source_range("public.product_prices")
+    for m in months(mmin, mmax):
+        ck = m.strftime("%Y-%m")
+        chunks.append(("prices_magic", ck, _magic_chunk_sql(m, next_month(m), ck)))
+    # Non-Magic: one chunk per (category, month).
+    nmin, nmax = source_range("public.tcgplayer_nonmagic_product_prices")
+    cats = nonmagic_categories()
+    for cat in cats:
+        for m in months(nmin, nmax):
+            ck = f"cat{cat}-{m.strftime('%Y-%m')}"
+            chunks.append(("prices_nonmagic", ck,
+                           _nonmagic_chunk_sql(cat, m, next_month(m), ck)))
+    return chunks
+
+
+def _values_list(cols):
+    return ",\n       ".join(f"({pid}::smallint, src.{col})" for pid, col in cols)
+
+
+def _magic_chunk_sql(start, end, ck):
+    vals = _values_list(MAGIC_COLS)
+    return f"""
+WITH ins AS (
+  INSERT INTO public.prices (ban_id, date, provider, price)
+  SELECT v.ban_id, src.date, u.provider, u.price
+  FROM public.product_prices src
+  JOIN public.variants v
+    ON v.mtgjson_uuid = src.mtgjson_uuid
+   AND v.is_foil   = src.is_foil
+   AND v.is_etched = src.is_etched
+   AND v.is_alt    = src.is_alt
+   AND v.language  = src.language
+  CROSS JOIN LATERAL (VALUES
+       {vals}
+  ) AS u(provider, price)
+  WHERE src.date >= DATE '{start}' AND src.date < DATE '{end}'
+    AND u.price > 0
+  RETURNING 1
+)
+UPDATE migration.progress
+   SET status='done', rows_written=(SELECT count(*) FROM ins),
+       started_at=now(), finished_at=now(), error_msg=NULL
+ WHERE phase='prices_magic' AND chunk_key='{ck}';
+"""
+
+
+def _nonmagic_chunk_sql(cat, start, end, ck):
+    vals = _values_list(NONMAGIC_COLS)
+    return f"""
+WITH ins AS (
+  INSERT INTO public.prices (ban_id, date, provider, price)
+  SELECT v.ban_id, src.date, u.provider, u.price
+  FROM public.tcgplayer_nonmagic_product_prices src
+  JOIN public.variants v
+    ON v.tcgp_category_id = src.category_id
+   AND v.tcgp_product_id  = src.product_id
+   AND v.tcgp_sub_type    = src.sub_type_name
+  CROSS JOIN LATERAL (VALUES
+       {vals}
+  ) AS u(provider, price)
+  WHERE src.category_id = {cat}
+    AND src.date >= DATE '{start}' AND src.date < DATE '{end}'
+    AND u.price > 0
+  RETURNING 1
+)
+UPDATE migration.progress
+   SET status='done', rows_written=(SELECT count(*) FROM ins),
+       started_at=now(), finished_at=now(), error_msg=NULL
+ WHERE phase='prices_nonmagic' AND chunk_key='{ck}';
+"""
+
+
+def cmd_seed():
+    chunks = build_chunks()
+    # Bulk seed pending rows.
+    values = ",".join(f"({_q(p)},{_q(c)})" for p, c, _ in chunks)
+    sql = (f"INSERT INTO migration.progress (phase, chunk_key) "
+           f"VALUES {values} ON CONFLICT (phase, chunk_key) DO NOTHING;")
+    rc, _ = psql(sql)
+    if rc != 0:
+        raise SystemExit("FAILED seeding progress")
+    print(f"seeded {len(chunks)} price chunks into migration.progress.")
+
+
+def cmd_prices(explain_first=False):
+    chunks = build_chunks()
+    seed_needed = query("SELECT count(*) FROM migration.progress WHERE phase LIKE 'prices_%'")
+    if int(seed_needed[0][0]) == 0:
+        cmd_seed()
+    if explain_first:
+        _explain_samples(chunks)
+
+    # Which chunks still need doing?
+    done = set()
+    for r in query("SELECT phase||'|'||chunk_key FROM migration.progress "
+                   "WHERE phase LIKE 'prices_%' AND status='done'"):
+        done.add(r[0])
+    pending = [(p, c, s) for (p, c, s) in chunks if f"{p}|{c}" not in done]
+    total = len(chunks)
+    print(f"{total-len(pending)}/{total} chunks already done; running {len(pending)} "
+          f"through ONE persistent connection.", flush=True)
+    if not pending:
+        print("nothing to do.")
+        return
+
+    # Stream every chunk through a single psql session. psql is autocommit, so each
+    # atomic (insert + mark-done) statement commits on its own — a mid-stream failure
+    # or dropped connection leaves the committed chunks done and stops the rest; a
+    # re-run resumes from the first still-pending chunk. \echo markers stream to the
+    # log; the live source of truth is `SELECT * FROM migration.status`.
+    parts = [SESSION_SETUP]
+    for i, (phase, ck, sql) in enumerate(pending, 1):
+        parts.append(f"\\echo [{i}/{len(pending)}] {phase} {ck}")
+        parts.append(sql)
+    rc, _ = psql("\n".join(parts), capture=False)
+    if rc != 0:
+        raise SystemExit("backfill errored (see log). Re-run 'prices' to resume "
+                         "from the first still-pending chunk.")
+    print("prices backfill complete for all seeded chunks.")
+
+
+def _explain_samples(chunks):
+    for want in ("prices_magic", "prices_nonmagic"):
+        for phase, ck, sql in chunks:
+            if phase == want:
+                inner = sql.split("RETURNING 1")[0]
+                inner = inner.replace(
+                    "INSERT INTO public.prices (ban_id, date, provider, price)\n  SELECT",
+                    "SELECT", 1)
+                print(f"\n=== EXPLAIN {phase} {ck} ===")
+                rc, out = psql("EXPLAIN " + inner + ";", capture=True, quiet=False)
+                print(out)
+                break
+
+
+def cmd_status():
+    rc, out = psql(
+        "\\echo === migration.status ===\n"
+        "SELECT * FROM migration.status;\n"
+        "\\echo\n\\echo === price chunk tally ===\n"
+        "SELECT phase, status, count(*) FROM migration.progress "
+        "WHERE phase LIKE 'prices_%' GROUP BY 1,2 ORDER BY 1,2;\n"
+        "\\echo\n\\echo === errored chunks (if any) ===\n"
+        "SELECT phase, chunk_key, error_msg FROM migration.progress "
+        "WHERE status='error' ORDER BY 1,2;",
+        capture=False, quiet=False)
+
+
+def cmd_estimate():
+    """Sample-based estimate of long-form row count + heap size for the full backfill."""
+    print("Sampling non-null, >0 price density (this reads small samples) ...", flush=True)
+    magic_expr = " + ".join(
+        f"count(*) FILTER (WHERE {col} > 0)" for _, col in MAGIC_COLS)
+    nm_expr = " + ".join(
+        f"count(*) FILTER (WHERE {col} > 0)" for _, col in NONMAGIC_COLS)
+    m = query(f"SELECT count(*), ({magic_expr}) FROM public.product_prices "
+              f"TABLESAMPLE SYSTEM (0.5)")
+    nm = query(f"SELECT count(*), ({nm_expr}) FROM public.tcgplayer_nonmagic_product_prices "
+               f"TABLESAMPLE SYSTEM (0.5)")
+    mrows_tot = int(query("SELECT reltuples::bigint FROM pg_class WHERE relname='product_prices'")[0][0])
+    nm_rows = query("SELECT coalesce(sum(c.reltuples),0)::bigint FROM pg_inherits i "
+                    "JOIN pg_class c ON c.oid=i.inhrelid JOIN pg_class p ON p.oid=i.inhparent "
+                    "WHERE p.relname='tcgplayer_nonmagic_product_prices'")
+    nm_tot = int(nm_rows[0][0])
+
+    def project(sample, total):
+        srows = int(sample[0][0]) or 1
+        scells = int(sample[0][1])
+        return int(scells / srows * total)
+
+    m_cells = project(m, mrows_tot)
+    nm_cells = project(nm, nm_tot)
+    total = m_cells + nm_cells
+    # heap ~ 24B header + 8(ban_id)+4(date)+2(provider)+ ~6(numeric) + padding ≈ ~48B/row
+    heap_gb = total * 48 / 1e9
+    print(f"  magic source rows   ~{mrows_tot:,} -> price rows ~{m_cells:,}")
+    print(f"  nonmagic source rows ~{nm_tot:,} -> price rows ~{nm_cells:,}")
+    print(f"  TOTAL price rows     ~{total:,}")
+    print(f"  est heap ~{heap_gb:,.0f} GB; + PK idx ~{total*40/1e9:,.0f} GB; "
+          f"+ (provider,date) idx ~{total*40/1e9:,.0f} GB")
+    print(f"  est prices total on disk ~{heap_gb + total*80/1e9:,.0f} GB")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return
+    cmd = sys.argv[1]
+    if cmd == "schema":
+        cmd_schema()
+    elif cmd == "variants":
+        cmd_variants()
+    elif cmd == "seed":
+        cmd_seed()
+    elif cmd == "prices":
+        cmd_prices(explain_first=("--explain-first" in sys.argv))
+    elif cmd == "status":
+        cmd_status()
+    elif cmd == "estimate":
+        cmd_estimate()
+    else:
+        print(__doc__)
+        raise SystemExit(f"unknown command: {cmd}")
+
+
+if __name__ == "__main__":
+    main()

--- a/main.go
+++ b/main.go
@@ -684,6 +684,14 @@ func genPageNav(activeTab, sig string) PageVars {
 	if Config.Game != DefaultGame {
 		// Append which game this site is for
 		pageVars.Title += " - " + mtgmatcher.Title(Config.Game)
+
+		// Charts for a non-Magic game are served only by the long-form read
+		// path; the legacy wide table is mtgjson-uuid keyed and has no rows for
+		// them. Until reads flip on, keep the chart UI hidden rather than show
+		// buttons that resolve to an always-empty chart.
+		if !Config.TimeseriesConfig.LongFormReads {
+			pageVars.DisableChart = true
+		}
 	}
 	if Config.OfflineKey != "" {
 		pageVars.DisableChart = true

--- a/main.go
+++ b/main.go
@@ -684,9 +684,6 @@ func genPageNav(activeTab, sig string) PageVars {
 	if Config.Game != DefaultGame {
 		// Append which game this site is for
 		pageVars.Title += " - " + mtgmatcher.Title(Config.Game)
-
-		// Charts are available only for one game
-		pageVars.DisableChart = true
 	}
 	if Config.OfflineKey != "" {
 		pageVars.DisableChart = true

--- a/main.go
+++ b/main.go
@@ -882,6 +882,22 @@ func openDBs() (err error) {
 				log.Println("warning: could not ensure tcg_products schema:", serr)
 			}
 		}
+		// Long-form dual-write: make sure the current and next month's price
+		// partitions exist ahead of any write, and prime the variant->ban_id
+		// cache so the first stash/ingest doesn't pay a round-trip per printing.
+		// Non-fatal; the write paths re-resolve on a miss regardless.
+		if Config.TimeseriesConfig.LongFormWrites {
+			now := time.Now()
+			if serr := PricesArchiveDB.EnsurePricePartition(context.Background(), now); serr != nil {
+				log.Println("warning: could not ensure current price partition:", serr)
+			}
+			if serr := PricesArchiveDB.EnsurePricePartition(context.Background(), now.AddDate(0, 1, 0)); serr != nil {
+				log.Println("warning: could not ensure next price partition:", serr)
+			}
+			if serr := PricesArchiveDB.WarmVariantCache(context.Background()); serr != nil {
+				log.Println("warning: could not warm variant cache:", serr)
+			}
+		}
 	}
 
 	if Config.UserStateConfig == nil {

--- a/main.go
+++ b/main.go
@@ -825,6 +825,9 @@ func loadVars(port, datastorePath, offlineKey string) error {
 		return err
 	}
 
+	// Build the game-agnostic chart provider registry from the dataset config.
+	buildProviderRegistry()
+
 	// The -port and -ds flags, when provided, override whatever the config
 	// file set. This must happen after the decode above, which would otherwise
 	// clobber the flag values with the config's fields (breaking blue-green

--- a/main.go
+++ b/main.go
@@ -883,9 +883,7 @@ func openDBs() (err error) {
 			}
 		}
 		// Long-form dual-write: make sure the current and next month's price
-		// partitions exist ahead of any write, and prime the variant->ban_id
-		// cache so the first stash/ingest doesn't pay a round-trip per printing.
-		// Non-fatal; the write paths re-resolve on a miss regardless.
+		// partitions exist ahead of any write. Writes-only (creates partitions).
 		if Config.TimeseriesConfig.LongFormWrites {
 			now := time.Now()
 			if serr := PricesArchiveDB.EnsurePricePartition(context.Background(), now); serr != nil {
@@ -894,6 +892,11 @@ func openDBs() (err error) {
 			if serr := PricesArchiveDB.EnsurePricePartition(context.Background(), now.AddDate(0, 1, 0)); serr != nil {
 				log.Println("warning: could not ensure next price partition:", serr)
 			}
+		}
+		// Prime the variant->ban_id cache: the write path resolves/mints on it,
+		// and the read path stamps a cached ban_id onto each rendered card so
+		// charts open by ban:<id> without a per-card round-trip. Non-fatal.
+		if Config.TimeseriesConfig.LongFormWrites || Config.TimeseriesConfig.LongFormReads {
 			if serr := PricesArchiveDB.WarmVariantCache(context.Background()); serr != nil {
 				log.Println("warning: could not warm variant cache:", serr)
 			}

--- a/product.go
+++ b/product.go
@@ -856,7 +856,17 @@ func buylistMetrics(store string, reducers map[string]buylistReducer) map[string
 	// One aggregate query for the whole buylist instead of N per-card lookups.
 	// Postgres computes the stats; each reducer just selects the field it
 	// cares about.
-	statsByCard, err := PricesArchiveDB.GetAggregatePriceStats(context.Background(), datasetIndex, threeMonthsAgo)
+	var statsByCard map[timeseries.AggregatePriceKey]timeseries.AggregatePriceStats
+	if Config.TimeseriesConfig.LongFormReads {
+		provider, ok := providerForDatasetIndex(datasetIndex)
+		if !ok {
+			log.Println(store, "has no provider configured for long-form reads")
+			return nil
+		}
+		statsByCard, err = PricesArchiveDB.GetAggregatePriceStatsLong(context.Background(), provider, threeMonthsAgo)
+	} else {
+		statsByCard, err = PricesArchiveDB.GetAggregatePriceStats(context.Background(), datasetIndex, threeMonthsAgo)
+	}
 	if err != nil {
 		log.Println(err)
 		return nil

--- a/screener.go
+++ b/screener.go
@@ -270,6 +270,13 @@ func screenerCacheKey(metric, window int, minPrice, minPriorPrice float64) strin
 
 // overridable in tests
 var screenerFetch = func(ctx context.Context, metric, window int, minPrice, minPriorPrice float64) ([]timeseries.MoverRow, error) {
+	if Config.TimeseriesConfig.LongFormReads {
+		provider, ok := providerForDatasetIndex(metric)
+		if !ok {
+			return nil, fmt.Errorf("screener: no provider configured for metric %d", metric)
+		}
+		return PricesArchiveDB.GetMoversLong(ctx, provider, window, minPrice, minPriorPrice)
+	}
 	return PricesArchiveDB.GetMovers(ctx, metric, window, minPrice, minPriorPrice)
 }
 

--- a/search.go
+++ b/search.go
@@ -727,7 +727,7 @@ func Search(w http.ResponseWriter, r *http.Request) {
 			lb := chartLookback(sig)
 			pageVars.MaxLookbackDays = lb.Days()
 
-			earliest, _ := PricesArchiveDB.GetEarliestDate(r.Context(), co.UUID, co.Foil, co.Etched, lb)
+			earliest, _ := earliestChartDate(r.Context(), co.UUID, co.Foil, co.Etched, lb)
 
 			pageVars.AxisLabels = getDateAxisValues(earliest)
 			pageVars.Datasets = getDatasets(r.Context(), chartId, co.Sealed, pageVars.AxisLabels, lb)
@@ -749,7 +749,7 @@ func Search(w http.ResponseWriter, r *http.Request) {
 					continue
 				}
 				chartNames = append(chartNames, co.Name)
-				e, _ := PricesArchiveDB.GetEarliestDate(r.Context(), co.UUID, co.Foil, co.Etched, lb)
+				e, _ := earliestChartDate(r.Context(), co.UUID, co.Foil, co.Etched, lb)
 				if e.IsZero() {
 					continue
 				}

--- a/search.go
+++ b/search.go
@@ -718,6 +718,54 @@ func Search(w http.ResponseWriter, r *http.Request) {
 
 		if PricesArchiveDB == nil {
 			pageVars.InfoMessage = "No chart data available"
+		} else if Config.TimeseriesConfig.LongFormReads {
+			lb := chartLookback(sig)
+			pageVars.MaxLookbackDays = lb.Days()
+
+			// Generic path: resolve every roster id to a target and chart it by
+			// whatever providers have data — one path for every game, keyed on the
+			// cached ban_id. The ?chart= url keeps the mtgmatcher id (the search
+			// UI's identity for favorites/roster/legend); the ban_id is internal.
+			var earliest time.Time
+			var ids, names []string
+			var targets []*chartTarget
+			for _, id := range chartIds {
+				target, terr := resolveChartTarget(r.Context(), id)
+				if terr != nil {
+					continue
+				}
+				ids = append(ids, id)
+				names = append(names, target.Name)
+				targets = append(targets, target)
+				if e, _ := chartTargetEarliest(r.Context(), target, lb); !e.IsZero() && (earliest.IsZero() || e.Before(earliest)) {
+					earliest = e
+				}
+			}
+			if len(targets) == 0 || earliest.IsZero() {
+				pageVars.InfoMessage = "No chart data available"
+			} else {
+				pageVars.AxisLabels = getDateAxisValues(earliest)
+				cards := make([]multiCardInput, len(targets))
+				for i, target := range targets {
+					cards[i] = multiCardInput{
+						CardID:   ids[i],
+						Name:     names[i],
+						Datasets: getChartDatasets(r.Context(), target, pageVars.AxisLabels, lb),
+					}
+				}
+				if isMultiChart {
+					datasets, refs := mergeMultiCardDatasets(cards)
+					pageVars.Datasets = datasets
+					pageVars.ChartReferences = refs
+					pageVars.Checkpoints = multiCardCheckpoints(names, earliest)
+				} else {
+					pageVars.Datasets = cards[0].Datasets
+					pageVars.Checkpoints = relevantCheckpoints(cards[0].Name, earliest)
+				}
+				if len(pageVars.Datasets) == 0 {
+					pageVars.InfoMessage = "No chart data available"
+				}
+			}
 		} else if !isMultiChart {
 			co, err := mtgmatcher.GetUUID(chartId)
 			if err != nil {

--- a/search.go
+++ b/search.go
@@ -82,6 +82,38 @@ func searchSuggestions(rawQuery string, config SearchConfig, sealed bool) (strin
 	})
 }
 
+// isValidChartID reports whether a chart= piece is a plausibly chartable id: a
+// mtgmatcher id or a ban:/tcg:/scryfall:/mtgjson: prefixed id (bare numbers are
+// TCGplayer ids). Full resolution happens at render time.
+func isValidChartID(part string) bool {
+	if _, err := mtgmatcher.GetUUID(part); err == nil {
+		return true
+	}
+	switch prefix, _ := splitIDPrefix(part); prefix {
+	case "ban", "tcg", "scryfall", "mtgjson":
+		return true
+	}
+	_, err := strconv.Atoi(part)
+	return err == nil
+}
+
+// chartIDToSearchID maps a chart-roster id to a mtgmatcher search id so the
+// results table (which the embedded chart lives inside) resolves it: a ban:<id>
+// becomes its mtgjson uuid; anything else passes through.
+func chartIDToSearchID(ctx context.Context, id string) string {
+	if _, err := mtgmatcher.GetUUID(id); err == nil {
+		return id
+	}
+	if prefix, val := splitIDPrefix(id); prefix == "ban" && PricesArchiveDB != nil {
+		if n, perr := strconv.ParseInt(val, 10, 64); perr == nil {
+			if vi, ok, _ := PricesArchiveDB.LookupVariant(ctx, n); ok && vi.MtgjsonUUID != "" {
+				return vi.MtgjsonUUID
+			}
+		}
+	}
+	return id
+}
+
 // parseChartIDs splits a chart=... param (comma-separated UUIDs) into a
 // validated, de-duplicated list. Pieces that don't resolve via mtgmatcher are
 // dropped silently, mirroring how single-UUID chart= used to be handled.
@@ -101,7 +133,7 @@ func parseChartIDs(chartParam string) (ids []string, truncated bool) {
 		if part == "" {
 			continue
 		}
-		if _, err := mtgmatcher.GetUUID(part); err != nil {
+		if !isValidChartID(part) {
 			continue
 		}
 		if slices.Contains(ids, part) {
@@ -254,7 +286,11 @@ func Search(w http.ResponseWriter, r *http.Request) {
 			// chart plots (not the raw chartParam), so a URL like
 			// ?chart=uuidA,%20uuidB doesn't leave card B off the results/remove
 			// controls just because fixupIDs won't trim the leading space.
-			query = strings.Join(chartIds, ",")
+			searchIDs := make([]string, len(chartIds))
+			for i, id := range chartIds {
+				searchIDs[i] = chartIDToSearchID(r.Context(), id)
+			}
+			query = strings.Join(searchIDs, ",")
 			pageVars.Title = strings.Replace(pageVars.Title, "Search", "Chart", 1)
 		}
 	} else {
@@ -708,13 +744,27 @@ func Search(w http.ResponseWriter, r *http.Request) {
 		pageVars.EditionSort = chartEditions.SealedEditionsSorted
 		pageVars.EditionList = chartEditions.SealedEditionsList
 
-		// Rebuild a display query from the (first) chart card
-		cfg := parseSearchOptionsNG(chartId, nil, nil, nil)
+		// Rebuild a display query from the (first) chart card. Use the resolved
+		// mtgmatcher id (a ban:<id> doesn't parse as a query), so SearchQuery is
+		// non-empty and the template renders the results+chart layout rather than
+		// the empty-query editions browse.
+		cfg := parseSearchOptionsNG(chartIDToSearchID(r.Context(), chartId), nil, nil, nil)
 		pageVars.SearchQuery = cfg.FullQuery
 
 		// Retrieve data
 		pageVars.ChartID = chartId
 		pageVars.IsMultiChart = isMultiChart
+
+		// The template keys card metadata off ChartID and the roster ids, but the
+		// results Metadata map is keyed by the resolved mtgmatcher id. Alias each
+		// ban:<id> roster entry to its resolved card so those lookups resolve.
+		for _, id := range chartIds {
+			if sid := chartIDToSearchID(r.Context(), id); sid != id {
+				if card, ok := pageVars.Metadata[sid]; ok {
+					pageVars.Metadata[id] = card
+				}
+			}
+		}
 
 		if PricesArchiveDB == nil {
 			pageVars.InfoMessage = "No chart data available"

--- a/search.go
+++ b/search.go
@@ -97,19 +97,38 @@ func isValidChartID(part string) bool {
 	return err == nil
 }
 
-// chartIDToSearchID maps a chart-roster id to a mtgmatcher search id so the
-// results table (which the embedded chart lives inside) resolves it: a ban:<id>
-// becomes its mtgjson uuid; anything else passes through.
+// chartIDToSearchID maps a chart-roster id to an id the results table (which the
+// embedded chart lives inside) can resolve to a card row, mirroring
+// resolveChartTarget's precedence so anything chartable also renders its row.
+// Magic resolves to an mtgjson uuid; non-Magic games (Lorcana, ...) to their
+// mtgmatcher-native id via the TCGplayer external id map.
 func chartIDToSearchID(ctx context.Context, id string) string {
 	if _, err := mtgmatcher.GetUUID(id); err == nil {
-		return id
+		return id // already a matcher id (bare uuid / variant string)
 	}
-	if prefix, val := splitIDPrefix(id); prefix == "ban" && PricesArchiveDB != nil {
+	prefix, val := splitIDPrefix(id)
+
+	// ban: or a bare integer — our ban_id first, matching the chart resolver.
+	if (prefix == "ban" || prefix == "") && PricesArchiveDB != nil {
 		if n, perr := strconv.ParseInt(val, 10, 64); perr == nil {
-			if vi, ok, _ := PricesArchiveDB.LookupVariant(ctx, n); ok && vi.MtgjsonUUID != "" {
-				return vi.MtgjsonUUID
+			if vi, ok, _ := PricesArchiveDB.LookupVariant(ctx, n); ok {
+				if vi.MtgjsonUUID != "" {
+					return vi.MtgjsonUUID // Magic: the mtgjson uuid
+				}
+				// Non-Magic: the product id maps back to the game's own card id.
+				if matched, merr := mtgmatcher.MatchId(strconv.Itoa(vi.TCGProductID)); merr == nil {
+					return matched
+				}
+				return id
 			}
+			// Not a ban_id: fall through to the external-id lookup below.
 		}
+	}
+
+	// tcg:, scryfall:, mtgjson:, or a bare id mtgmatcher maps through its external
+	// id table (a TCGplayer product id, a Scryfall id, or an mtgjson uuid).
+	if matched, merr := mtgmatcher.MatchId(val); merr == nil {
+		return matched
 	}
 	return id
 }

--- a/tcgcsv_ingest.go
+++ b/tcgcsv_ingest.go
@@ -12,6 +12,41 @@ import (
 	"github.com/mtgban/mtgban-website/timeseries"
 )
 
+// tcgLongForm dual-writes non-Magic price rows into the long prices table,
+// resolving each (category, product, sub-type) to a ban_id and emitting one
+// LongPrice per set price column (> 0, zeros omitted like the backfill). The
+// legacy tcgplayer_nonmagic_product_prices upsert stays the source of truth
+// during the dual-write window; a long-form failure is logged, not fatal.
+func tcgLongForm(ctx context.Context, rows []timeseries.TCGPriceRow) (int, error) {
+	longRows := make([]timeseries.LongPrice, 0, len(rows)*3)
+	for _, r := range rows {
+		banID, err := PricesArchiveDB.ResolveTCGBanID(ctx, timeseries.TCGVariant{
+			CategoryID: r.CategoryID, ProductID: r.ProductID, SubType: r.SubTypeName,
+		})
+		if err != nil {
+			log.Println("tcgcsv long-form: resolve ban_id:", err)
+			continue
+		}
+		for _, pc := range []struct {
+			p        *float64
+			provider int16
+		}{
+			{r.LowPrice, timeseries.ProviderTCGLow},
+			{r.MarketPrice, timeseries.ProviderTCGMarket},
+			{r.MidPrice, timeseries.ProviderTCGMid},
+			{r.HighPrice, timeseries.ProviderTCGHigh},
+			{r.DirectLowPrice, timeseries.ProviderTCGDirectLow},
+		} {
+			if pc.p != nil && *pc.p > 0 {
+				longRows = append(longRows, timeseries.LongPrice{
+					BanID: banID, Date: r.Date, Provider: pc.provider, Price: *pc.p,
+				})
+			}
+		}
+	}
+	return PricesArchiveDB.UpsertLongPrices(ctx, longRows, 0)
+}
+
 // priceToRow maps a tcgcsv price into a tcg_prices row. The pointer price
 // fields carry through unchanged so genuine nulls stay distinct from 0.
 func priceToRow(date string, categoryID int, p tcgcsv.Price) timeseries.TCGPriceRow {
@@ -179,6 +214,11 @@ func backfillTCGCSV(ctx context.Context, from, to time.Time, resume bool) error 
 		n, err := PricesArchiveDB.UpsertTCGPrices(ctx, rows, 0)
 		if err != nil {
 			return fmt.Errorf("tcgcsv backfill upsert %s: %w", dateStr, err)
+		}
+		if Config.TimeseriesConfig.LongFormWrites {
+			if _, lerr := tcgLongForm(ctx, rows); lerr != nil {
+				log.Printf("tcgcsv backfill long-form %s: %v", dateStr, lerr)
+			}
 		}
 		totalRows += n
 		daysWithData++
@@ -362,6 +402,11 @@ func ingestTCGCSVGame(ctx context.Context, client *tcgcsv.Client, categoryID int
 	n, err := PricesArchiveDB.UpsertTCGPrices(ctx, rows, 0)
 	if err != nil {
 		return 0, fmt.Errorf("upsert: %w", err)
+	}
+	if Config.TimeseriesConfig.LongFormWrites {
+		if _, lerr := tcgLongForm(ctx, rows); lerr != nil {
+			log.Printf("tcgcsv daily long-form category %d: %v", categoryID, lerr)
+		}
 	}
 	log.Printf("tcgcsv daily %s: category %d, %d rows (%d groups)", dateStr, categoryID, n, len(groups))
 	return n, nil

--- a/templates/mobile/search.html
+++ b/templates/mobile/search.html
@@ -234,7 +234,7 @@
                     {{range $card.Treatments}}<span class="m-badge treatment">{{.}}</span>{{end}}
                     {{if $card.Reserved}}<span class="m-badge rl">RL</span>{{end}}
                     <button class="m-fav-btn fav-btn" data-card-id="{{$cardId}}" onclick="event.stopPropagation(); toggleFavorite(this);" title="Add to favorites"><i data-lucide="star"></i></button>
-                    {{if not $.DisableChart}}<button class="m-chart-btn" onclick="event.stopPropagation(); showChartDrawer('{{$cardId}}', {{$card.Sealed}}, '{{$card.Name}}');" title="Price history"><i data-lucide="chart-line"></i></button>{{end}}
+                    {{if not $.DisableChart}}<button class="m-chart-btn" onclick="event.stopPropagation(); showChartDrawer('{{$card.ChartID}}', {{$card.Sealed}}, '{{$card.Name}}');" title="Price history"><i data-lucide="chart-line"></i></button>{{end}}
                     <button class="m-actions-btn" onclick="event.stopPropagation(); toggleActionsMenu(this);" title="More actions"><i data-lucide="more-vertical"></i></button>
                 </div>
             </div>
@@ -245,7 +245,7 @@
                     <i data-lucide="star"></i><span>Favorite</span>
                 </button>
                 {{if not $.DisableChart}}
-                    <button type="button" class="m-actions-item m-actions-chart" onclick="event.stopPropagation(); showChartDrawer('{{$cardId}}', {{$card.Sealed}}, '{{$card.Name}}'); closeActionsMenus();">
+                    <button type="button" class="m-actions-item m-actions-chart" onclick="event.stopPropagation(); showChartDrawer('{{$card.ChartID}}', {{$card.Sealed}}, '{{$card.Name}}'); closeActionsMenus();">
                         <i data-lucide="chart-line"></i><span>Price history</span>
                     </button>
                 {{end}}

--- a/templates/search.html
+++ b/templates/search.html
@@ -674,7 +674,9 @@
                                     var cardId = item.getAttribute('data-card-id');
                                     if (cardId === lastHoverId) return;
                                     lastHoverId = cardId;
-                                    var row = document.querySelector('.result-header[data-card-id="' + cardId + '"]');
+                                    // Legend entries carry the chart id (ban:<id> when long-form reads
+                                    // are on); match them to the row's data-chart-id, not data-card-id.
+                                    var row = document.querySelector('.result-header[data-chart-id="' + cardId + '"]');
                                     if (row && typeof row.onmouseover === 'function') row.onmouseover();
                                 });
                                 legendEl.addEventListener('mouseleave', function() { lastHoverId = null; });
@@ -967,6 +969,7 @@
                             <div class="result-header{{if eq $i 0}} result-first{{end}}"
                                  style="z-index: {{inc $i 100}}"
                                  data-card-id="{{$cardId}}"
+                                 data-chart-id="{{$card.ChartID}}"
                                  data-card-name="{{$card.Name}}"
                                  data-set-code="{{$card.SetCode}}"
                                  data-edition="{{$card.Edition}}"
@@ -1042,10 +1045,10 @@
                                     {{end}}
                                     {{if not $.DisableChart}}
                                         {{if eq $.ChartIDsCSV ""}}
-                                            <a href="?chart={{$cardId}}" title="See historical data">&#128200;</a>
-                                        {{else if slice_has $.ChartIDs $cardId}}
+                                            <a href="?chart={{$card.ChartID}}" title="See historical data">&#128200;</a>
+                                        {{else if slice_has $.ChartIDs $card.ChartID}}
                                             {{if or $.ModalMode (gt (len $.ChartIDs) 1)}}
-                                            <a class="chart-remove-link" data-card-id="{{$cardId}}" href="?chart={{csv_without $.ChartIDsCSV $cardId}}" title="Remove from this chart">&#128200;&#10134;</a>
+                                            <a class="chart-remove-link" data-card-id="{{$card.ChartID}}" href="?chart={{csv_without $.ChartIDsCSV $card.ChartID}}" title="Remove from this chart">&#128200;&#10134;</a>
                                             {{else}}
                                             {{/* Sole card on a non-modal chart page: a remove link would
                                                  point at ?chart= and dump the user on a blank landing, so
@@ -1053,7 +1056,7 @@
                                             <span class="emoji" title="The only card on this chart">&#128200;</span>
                                             {{end}}
                                         {{else}}
-                                            <a class="chart-add-link" data-card-id="{{$cardId}}" href="?chart={{$.ChartIDsCSV}},{{$cardId}}" title="Add to this chart">&#128200;&#10133;</a>
+                                            <a class="chart-add-link" data-card-id="{{$card.ChartID}}" href="?chart={{$.ChartIDsCSV}},{{$card.ChartID}}" title="Add to this chart">&#128200;&#10133;</a>
                                         {{end}}
                                     {{end}}
                                     {{/* Shown only when the screen is narrow enough that the sidebar

--- a/timeseries/compare_live_test.go
+++ b/timeseries/compare_live_test.go
@@ -1,0 +1,158 @@
+package timeseries
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestCompareReadPaths benchmarks the legacy wide-table reads against the new
+// long-table reads on the SAME real cards, against a live DB, and checks the
+// results agree. It is a diagnostic, not a pass/fail unit test: run it with -v to
+// read the timing/parity report.
+//
+//	TCGLIVE_HOST=... TCGLIVE_USER=... TCGLIVE_PASSWORD=... TCGLIVE_DBNAME=card_prices \
+//	TCGLIVE_SSLMODE=require go test ./timeseries/ -run TestCompareReadPaths -v
+//
+// TCGLow is legacy dataset index 2 / long provider id 3; both sides read that
+// metric so the comparison is apples-to-apples.
+const (
+	cmpDatasetIndex = 2              // TCGLow, legacy columnForDataset index
+	cmpProvider     = ProviderTCGLow // = 3
+	cmpLookback     = Lookback(90)
+)
+
+func TestCompareReadPaths(t *testing.T) {
+	ctx := context.Background()
+	c, err := NewClient(liveConfig(t))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer c.Close()
+
+	// Sample recent canonical (English, non-alt) Magic cards that have TCGLow data.
+	type card struct {
+		uuid             string
+		isFoil, isEtched bool
+	}
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT DISTINCT v.mtgjson_uuid, v.is_foil, v.is_etched
+		FROM prices p JOIN variants v ON v.ban_id = p.ban_id
+		WHERE p.provider = $1 AND p.date >= CURRENT_DATE - 7
+		  AND v.mtgjson_uuid IS NOT NULL AND v.language = '' AND v.is_alt = false
+		LIMIT 25`, cmpProvider)
+	if err != nil {
+		t.Fatalf("sample query: %v", err)
+	}
+	var cards []card
+	for rows.Next() {
+		var cd card
+		if err := rows.Scan(&cd.uuid, &cd.isFoil, &cd.isEtched); err != nil {
+			t.Fatal(err)
+		}
+		cards = append(cards, cd)
+	}
+	rows.Close()
+	if len(cards) == 0 {
+		t.Skip("no sample cards found")
+	}
+	t.Logf("sampled %d canonical cards for the single-card comparison", len(cards))
+
+	// --- single-card chart read: HGetAll (wide) vs HGetAllLong (long) ---
+	var oldDur, newDur time.Duration
+	var matches, compared int
+	for _, cd := range cards {
+		t0 := time.Now()
+		wide, err := c.HGetAll(ctx, cd.uuid, cd.isFoil, cd.isEtched, nil, cmpLookback)
+		oldDur += time.Since(t0)
+		if err != nil {
+			t.Fatalf("HGetAll: %v", err)
+		}
+		t1 := time.Now()
+		long, err := c.HGetAllLong(ctx, cd.uuid, cd.isFoil, cd.isEtched, cmpLookback)
+		newDur += time.Since(t1)
+		if err != nil {
+			t.Fatalf("HGetAllLong: %v", err)
+		}
+		// Parity on the TCGLow series: for each date the wide row has a TCGLow
+		// price, the long map should carry the same value under provider 3.
+		for date, wrow := range wide {
+			wp := wrow.PriceForDataset(cmpDatasetIndex)
+			if wp == nil {
+				continue
+			}
+			compared++
+			if lp, ok := long[date][cmpProvider]; ok && lp == *wp {
+				matches++
+			}
+		}
+	}
+	t.Logf("HGetAll   (wide, %d cards): total %v, avg %v/card",
+		len(cards), oldDur.Round(time.Millisecond), (oldDur / time.Duration(len(cards))).Round(time.Microsecond))
+	t.Logf("HGetAllLong (long, %d cards): total %v, avg %v/card",
+		len(cards), newDur.Round(time.Millisecond), (newDur / time.Duration(len(cards))).Round(time.Microsecond))
+	t.Logf("TCGLow series parity: %d/%d date-points match (differences are expected where the wide last-wins picked a non-canonical language/alt row)", matches, compared)
+
+	// --- earliest date ---
+	oldDur, newDur = 0, 0
+	for _, cd := range cards {
+		t0 := time.Now()
+		_, _ = c.GetEarliestDate(ctx, cd.uuid, cd.isFoil, cd.isEtched, cmpLookback)
+		oldDur += time.Since(t0)
+		t1 := time.Now()
+		_, _ = c.GetEarliestDateLong(ctx, cd.uuid, cd.isFoil, cd.isEtched, cmpLookback)
+		newDur += time.Since(t1)
+	}
+	t.Logf("GetEarliestDate     avg %v/card | GetEarliestDateLong avg %v/card",
+		(oldDur / time.Duration(len(cards))).Round(time.Microsecond),
+		(newDur / time.Duration(len(cards))).Round(time.Microsecond))
+
+	// --- aggregate buylist metrics over ~90 days (whole-provider scan) ---
+	since := time.Now().AddDate(0, 0, -90)
+	t0 := time.Now()
+	wideStats, err := c.GetAggregatePriceStats(ctx, cmpDatasetIndex, since)
+	oldAgg := time.Since(t0)
+	if err != nil {
+		t.Fatalf("GetAggregatePriceStats: %v", err)
+	}
+	t1 := time.Now()
+	longStats, err := c.GetAggregatePriceStatsLong(ctx, cmpProvider, since)
+	newAgg := time.Since(t1)
+	if err != nil {
+		t.Fatalf("GetAggregatePriceStatsLong: %v", err)
+	}
+	t.Logf("GetAggregatePriceStats     (wide): %v, %d cards", oldAgg.Round(time.Millisecond), len(wideStats))
+	t.Logf("GetAggregatePriceStatsLong (long): %v, %d cards", newAgg.Round(time.Millisecond), len(longStats))
+	// Spot-check parity on a few shared keys.
+	var aggChecked, aggMatch int
+	for k, ws := range wideStats {
+		ls, ok := longStats[k]
+		if !ok {
+			continue
+		}
+		aggChecked++
+		if ws.Max == ls.Max && ws.Min == ls.Min && ws.Count == ls.Count {
+			aggMatch++
+		}
+		if aggChecked >= 500 {
+			break
+		}
+	}
+	t.Logf("aggregate parity (first %d shared keys): %d match on max/min/count", aggChecked, aggMatch)
+
+	// --- movers over a 30-day window (two-date compare) ---
+	t0 = time.Now()
+	wideMovers, err := c.GetMovers(ctx, cmpDatasetIndex, 30, 1.0, 1.0)
+	oldMov := time.Since(t0)
+	if err != nil {
+		t.Fatalf("GetMovers: %v", err)
+	}
+	t1 = time.Now()
+	longMovers, err := c.GetMoversLong(ctx, cmpProvider, 30, 1.0, 1.0)
+	newMov := time.Since(t1)
+	if err != nil {
+		t.Fatalf("GetMoversLong: %v", err)
+	}
+	t.Logf("GetMovers     (wide): %v, %d rows", oldMov.Round(time.Millisecond), len(wideMovers))
+	t.Logf("GetMoversLong (long): %v, %d rows", newMov.Round(time.Millisecond), len(longMovers))
+}

--- a/timeseries/config.go
+++ b/timeseries/config.go
@@ -37,6 +37,10 @@ func (c SqlConfig) DSN() string {
 type Client struct {
 	db       *sql.DB
 	readOnly bool
+
+	// variants caches variant identity -> ban_id for the long-form (variants +
+	// prices) write path. Warm it once with WarmVariantCache; misses mint.
+	variants variantCache
 }
 
 // OpenDB opens a raw Postgres pool for the database described by the config,

--- a/timeseries/prices_long.go
+++ b/timeseries/prices_long.go
@@ -30,7 +30,7 @@ const longMaxBatch = pgMaxParams / longColsPerRow
 // HGetAllLong returns a single card's price history over the lookback window,
 // pivoted to date -> (provider -> price). The read identity (uuid, foil, etched)
 // is coarser than a ban_id, so a CTE resolves the canonical printing first:
-// preferring language='' AND is_alt=false, falling back to the smallest matching
+// preferring language=” AND is_alt=false, falling back to the smallest matching
 // ban_id (e.g. a Japanese-only promo). Deterministic, unlike the wide table's
 // last-wins over an unordered scan (plan 17.2).
 //
@@ -73,6 +73,38 @@ func (c *Client) HGetAllLong(ctx context.Context, uuid string, isFoil, isEtched 
 	return result, rows.Err()
 }
 
+// HGetAllByBanID returns one exact variant's price history over the lookback
+// window, pivoted to date -> (provider -> price). Unlike HGetAllLong it does no
+// canonical resolution: the caller already holds the precise ban_id (a ban: id,
+// or a resolved TCGplayer product), so it charts that printing exactly, including
+// a specific language/finish/alt or a non-Magic sub-type.
+func (c *Client) HGetAllByBanID(ctx context.Context, banID int64, lb Lookback) (map[string]ProviderPrices, error) {
+	result := make(map[string]ProviderPrices)
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT date, provider, price FROM prices
+		 WHERE ban_id=$1 AND date >= $2`, banID, lb.Since())
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var d time.Time
+		var provider int16
+		var price float64
+		if err := rows.Scan(&d, &provider, &price); err != nil {
+			return nil, err
+		}
+		day := d.Format("2006-01-02")
+		pp := result[day]
+		if pp == nil {
+			pp = ProviderPrices{}
+			result[day] = pp
+		}
+		pp[provider] = price
+	}
+	return result, rows.Err()
+}
+
 // GetEarliestDateLong returns the oldest on-record date for a card, bounded by
 // the lookback window, across every ban_id that shares (uuid, foil, etched) —
 // language/alt-agnostic, matching the wide table's MIN (plan 17.2).
@@ -86,6 +118,19 @@ func (c *Client) GetEarliestDateLong(ctx context.Context, uuid string, isFoil, i
 		  JOIN variants v ON v.ban_id = p.ban_id
 		 WHERE v.mtgjson_uuid=$1 AND v.is_foil=$2 AND v.is_etched=$3 AND p.date >= $4`,
 		uuid, isFoil, isEtched, boundary).Scan(&earliest)
+	if err != nil || !earliest.Valid || earliest.Time.IsZero() {
+		return boundary, err
+	}
+	return earliest.Time, nil
+}
+
+// GetEarliestDateByBanID returns the oldest on-record date for one exact variant,
+// bounded by the lookback window (the ban_id counterpart of GetEarliestDateLong).
+func (c *Client) GetEarliestDateByBanID(ctx context.Context, banID int64, lb Lookback) (time.Time, error) {
+	boundary := lb.Since()
+	var earliest sql.NullTime
+	err := c.db.QueryRowContext(ctx,
+		`SELECT MIN(date) FROM prices WHERE ban_id=$1 AND date >= $2`, banID, boundary).Scan(&earliest)
 	if err != nil || !earliest.Valid || earliest.Time.IsZero() {
 		return boundary, err
 	}

--- a/timeseries/prices_long.go
+++ b/timeseries/prices_long.go
@@ -1,0 +1,291 @@
+package timeseries
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// LongPrice is one row of the long prices table: a single provider's price for a
+// variant (ban_id) on a day. It replaces the wide, one-column-per-provider
+// PriceRow — each provider is its own row, so there is no COALESCE merge.
+type LongPrice struct {
+	BanID    int64
+	Date     string
+	Provider int16
+	Price    float64
+}
+
+// ProviderPrices maps a provider id to its price on one day. It is the pivoted
+// shape a single-card chart consumes: one map per date, indexed by provider.
+type ProviderPrices map[int16]float64
+
+const longColsPerRow = 4
+
+// longMaxBatch keeps a bulk upsert under Postgres's bind-parameter cap.
+const longMaxBatch = pgMaxParams / longColsPerRow
+
+// resolveCanonicalBanID maps a (uuid, foil, etched) — the read identity the chart
+// keys on, coarser than a ban_id — to a single ban_id. It prefers the canonical
+// printing (language=” AND is_alt=false); if none exists (e.g. a Japanese-only
+// promo) it falls back to the smallest matching ban_id. Deterministic, unlike the
+// wide table's last-wins over an unordered scan (plan 17.2). Returns ok=false
+// when the card has no variant at all.
+func (c *Client) resolveCanonicalBanID(ctx context.Context, uuid string, isFoil, isEtched bool) (int64, bool, error) {
+	uuid = NormalizeUUID(uuid)
+	var banID int64
+	err := c.db.QueryRowContext(ctx, `
+		SELECT ban_id FROM variants
+		 WHERE mtgjson_uuid=$1 AND is_foil=$2 AND is_etched=$3
+		 ORDER BY (language='' AND is_alt=false) DESC, ban_id ASC
+		 LIMIT 1`, uuid, isFoil, isEtched).Scan(&banID)
+	if err == sql.ErrNoRows {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, err
+	}
+	return banID, true, nil
+}
+
+// HGetAllLong returns a single card's price history over the lookback window,
+// pivoted to date -> (provider -> price). It resolves the canonical ban_id for
+// (uuid, foil, etched) and returns that variant's series. The long-form
+// replacement for HGetAll; the caller projects the provider it wants per dataset.
+func (c *Client) HGetAllLong(ctx context.Context, uuid string, isFoil, isEtched bool, lb Lookback) (map[string]ProviderPrices, error) {
+	banID, ok, err := c.resolveCanonicalBanID(ctx, uuid, isFoil, isEtched)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]ProviderPrices)
+	if !ok {
+		return result, nil
+	}
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT date, provider, price FROM prices
+		 WHERE ban_id=$1 AND date >= $2`, banID, lb.Since())
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var d time.Time
+		var provider int16
+		var price float64
+		if err := rows.Scan(&d, &provider, &price); err != nil {
+			return nil, err
+		}
+		day := d.Format("2006-01-02")
+		pp := result[day]
+		if pp == nil {
+			pp = ProviderPrices{}
+			result[day] = pp
+		}
+		pp[provider] = price
+	}
+	return result, rows.Err()
+}
+
+// GetEarliestDateLong returns the oldest on-record date for a card, bounded by
+// the lookback window, across every ban_id that shares (uuid, foil, etched) —
+// language/alt-agnostic, matching the wide table's MIN (plan 17.2).
+func (c *Client) GetEarliestDateLong(ctx context.Context, uuid string, isFoil, isEtched bool, lb Lookback) (time.Time, error) {
+	uuid = NormalizeUUID(uuid)
+	boundary := lb.Since()
+	var earliest sql.NullTime
+	err := c.db.QueryRowContext(ctx, `
+		SELECT MIN(p.date)
+		  FROM prices p
+		  JOIN variants v ON v.ban_id = p.ban_id
+		 WHERE v.mtgjson_uuid=$1 AND v.is_foil=$2 AND v.is_etched=$3 AND p.date >= $4`,
+		uuid, isFoil, isEtched, boundary).Scan(&earliest)
+	if err != nil || !earliest.Valid || earliest.Time.IsZero() {
+		return boundary, err
+	}
+	return earliest.Time, nil
+}
+
+// GetAggregatePriceStatsLong returns per-card max/min/p90/count of one provider
+// over rows with date >= since, keyed by (uuid, foil, etched) so callers do O(1)
+// lookups while iterating a buylist/inventory. Scoped to Magic variants
+// (mtgjson_uuid IS NOT NULL) so a shared provider (3/4) doesn't pull other games'
+// rows (plan 17.3). price > 0 is redundant with the zero-omitting backfill but
+// kept defensive.
+func (c *Client) GetAggregatePriceStatsLong(ctx context.Context, provider int16, since time.Time) (map[AggregatePriceKey]AggregatePriceStats, error) {
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT v.mtgjson_uuid, v.is_foil, v.is_etched,
+		       MAX(p.price)                                          AS max_price,
+		       MIN(p.price)                                          AS min_price,
+		       percentile_disc(0.9) WITHIN GROUP (ORDER BY p.price)  AS p90_price,
+		       COUNT(*)                                              AS sample_count
+		  FROM prices p
+		  JOIN variants v ON v.ban_id = p.ban_id
+		 WHERE p.provider = $1 AND p.date >= $2 AND p.price > 0
+		   AND v.mtgjson_uuid IS NOT NULL
+		 GROUP BY v.mtgjson_uuid, v.is_foil, v.is_etched`, provider, since)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make(map[AggregatePriceKey]AggregatePriceStats)
+	for rows.Next() {
+		var key AggregatePriceKey
+		var stats AggregatePriceStats
+		if err := rows.Scan(&key.MtgjsonUUID, &key.IsFoil, &key.IsEtched,
+			&stats.Max, &stats.Min, &stats.P90, &stats.Count); err != nil {
+			return nil, err
+		}
+		result[key] = stats
+	}
+	return result, rows.Err()
+}
+
+// GetMoversLong returns the largest per-card price moves for one provider over a
+// window. Anchored to the provider's own latest date (a lagging metric has no
+// data on the global latest). Restricted to canonical English variants
+// (language=”), so each (uuid, foil, etched, is_alt) is a single ban_id and cur
+// vs prior compare the same printing (plan 17.2).
+func (c *Client) GetMoversLong(ctx context.Context, provider int16, windowDays int, minPrice, minPriorPrice float64) ([]MoverRow, error) {
+	var latest sql.NullTime
+	if err := c.db.QueryRowContext(ctx,
+		`SELECT max(date) FROM prices WHERE provider=$1`, provider).Scan(&latest); err != nil {
+		return nil, err
+	}
+	if !latest.Valid {
+		return nil, nil
+	}
+	target := latest.Time.AddDate(0, 0, -windowDays)
+
+	var prior sql.NullTime
+	if err := c.db.QueryRowContext(ctx,
+		`SELECT max(date) FROM prices WHERE provider=$1 AND date <= $2`, provider, target).Scan(&prior); err != nil {
+		return nil, err
+	}
+	if !prior.Valid {
+		return nil, nil
+	}
+
+	q := `
+		WITH cur AS (
+			SELECT ban_id, price FROM prices
+			 WHERE provider=$1 AND date=$2 AND price >= $4
+		),
+		old AS (
+			SELECT ban_id, price FROM prices
+			 WHERE provider=$1 AND date=$3 AND price >= $5
+		)
+		SELECT v.mtgjson_uuid, v.is_foil, v.is_etched, cur.price, old.price
+		  FROM cur JOIN old USING (ban_id)
+		  JOIN variants v ON v.ban_id = cur.ban_id
+		 WHERE v.mtgjson_uuid IS NOT NULL AND v.language=''`
+	rows, err := c.db.QueryContext(ctx, q, provider, latest.Time, prior.Time, minPrice, minPriorPrice)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []MoverRow
+	for rows.Next() {
+		var m MoverRow
+		if err := rows.Scan(&m.MtgjsonUUID, &m.IsFoil, &m.IsEtched, &m.Current, &m.Prior); err != nil {
+			return nil, err
+		}
+		result = append(result, m)
+	}
+	return result, rows.Err()
+}
+
+// dedupeLongPrices collapses rows sharing (ban_id, date, provider) to their last
+// occurrence — one INSERT ... ON CONFLICT DO UPDATE errors if a key appears twice
+// (mirrors dedupeTCGPriceRows).
+func dedupeLongPrices(rows []LongPrice) []LongPrice {
+	type key struct {
+		banID    int64
+		date     string
+		provider int16
+	}
+	seen := make(map[key]int, len(rows))
+	out := make([]LongPrice, 0, len(rows))
+	for _, r := range rows {
+		k := key{r.BanID, r.Date, r.Provider}
+		if idx, ok := seen[k]; ok {
+			out[idx] = r
+			continue
+		}
+		seen[k] = len(out)
+		out = append(out, r)
+	}
+	return out
+}
+
+// UpsertLongPrices inserts/overwrites long price rows in one transaction,
+// batched under the parameter cap. Each provider is its own row, so this is a
+// plain per-row overwrite — no COALESCE merge. No-op on a read-only client.
+func (c *Client) UpsertLongPrices(ctx context.Context, rows []LongPrice, batchSize int) (int, error) {
+	if c.readOnly || len(rows) == 0 {
+		return 0, nil
+	}
+	rows = dedupeLongPrices(rows)
+
+	tx, err := c.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback() // no-op after Commit
+
+	var total int
+	for _, b := range batchBounds(len(rows), batchSize, longMaxBatch) {
+		q, args := buildLongUpsertQuery(rows[b[0]:b[1]])
+		res, err := tx.ExecContext(ctx, q, args...)
+		if err != nil {
+			return 0, fmt.Errorf("batch starting at row %d: %w", b[0], err)
+		}
+		n, _ := res.RowsAffected()
+		total += int(n)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return total, nil
+}
+
+func buildLongUpsertQuery(batch []LongPrice) (string, []any) {
+	valueClauses := make([]string, 0, len(batch))
+	args := make([]any, 0, len(batch)*longColsPerRow)
+	for i := range batch {
+		offset := i * longColsPerRow
+		valueClauses = append(valueClauses, fmt.Sprintf("($%d,$%d,$%d,$%d)",
+			offset+1, offset+2, offset+3, offset+4))
+		r := batch[i]
+		args = append(args, r.BanID, r.Date, r.Provider, r.Price)
+	}
+	q := `INSERT INTO prices (ban_id, date, provider, price) VALUES ` +
+		strings.Join(valueClauses, ",") +
+		` ON CONFLICT (ban_id, date, provider) DO UPDATE SET price = EXCLUDED.price`
+	return q, args
+}
+
+// EnsurePricePartition creates the monthly range partition of prices covering
+// the given day if it does not already exist, behind the DDL advisory lock so
+// concurrent creators serialize. Call it at startup and from the daily cron so a
+// write never races ahead of an existing partition (plan section 13). Idempotent;
+// no-op on a read-only client.
+func (c *Client) EnsurePricePartition(ctx context.Context, day time.Time) error {
+	if c.readOnly {
+		return nil
+	}
+	start := time.Date(day.Year(), day.Month(), 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 1, 0)
+	name := fmt.Sprintf("prices_%04d_%02d", start.Year(), start.Month())
+	// name/bounds derive from a calendar month, safe to interpolate.
+	q := fmt.Sprintf(
+		`CREATE TABLE IF NOT EXISTS %s PARTITION OF prices FOR VALUES FROM ('%s') TO ('%s')`,
+		name, start.Format("2006-01-02"), end.Format("2006-01-02"))
+	if err := c.execTCGDDL(ctx, q); err != nil {
+		return fmt.Errorf("timeseries: ensure price partition %s: %w", name, err)
+	}
+	return nil
+}

--- a/timeseries/prices_long.go
+++ b/timeseries/prices_long.go
@@ -27,45 +27,30 @@ const longColsPerRow = 4
 // longMaxBatch keeps a bulk upsert under Postgres's bind-parameter cap.
 const longMaxBatch = pgMaxParams / longColsPerRow
 
-// resolveCanonicalBanID maps a (uuid, foil, etched) — the read identity the chart
-// keys on, coarser than a ban_id — to a single ban_id. It prefers the canonical
-// printing (language=” AND is_alt=false); if none exists (e.g. a Japanese-only
-// promo) it falls back to the smallest matching ban_id. Deterministic, unlike the
-// wide table's last-wins over an unordered scan (plan 17.2). Returns ok=false
-// when the card has no variant at all.
-func (c *Client) resolveCanonicalBanID(ctx context.Context, uuid string, isFoil, isEtched bool) (int64, bool, error) {
-	uuid = NormalizeUUID(uuid)
-	var banID int64
-	err := c.db.QueryRowContext(ctx, `
-		SELECT ban_id FROM variants
-		 WHERE mtgjson_uuid=$1 AND is_foil=$2 AND is_etched=$3
-		 ORDER BY (language='' AND is_alt=false) DESC, ban_id ASC
-		 LIMIT 1`, uuid, isFoil, isEtched).Scan(&banID)
-	if err == sql.ErrNoRows {
-		return 0, false, nil
-	}
-	if err != nil {
-		return 0, false, err
-	}
-	return banID, true, nil
-}
-
 // HGetAllLong returns a single card's price history over the lookback window,
-// pivoted to date -> (provider -> price). It resolves the canonical ban_id for
-// (uuid, foil, etched) and returns that variant's series. The long-form
-// replacement for HGetAll; the caller projects the provider it wants per dataset.
+// pivoted to date -> (provider -> price). The read identity (uuid, foil, etched)
+// is coarser than a ban_id, so a CTE resolves the canonical printing first:
+// preferring language='' AND is_alt=false, falling back to the smallest matching
+// ban_id (e.g. a Japanese-only promo). Deterministic, unlike the wide table's
+// last-wins over an unordered scan (plan 17.2).
+//
+// Resolution and fetch are one statement (a scalar subquery over the CTE), so the
+// common chart read stays a single round-trip; splitting it doubled latency
+// against a remote DB. An unresolved card yields NULL, which matches no prices
+// and returns an empty map.
 func (c *Client) HGetAllLong(ctx context.Context, uuid string, isFoil, isEtched bool, lb Lookback) (map[string]ProviderPrices, error) {
-	banID, ok, err := c.resolveCanonicalBanID(ctx, uuid, isFoil, isEtched)
-	if err != nil {
-		return nil, err
-	}
+	uuid = NormalizeUUID(uuid)
 	result := make(map[string]ProviderPrices)
-	if !ok {
-		return result, nil
-	}
 	rows, err := c.db.QueryContext(ctx, `
+		WITH canon AS (
+			SELECT ban_id FROM variants
+			 WHERE mtgjson_uuid=$1 AND is_foil=$2 AND is_etched=$3
+			 ORDER BY (language='' AND is_alt=false) DESC, ban_id ASC
+			 LIMIT 1
+		)
 		SELECT date, provider, price FROM prices
-		 WHERE ban_id=$1 AND date >= $2`, banID, lb.Since())
+		 WHERE ban_id = (SELECT ban_id FROM canon) AND date >= $4`,
+		uuid, isFoil, isEtched, lb.Since())
 	if err != nil {
 		return nil, err
 	}

--- a/timeseries/prices_long_live_test.go
+++ b/timeseries/prices_long_live_test.go
@@ -1,0 +1,167 @@
+package timeseries
+
+import (
+	"context"
+	"testing"
+)
+
+// TestLongFormLive exercises the long-form (variants + prices) code end to end
+// against a real Postgres: ban_id minting + caching, the long upsert, and the
+// four read paths (HGetAllLong canonical resolution, GetEarliestDateLong,
+// GetAggregatePriceStatsLong, GetMoversLong).
+//
+// Like TestTCGPricesLive it is skipped unless TCGLIVE_HOST is set, and it only
+// touches sentinel identities (a fake uuid, a sentinel category, and sentinel
+// provider id 999) that never collide with real data, deleting them on
+// completion. Using provider 999 keeps the per-provider aggregate/mover scans
+// isolated to this test's rows, so they stay fast against the full table.
+const (
+	liveSentinelUUID     = "ffffffff-0000-0000-0000-000000000001"
+	liveSentinelUUIDAlt  = "ffffffff-0000-0000-0000-000000000002"
+	liveSentinelCatLong  = 999002
+	liveSentinelProdLong = 888111
+	liveSentinelProvider = int16(999)
+)
+
+func TestLongFormLive(t *testing.T) {
+	ctx := context.Background()
+	c, err := NewClient(liveConfig(t))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	clear := func() {
+		// prices first (FK -> providers, variants), then variants, then provider.
+		_, _ = c.db.ExecContext(ctx, `DELETE FROM prices WHERE provider=$1`, liveSentinelProvider)
+		_, _ = c.db.ExecContext(ctx, `DELETE FROM variants WHERE mtgjson_uuid IN ($1,$2) OR tcgp_category_id=$3`,
+			liveSentinelUUID, liveSentinelUUIDAlt, liveSentinelCatLong)
+		_, _ = c.db.ExecContext(ctx, `DELETE FROM providers WHERE id=$1`, liveSentinelProvider)
+	}
+	clear() // start clean (removes any leftover sentinel rows from a prior run)
+	t.Cleanup(clear)
+
+	// Sentinel provider so per-provider scans only see this test's rows. Inserted
+	// AFTER the initial clear so it survives into the test body.
+	if _, err := c.db.ExecContext(ctx, `
+		INSERT INTO providers (id, shorthand, public_name, kind, currency)
+		VALUES ($1,'SENTINEL','Sentinel','retail','USD')
+		ON CONFLICT (id) DO NOTHING`, liveSentinelProvider); err != nil {
+		t.Fatalf("insert sentinel provider: %v", err)
+	}
+
+	// --- mint + cache idempotence ---
+	base := MagicVariant{MtgjsonUUID: liveSentinelUUID} // lang="", alt=false (canonical)
+	banBase, err := c.ResolveMagicBanID(ctx, base)
+	if err != nil {
+		t.Fatalf("ResolveMagicBanID: %v", err)
+	}
+	again, err := c.ResolveMagicBanID(ctx, base)
+	if err != nil || again != banBase {
+		t.Fatalf("resolve not idempotent: %d vs %d err=%v", banBase, again, err)
+	}
+	// A fresh client (cold cache) must resolve the same row via ON CONFLICT.
+	c2, err := NewClient(liveConfig(t))
+	if err != nil {
+		t.Fatalf("NewClient 2: %v", err)
+	}
+	defer c2.Close()
+	if cold, err := c2.ResolveMagicBanID(ctx, base); err != nil || cold != banBase {
+		t.Fatalf("cold resolve = %d, want %d (err=%v)", cold, banBase, err)
+	}
+
+	// A non-canonical sibling (Japanese) of the same (uuid, foil, etched).
+	banJa, err := c.ResolveMagicBanID(ctx, MagicVariant{MtgjsonUUID: liveSentinelUUIDAlt, Language: "Japanese"})
+	if err != nil {
+		t.Fatalf("ResolveMagicBanID ja: %v", err)
+	}
+	// Give the sibling the SAME uuid so canonical resolution has to choose. We
+	// can't via ResolveMagicBanID (different uuid), so insert a same-uuid ja row.
+	var banBaseJa int64
+	if err := c.db.QueryRowContext(ctx, `
+		INSERT INTO variants (mtgjson_uuid, language) VALUES ($1,'Japanese') RETURNING ban_id`,
+		liveSentinelUUID).Scan(&banBaseJa); err != nil {
+		t.Fatalf("insert same-uuid ja variant: %v", err)
+	}
+
+	// --- upsert + overwrite in place ---
+	rows := []LongPrice{
+		{BanID: banBase, Date: "2024-02-08", Provider: liveSentinelProvider, Price: 5.00},
+		{BanID: banBase, Date: "2024-02-20", Provider: liveSentinelProvider, Price: 7.00},
+		{BanID: banBaseJa, Date: "2024-02-20", Provider: liveSentinelProvider, Price: 99.00}, // canonical must ignore
+	}
+	if _, err := c.UpsertLongPrices(ctx, rows, 0); err != nil {
+		t.Fatalf("UpsertLongPrices: %v", err)
+	}
+	// Overwrite the 2024-02-20 base price; count must not grow.
+	rows[1].Price = 8.00
+	if _, err := c.UpsertLongPrices(ctx, []LongPrice{rows[1]}, 0); err != nil {
+		t.Fatalf("re-upsert: %v", err)
+	}
+
+	// --- HGetAllLong: canonical (lang='') series only ---
+	hist, err := c.HGetAllLong(ctx, liveSentinelUUID, false, false, Lookback(3650))
+	if err != nil {
+		t.Fatalf("HGetAllLong: %v", err)
+	}
+	if got := hist["2024-02-20"][liveSentinelProvider]; got != 8.00 {
+		t.Errorf("HGetAllLong 2024-02-20 = %v, want 8.00 (overwrite + canonical, not the 99.00 ja row)", got)
+	}
+	if got := hist["2024-02-08"][liveSentinelProvider]; got != 5.00 {
+		t.Errorf("HGetAllLong 2024-02-08 = %v, want 5.00", got)
+	}
+
+	// --- GetEarliestDateLong: MIN across all matching ban_ids ---
+	earliest, err := c.GetEarliestDateLong(ctx, liveSentinelUUID, false, false, Lookback(3650))
+	if err != nil {
+		t.Fatalf("GetEarliestDateLong: %v", err)
+	}
+	if got := earliest.Format("2006-01-02"); got != "2024-02-08" {
+		t.Errorf("earliest = %s, want 2024-02-08", got)
+	}
+
+	// --- GetAggregatePriceStatsLong: isolated to sentinel provider ---
+	sinceAll := Lookback(3650).Since()
+	stats, err := c.GetAggregatePriceStatsLong(ctx, liveSentinelProvider, sinceAll)
+	if err != nil {
+		t.Fatalf("GetAggregatePriceStatsLong: %v", err)
+	}
+	s, ok := stats[AggregatePriceKey{MtgjsonUUID: liveSentinelUUID}]
+	if !ok {
+		t.Fatalf("no aggregate stats for sentinel; got %d keys", len(stats))
+	}
+	// Grouped by (uuid, foil, etched) ACROSS language (matching the legacy
+	// GetAggregatePriceStats), so the same-uuid Japanese row (99.00) is included
+	// alongside the base 5.00 and 8.00: max 99, min 5, count 3.
+	if s.Max != 99.00 || s.Min != 5.00 || s.Count != 3 {
+		t.Errorf("stats = %+v, want max 99 min 5 count 3", s)
+	}
+
+	// --- GetMoversLong: 2024-02-08 -> 2024-02-20 for the sentinel ---
+	movers, err := c.GetMoversLong(ctx, liveSentinelProvider, 7, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMoversLong: %v", err)
+	}
+	var found bool
+	for _, m := range movers {
+		if m.MtgjsonUUID == liveSentinelUUID {
+			found = true
+			if m.Current != 8.00 || m.Prior != 5.00 {
+				t.Errorf("mover = %+v, want current 8 prior 5", m)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("sentinel not in movers: %+v", movers)
+	}
+
+	// --- non-Magic ban_id minting ---
+	tcgBan, err := c.ResolveTCGBanID(ctx, TCGVariant{CategoryID: liveSentinelCatLong, ProductID: liveSentinelProdLong, SubType: "Normal"})
+	if err != nil {
+		t.Fatalf("ResolveTCGBanID: %v", err)
+	}
+	if tcgBan2, err := c.ResolveTCGBanID(ctx, TCGVariant{CategoryID: liveSentinelCatLong, ProductID: liveSentinelProdLong, SubType: "Normal"}); err != nil || tcgBan2 != tcgBan {
+		t.Fatalf("tcg resolve not idempotent: %d vs %d err=%v", tcgBan, tcgBan2, err)
+	}
+	_ = banJa
+}

--- a/timeseries/prices_long_test.go
+++ b/timeseries/prices_long_test.go
@@ -1,0 +1,47 @@
+package timeseries
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDedupeLongPrices(t *testing.T) {
+	rows := []LongPrice{
+		{BanID: 1, Date: "2024-02-08", Provider: ProviderTCGLow, Price: 1.00},
+		{BanID: 1, Date: "2024-02-08", Provider: ProviderTCGMarket, Price: 2.00},
+		{BanID: 1, Date: "2024-02-08", Provider: ProviderTCGLow, Price: 1.50}, // dup key, later wins
+		{BanID: 2, Date: "2024-02-08", Provider: ProviderTCGLow, Price: 9.00},
+	}
+	out := dedupeLongPrices(rows)
+	if len(out) != 3 {
+		t.Fatalf("dedupe len = %d, want 3: %+v", len(out), out)
+	}
+	// The (1, 2024-02-08, TCGLow) entry keeps its first slot but the later price.
+	if out[0].BanID != 1 || out[0].Provider != ProviderTCGLow || out[0].Price != 1.50 {
+		t.Errorf("first row = %+v, want ban 1 TCGLow price 1.50 (last wins)", out[0])
+	}
+	if out[1].Provider != ProviderTCGMarket || out[2].BanID != 2 {
+		t.Errorf("ordering not preserved: %+v", out)
+	}
+}
+
+func TestBuildLongUpsertQuery(t *testing.T) {
+	batch := []LongPrice{
+		{BanID: 10, Date: "2024-02-08", Provider: ProviderCKRetail, Price: 3.00},
+		{BanID: 11, Date: "2024-02-08", Provider: ProviderCKBuylist, Price: 1.00},
+	}
+	q, args := buildLongUpsertQuery(batch)
+	if len(args) != len(batch)*longColsPerRow {
+		t.Fatalf("args len = %d, want %d", len(args), len(batch)*longColsPerRow)
+	}
+	if !strings.Contains(q, "ON CONFLICT (ban_id, date, provider) DO UPDATE SET price = EXCLUDED.price") {
+		t.Errorf("missing conflict clause: %s", q)
+	}
+	if !strings.Contains(q, "($1,$2,$3,$4)") || !strings.Contains(q, "($5,$6,$7,$8)") {
+		t.Errorf("placeholder layout wrong: %s", q)
+	}
+	// args are laid out ban_id, date, provider, price per row.
+	if args[0] != int64(10) || args[3] != 3.00 || args[4] != int64(11) {
+		t.Errorf("args order wrong: %+v", args[:5])
+	}
+}

--- a/timeseries/tcg_products.go
+++ b/timeseries/tcg_products.go
@@ -2,6 +2,7 @@ package timeseries
 
 import (
 	"context"
+	"database/sql"
 	_ "embed"
 	"fmt"
 	"strings"
@@ -33,6 +34,27 @@ const (
 const tcgProductColumns = `
 	product_id, category_id, group_id, name, clean_name,
 	number, rarity, image_url, url, modified_on`
+
+// GetTCGProduct returns the catalog metadata for a TCGplayer product id (name,
+// image, url for non-Magic chart display), ok=false if it is not in the catalog.
+// Nullable text columns coalesce to "".
+func (c *Client) GetTCGProduct(ctx context.Context, productID int) (TCGProduct, bool, error) {
+	var p TCGProduct
+	err := c.db.QueryRowContext(ctx, `
+		SELECT product_id, category_id, group_id, name,
+		       coalesce(clean_name,''), coalesce(number,''), coalesce(rarity,''),
+		       coalesce(image_url,''), coalesce(url,''), coalesce(modified_on,'')
+		FROM tcg_products WHERE product_id=$1`, productID).Scan(
+		&p.ProductID, &p.CategoryID, &p.GroupID, &p.Name,
+		&p.CleanName, &p.Number, &p.Rarity, &p.ImageURL, &p.URL, &p.ModifiedOn)
+	if err == sql.ErrNoRows {
+		return TCGProduct{}, false, nil
+	}
+	if err != nil {
+		return TCGProduct{}, false, err
+	}
+	return p, true, nil
+}
 
 // EnsureTCGProductsSchema creates the tcg_products table and its index if
 // missing. Idempotent; a no-op on a read-only client.

--- a/timeseries/variants.go
+++ b/timeseries/variants.go
@@ -138,6 +138,95 @@ func (c *Client) ResolveMagicBanID(ctx context.Context, v MagicVariant) (int64, 
 	return banID, nil
 }
 
+// VariantInfo is a variants row resolved by ban_id: either a Magic printing
+// (MtgjsonUUID set) or a non-Magic TCGplayer product (TCGProductID set). It is
+// the bridge from a ban_id back to a chartable/displayable identity.
+type VariantInfo struct {
+	BanID         int64
+	MtgjsonUUID   string // "" for non-Magic
+	IsFoil        bool
+	IsEtched      bool
+	IsAlt         bool
+	Language      string
+	TCGCategoryID int    // 0 for Magic
+	TCGProductID  int    // 0 for Magic
+	TCGSubType    string // "" for Magic
+}
+
+// IsMagic reports whether the variant is a Magic printing (has an mtgjson uuid).
+func (v VariantInfo) IsMagic() bool { return v.MtgjsonUUID != "" }
+
+// LookupVariant returns the identity for a ban_id, ok=false if no such variant.
+// Used to chart/display a ban: id and to route Magic vs non-Magic handling.
+func (c *Client) LookupVariant(ctx context.Context, banID int64) (VariantInfo, bool, error) {
+	v := VariantInfo{BanID: banID}
+	var uuid, subType sql.NullString
+	var catID, prodID sql.NullInt64
+	err := c.db.QueryRowContext(ctx, `
+		SELECT mtgjson_uuid, is_foil, is_etched, is_alt, language,
+		       tcgp_category_id, tcgp_product_id, tcgp_sub_type
+		FROM variants WHERE ban_id=$1`, banID).Scan(
+		&uuid, &v.IsFoil, &v.IsEtched, &v.IsAlt, &v.Language,
+		&catID, &prodID, &subType)
+	if err == sql.ErrNoRows {
+		return VariantInfo{}, false, nil
+	}
+	if err != nil {
+		return VariantInfo{}, false, err
+	}
+	v.MtgjsonUUID = uuid.String
+	v.TCGCategoryID = int(catID.Int64)
+	v.TCGProductID = int(prodID.Int64)
+	v.TCGSubType = subType.String
+	return v, true, nil
+}
+
+// LookupMagicBanIDByUUID resolves a bare mtgjson uuid to the canonical Magic
+// ban_id (preferring the base printing: language empty, non-foil, non-etched,
+// non-alt; else the smallest match). It lets a uuid that is in our price history
+// but retired from the current mtgmatcher datastore still chart. ok=false if the
+// uuid has no variant.
+func (c *Client) LookupMagicBanIDByUUID(ctx context.Context, uuid string) (int64, bool, error) {
+	uuid = NormalizeUUID(uuid)
+	var banID int64
+	err := c.db.QueryRowContext(ctx, `
+		SELECT ban_id FROM variants
+		 WHERE mtgjson_uuid=$1
+		 ORDER BY (language='' AND is_alt=false AND is_foil=false AND is_etched=false) DESC, ban_id ASC
+		 LIMIT 1`, uuid).Scan(&banID)
+	if err == sql.ErrNoRows {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, err
+	}
+	return banID, true, nil
+}
+
+// LookupTCGBanID resolves a bare TCGplayer product id to a canonical non-Magic
+// variant, preferring sub-type "Normal" (the base printing) and otherwise the
+// smallest ban_id. ok=false when the product has no ingested variant. For a
+// precise sub-type, chart the ban: id directly instead.
+func (c *Client) LookupTCGBanID(ctx context.Context, productID int) (VariantInfo, bool, error) {
+	v := VariantInfo{TCGProductID: productID}
+	var catID sql.NullInt64
+	var subType sql.NullString
+	err := c.db.QueryRowContext(ctx, `
+		SELECT ban_id, tcgp_category_id, tcgp_sub_type FROM variants
+		 WHERE tcgp_product_id=$1
+		 ORDER BY (tcgp_sub_type='Normal') DESC, ban_id ASC LIMIT 1`, productID).Scan(
+		&v.BanID, &catID, &subType)
+	if err == sql.ErrNoRows {
+		return VariantInfo{}, false, nil
+	}
+	if err != nil {
+		return VariantInfo{}, false, err
+	}
+	v.TCGCategoryID = int(catID.Int64)
+	v.TCGSubType = subType.String
+	return v, true, nil
+}
+
 // ResolveTCGBanID returns the ban_id for a non-Magic variant, minting it if new.
 func (c *Client) ResolveTCGBanID(ctx context.Context, v TCGVariant) (int64, error) {
 	if id, ok := c.variants.tcg.Load(v); ok {

--- a/timeseries/variants.go
+++ b/timeseries/variants.go
@@ -59,6 +59,12 @@ type TCGVariant struct {
 type variantCache struct {
 	magic sync.Map // MagicVariant -> int64
 	tcg   sync.Map // TCGVariant   -> int64
+	// tcgByProduct maps a TCGplayer product id to its canonical ban_id (the
+	// "Normal" sub-type, else the smallest ban_id), so a rendered non-Magic card
+	// resolves its ban_id from memory by product id alone — the read-path analogue
+	// of magic's uuid-keyed lookup, with no per-card DB round-trip. Mirrors
+	// LookupTCGBanID's precedence.
+	tcgByProduct sync.Map // int (product id) -> int64
 }
 
 // WarmVariantCache bulk-loads every existing variant into the in-memory cache in
@@ -73,6 +79,15 @@ func (c *Client) WarmVariantCache(ctx context.Context) error {
 		return err
 	}
 	defer rows.Close()
+
+	// Best canonical ban_id per product id, resolved after the scan since rows
+	// arrive unordered: prefer the "Normal" sub-type, else the smallest ban_id
+	// (matching LookupTCGBanID's ORDER BY).
+	type tcgBest struct {
+		banID  int64
+		normal bool
+	}
+	byProduct := map[int]tcgBest{}
 
 	var loadedMagic, loadedTCG int
 	for rows.Next() {
@@ -98,9 +113,36 @@ func (c *Client) WarmVariantCache(ctx context.Context) error {
 				SubType: subType.String,
 			}, banID)
 			loadedTCG++
+
+			pid := int(prodID.Int64)
+			isNormal := subType.String == "Normal"
+			if cur, ok := byProduct[pid]; !ok ||
+				(isNormal && !cur.normal) ||
+				(isNormal == cur.normal && banID < cur.banID) {
+				byProduct[pid] = tcgBest{banID: banID, normal: isNormal}
+			}
 		}
 	}
-	return rows.Err()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for pid, best := range byProduct {
+		c.variants.tcgByProduct.Store(pid, best.banID)
+	}
+	return nil
+}
+
+// CachedTCGBanID returns the canonical ban_id for a non-Magic TCGplayer product
+// if it is already in the in-memory cache, without touching the DB. It is the
+// non-Magic counterpart of CachedMagicBanID: the read-side lookup that stamps a
+// ban_id onto a rendered card by product id alone (no per-card round-trip). A miss
+// (new product, or an unwarmed cache) returns ok=false and the caller falls back
+// to the game-native id.
+func (c *Client) CachedTCGBanID(productID int) (int64, bool) {
+	if id, ok := c.variants.tcgByProduct.Load(productID); ok {
+		return id.(int64), true
+	}
+	return 0, false
 }
 
 // ResolveMagicBanID returns the ban_id for a Magic variant, minting it if new.

--- a/timeseries/variants.go
+++ b/timeseries/variants.go
@@ -227,6 +227,19 @@ func (c *Client) LookupTCGBanID(ctx context.Context, productID int) (VariantInfo
 	return v, true, nil
 }
 
+// CachedMagicBanID returns the ban_id for a Magic variant if it is already in the
+// in-memory cache, without touching the DB or minting. It is the read-side lookup
+// for stamping a ban_id onto rendered cards (no per-card round-trip); warm the
+// cache once with WarmVariantCache. A miss (new printing, or an unwarmed cache)
+// returns ok=false and the caller falls back to the uuid path.
+func (c *Client) CachedMagicBanID(v MagicVariant) (int64, bool) {
+	v = v.normalized()
+	if id, ok := c.variants.magic.Load(v); ok {
+		return id.(int64), true
+	}
+	return 0, false
+}
+
 // ResolveTCGBanID returns the ban_id for a non-Magic variant, minting it if new.
 func (c *Client) ResolveTCGBanID(ctx context.Context, v TCGVariant) (int64, error) {
 	if id, ok := c.variants.tcg.Load(v); ok {

--- a/timeseries/variants.go
+++ b/timeseries/variants.go
@@ -1,0 +1,167 @@
+package timeseries
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+)
+
+// Provider ids in the providers lookup table (see db_migration/02_seed_providers.sql).
+// These are stable and referenced by config.json's per-dataset "provider" field.
+const (
+	ProviderCKRetail     int16 = 1
+	ProviderCKBuylist    int16 = 2
+	ProviderTCGLow       int16 = 3
+	ProviderTCGMarket    int16 = 4
+	ProviderTCGMid       int16 = 5
+	ProviderTCGHigh      int16 = 6
+	ProviderTCGDirectLow int16 = 7
+	ProviderMKMLow       int16 = 8
+	ProviderMKMTrend     int16 = 9
+	ProviderSCGBuylist   int16 = 10
+	ProviderABUBuylist   int16 = 11
+	ProviderCSIBuylist   int16 = 12
+	ProviderSealedEV     int16 = 13
+)
+
+// MagicVariant is the language-aware, condition-agnostic identity of a Magic
+// printing in the variants table. NormalizeUUID / NormalizeLanguage must have
+// been applied before it is used as a cache key or a lookup, or the live write
+// path mints duplicate variants the backfill won't match (plan 17.4).
+type MagicVariant struct {
+	MtgjsonUUID string
+	IsFoil      bool
+	IsEtched    bool
+	IsAlt       bool
+	Language    string
+}
+
+func (v MagicVariant) normalized() MagicVariant {
+	v.MtgjsonUUID = NormalizeUUID(v.MtgjsonUUID)
+	v.Language = *NormalizeLanguage(&v.Language)
+	return v
+}
+
+// TCGVariant is the identity of a non-Magic (TCGplayer-keyed) product printing.
+// SubType is stored as "" (never NULL) so partial-index NULL-distinctness can't
+// admit duplicates (plan 17.2).
+type TCGVariant struct {
+	CategoryID int
+	ProductID  int
+	SubType    string
+}
+
+// variantCache maps a normalized variant identity to its ban_id. It is shared by
+// the 12h stash cron (via the admin button too) and the daily tcgcsv ingest,
+// which can run at once, so access is concurrency-safe. Misses mint the variant
+// with INSERT ... ON CONFLICT DO NOTHING so cross-process races resolve to one row.
+type variantCache struct {
+	magic sync.Map // MagicVariant -> int64
+	tcg   sync.Map // TCGVariant   -> int64
+}
+
+// WarmVariantCache bulk-loads every existing variant into the in-memory cache in
+// one query, so a stash of ~150k printings resolves without ~150k round-trips.
+// Only genuinely new printings then miss and mint. Safe to call repeatedly.
+func (c *Client) WarmVariantCache(ctx context.Context) error {
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT ban_id, mtgjson_uuid, is_foil, is_etched, is_alt, language,
+		       tcgp_category_id, tcgp_product_id, tcgp_sub_type
+		FROM variants`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var loadedMagic, loadedTCG int
+	for rows.Next() {
+		var banID int64
+		var uuid sql.NullString
+		var isFoil, isEtched, isAlt bool
+		var language string
+		var catID, prodID sql.NullInt64
+		var subType sql.NullString
+		if err := rows.Scan(&banID, &uuid, &isFoil, &isEtched, &isAlt, &language,
+			&catID, &prodID, &subType); err != nil {
+			return err
+		}
+		if uuid.Valid {
+			c.variants.magic.Store(MagicVariant{
+				MtgjsonUUID: uuid.String, IsFoil: isFoil, IsEtched: isEtched,
+				IsAlt: isAlt, Language: language,
+			}, banID)
+			loadedMagic++
+		} else if prodID.Valid {
+			c.variants.tcg.Store(TCGVariant{
+				CategoryID: int(catID.Int64), ProductID: int(prodID.Int64),
+				SubType: subType.String,
+			}, banID)
+			loadedTCG++
+		}
+	}
+	return rows.Err()
+}
+
+// ResolveMagicBanID returns the ban_id for a Magic variant, minting it if new.
+// Reads/writes the in-memory cache; a miss upserts (ON CONFLICT DO NOTHING) so
+// concurrent callers and other processes converge on one row.
+func (c *Client) ResolveMagicBanID(ctx context.Context, v MagicVariant) (int64, error) {
+	v = v.normalized()
+	if id, ok := c.variants.magic.Load(v); ok {
+		return id.(int64), nil
+	}
+	// Insert-returning on a fresh variant (one round-trip); on conflict it returns
+	// no rows and we fetch the existing id in a second, separately-committed
+	// statement — which always sees a concurrently-inserted row, unlike a
+	// same-snapshot SELECT folded into the INSERT via a CTE.
+	var banID int64
+	err := c.db.QueryRowContext(ctx, `
+		INSERT INTO variants (mtgjson_uuid, is_foil, is_etched, is_alt, language)
+		VALUES ($1,$2,$3,$4,$5)
+		ON CONFLICT (mtgjson_uuid, is_foil, is_etched, is_alt, language)
+		    WHERE mtgjson_uuid IS NOT NULL DO NOTHING
+		RETURNING ban_id`,
+		v.MtgjsonUUID, v.IsFoil, v.IsEtched, v.IsAlt, v.Language,
+	).Scan(&banID)
+	if err == sql.ErrNoRows {
+		err = c.db.QueryRowContext(ctx, `
+			SELECT ban_id FROM variants
+			 WHERE mtgjson_uuid=$1 AND is_foil=$2 AND is_etched=$3 AND is_alt=$4 AND language=$5`,
+			v.MtgjsonUUID, v.IsFoil, v.IsEtched, v.IsAlt, v.Language,
+		).Scan(&banID)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("resolve magic ban_id %+v: %w", v, err)
+	}
+	c.variants.magic.Store(v, banID)
+	return banID, nil
+}
+
+// ResolveTCGBanID returns the ban_id for a non-Magic variant, minting it if new.
+func (c *Client) ResolveTCGBanID(ctx context.Context, v TCGVariant) (int64, error) {
+	if id, ok := c.variants.tcg.Load(v); ok {
+		return id.(int64), nil
+	}
+	var banID int64
+	err := c.db.QueryRowContext(ctx, `
+		INSERT INTO variants (tcgp_category_id, tcgp_product_id, tcgp_sub_type)
+		VALUES ($1,$2,$3)
+		ON CONFLICT (tcgp_category_id, tcgp_product_id, tcgp_sub_type)
+		    WHERE tcgp_product_id IS NOT NULL DO NOTHING
+		RETURNING ban_id`,
+		v.CategoryID, v.ProductID, v.SubType,
+	).Scan(&banID)
+	if err == sql.ErrNoRows {
+		err = c.db.QueryRowContext(ctx, `
+			SELECT ban_id FROM variants
+			 WHERE tcgp_category_id=$1 AND tcgp_product_id=$2 AND tcgp_sub_type=$3`,
+			v.CategoryID, v.ProductID, v.SubType,
+		).Scan(&banID)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("resolve tcg ban_id %+v: %w", v, err)
+	}
+	c.variants.tcg.Store(v, banID)
+	return banID, nil
+}

--- a/timeseries/variants_test.go
+++ b/timeseries/variants_test.go
@@ -1,0 +1,30 @@
+package timeseries
+
+import "testing"
+
+func TestMagicVariantNormalized(t *testing.T) {
+	cases := []struct {
+		name string
+		in   MagicVariant
+		want MagicVariant
+	}{
+		{
+			name: "strips mtgmatcher suffix and normalizes english",
+			in:   MagicVariant{MtgjsonUUID: "abcdef01-2345-6789-abcd-ef0123456789_f", Language: "English"},
+			want: MagicVariant{MtgjsonUUID: "abcdef01-2345-6789-abcd-ef0123456789", Language: ""},
+		},
+		{
+			name: "keeps a clean uuid and a real language",
+			in:   MagicVariant{MtgjsonUUID: "abcdef01-2345-6789-abcd-ef0123456789", IsFoil: true, Language: "Japanese"},
+			want: MagicVariant{MtgjsonUUID: "abcdef01-2345-6789-abcd-ef0123456789", IsFoil: true, Language: "Japanese"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.in.normalized()
+			if got != tc.want {
+				t.Errorf("normalized() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mtgban/go-mtgban/mtgban"
 	"github.com/mtgban/go-mtgban/mtgmatcher"
 	"github.com/mtgban/mtgban-website/internal/notify"
+	"github.com/mtgban/mtgban-website/timeseries"
 )
 
 var Country2flag = map[string]string{
@@ -38,7 +39,14 @@ var colorRarityMap = map[string]map[string]string{
 }
 
 type GenericCard struct {
-	UUID         string
+	UUID string
+	// BanID is the internal long-form variant id (see the card_prices redesign),
+	// cached here so charts open by ban:<id> without re-resolving. 0 when unknown
+	// (cache cold / new printing / no DB); callers fall back to UUID.
+	BanID int64
+	// ChartID is the id the UI passes to the chart system: ban:<BanID> when
+	// long-form reads are on, else the mtgmatcher card id (legacy path).
+	ChartID      string
 	Name         string
 	FlavorName   string
 	Edition      string
@@ -426,6 +434,28 @@ func uuid2card(cardId string, useThumbs, genPrints, preferFlavorName bool) Gener
 		return GenericCard{}
 	}
 
+	// Cache the internal ban_id onto the card so charts open by ban:<id> off the
+	// warmed variant cache (no per-card DB round-trip). 0 falls back to the uuid.
+	var banID int64
+	if PricesArchiveDB != nil {
+		if id, ok := PricesArchiveDB.CachedMagicBanID(timeseries.MagicVariant{
+			MtgjsonUUID: co.UUID,
+			IsFoil:      co.Foil,
+			IsEtched:    co.Etched,
+			IsAlt:       co.IsAlternative,
+			Language:    co.Language,
+		}); ok {
+			banID = id
+		}
+	}
+	// ChartID is what the UI hands the chart system. It is the internal ban:<id>
+	// once long-form reads serve charts (so lookups go through the new path), and
+	// the mtgmatcher id otherwise, keeping the legacy chart path working pre-cutover.
+	chartID := cardId
+	if banID != 0 && Config.TimeseriesConfig.LongFormReads {
+		chartID = "ban:" + strconv.FormatInt(banID, 10)
+	}
+
 	var stocksURL string
 	var sypList bool
 
@@ -631,6 +661,8 @@ func uuid2card(cardId string, useThumbs, genPrints, preferFlavorName bool) Gener
 
 	return GenericCard{
 		UUID:         co.UUID,
+		BanID:        banID,
+		ChartID:      chartID,
 		Name:         name,
 		FlavorName:   flavor,
 		Edition:      co.Edition,

--- a/utils.go
+++ b/utils.go
@@ -18,7 +18,6 @@ import (
 	"github.com/mtgban/go-mtgban/mtgban"
 	"github.com/mtgban/go-mtgban/mtgmatcher"
 	"github.com/mtgban/mtgban-website/internal/notify"
-	"github.com/mtgban/mtgban-website/timeseries"
 )
 
 var Country2flag = map[string]string{
@@ -435,19 +434,10 @@ func uuid2card(cardId string, useThumbs, genPrints, preferFlavorName bool) Gener
 	}
 
 	// Cache the internal ban_id onto the card so charts open by ban:<id> off the
-	// warmed variant cache (no per-card DB round-trip). 0 falls back to the uuid.
-	var banID int64
-	if PricesArchiveDB != nil {
-		if id, ok := PricesArchiveDB.CachedMagicBanID(timeseries.MagicVariant{
-			MtgjsonUUID: co.UUID,
-			IsFoil:      co.Foil,
-			IsEtched:    co.Etched,
-			IsAlt:       co.IsAlternative,
-			Language:    co.Language,
-		}); ok {
-			banID = id
-		}
-	}
+	// warmed variant cache (no per-card DB round-trip), game-agnostically: a Magic
+	// printing resolves by uuid, a non-Magic product by its TCGplayer id. 0 falls
+	// back to the game-native id.
+	banID := cachedBanIDForCard(co)
 	// ChartID is what the UI hands the chart system. It is the internal ban:<id>
 	// once long-form reads serve charts (so lookups go through the new path), and
 	// the mtgmatcher id otherwise, keeping the legacy chart path working pre-cutover.


### PR DESCRIPTION
## Summary

Long-form price storage: collapses the two wide price tables
(`product_prices`, `tcgplayer_nonmagic_product_prices`) into a unified
`variants` identity table + a long, date-partitioned `prices(ban_id, date,
provider, price)` table, and makes charts game-agnostic (any resolvable id —
`ban:`, `tcg:`, `scryfall:`, `mtgjson:`, bare uuid/number — including non-Magic
products).

Everything new sits behind two config flags (`long_form_writes`,
`long_form_reads`), both default off. **Merging this changes nothing in
production until the flags are flipped** — with both off, every path is the
existing legacy path. The legacy wide write path stays intact as a safety net
through the whole cutover, so every step is reversible by flipping a flag back.

## What's in here

- Long-form write path (dual-write into `variants` + `prices`) — gated on `long_form_writes`
- Long-form read path (charts, earliest-date, buylist metrics, screener) — gated on `long_form_reads`
- Game-agnostic chart id resolution + a provider registry that renders whatever providers actually have data
- `db_migration/` — schema, seeds, indexes, verify SQL, and the resumable `backfill.py`
- Charts enabled for non-Magic games (previously force-disabled), but only when long-form reads are on

## Required config.json changes BEFORE deploy

`config.json` is gitignored, so these must be applied on the deployment target.

**1. Add a `provider` id to every `timeseries_config.datasets` entry:**

| dataset `index` | column | `provider` |
|---|---|---|
| 0 | cardkingdom_retail_price | 1 |
| 1 | cardkingdom_buylist_price | 2 |
| 2 | tcgplayer_low_price | 3 |
| 3 | tcgplayer_market_price | 4 |
| 4 | cardmarket_low_price | 8 |
| 5 | cardmarket_trend_price | 9 |
| 6 | starcitygames_buylist_price | 10 |
| 7 | abu_buylist_price | 11 |
| 8 | tcgplayer_low_sealed_expected_value | 13 |
| 9 | coolstuffinc_buylist_price | 12 |

**2. Full `timeseries_config` block** (adds the two flags + `provider` on every
dataset). Copy/paste-ready — the `address` line is commented so it can't clobber
your existing DSN; leave that field as-is:

```jsonc
"timeseries_config": {
    // "address": "<keep your existing DSN — do not overwrite>",
    "long_form_writes": false,   // step 2 of cutover flips this on
    "long_form_reads": false,    // step 5 of cutover flips this on
    "datasets": [
        { "retail":  ["TCGLow", "TCGSealed"], "public_name": "TCGplayer Low",         "index": 2, "provider": 3,  "color": "rgb(255, 99, 132)",  "has_sealed": true },
        { "retail":  ["TCGMarket"],           "public_name": "TCGplayer Market",       "index": 3, "provider": 4,  "color": "rgb(255, 159, 64)" },
        { "retail":  ["CK", "CKSealed"],      "public_name": "Card Kingdom Retail",    "index": 0, "provider": 1,  "color": "rgb(162, 235, 54)",  "has_sealed": true },
        { "buylist": ["CK", "CKSealed"],      "public_name": "Card Kingdom Buylist",   "index": 1, "provider": 2,  "color": "rgb(54, 162, 235)",  "has_sealed": true },
        { "retail":  ["MKMLow", "MKMSealed"], "public_name": "Cardmarket Low",         "index": 4, "provider": 8,  "color": "rgb(235, 205, 86)",  "has_sealed": true },
        { "retail":  ["MKMTrend"],            "public_name": "Cardmarket Trend",        "index": 5, "provider": 9,  "color": "rgb(201, 203, 207)" },
        { "buylist": ["SCG"],                 "public_name": "Star City Games Buylist", "index": 6, "provider": 10, "color": "rgb(23,42,72)" },
        { "buylist": ["ABUGames"],            "public_name": "ABU Games Buylist",       "index": 7, "provider": 11, "color": "rgb(153, 102, 255)" },
        { "retail":  ["TCGLowEV"],            "public_name": "Sealed EV (TCG Low)",     "index": 8, "provider": 13, "color": "rgb(201, 203, 207)", "has_sealed": true, "only_sealed": true },
        { "buylist": ["CSI"],                 "public_name": "Cool Stuff Inc Buylist",  "index": 9, "provider": 12, "color": "rgb(124, 211, 224)" }
    ]
}
```

Non-Magic TCGplayer providers (low/market/mid/high/direct_low → 3/4/5/6/7) are
wired in code, not config.

## Cutover sequence

⚠️ **Ordering note specific to us:** the first backfill was already run, but this
PR was never dual-writing, so the long tables are missing every snapshot since
that backfill's high-water mark. To close that gap with no hole, **dual-write
must go on before the catch-up backfill** — do not backfill first.

1. Merge + apply the config.json changes above (flags still off).
2. Deploy with `long_form_writes: true` (reads still off). Startup ensures the
   current+next month partitions and warms the variant→ban_id cache. Dual-write
   now captures all new snapshots.
3. Run the catch-up backfill for the window since the first backfill's
   high-water mark (`backfill.py prices` — resumable/idempotent, skips done
   chunks; force-rerun the partial final month from run 1). Its tail overlaps
   dual-write's head, and both sides are `ON CONFLICT`, so no gap and no
   double-count.
4. `08_catchup.sql` to close residual drift, then `07_verify.sql` until
   per-provider diffs are 0. Spot-check a few charts (incl. non-Magic).
5. Deploy with `long_form_reads: true`. Charts / earliest-date / buylist metrics
   / screener now serve from the long tables; legacy writes continue as the
   safety net. Watch for a day. Rollback = `long_form_reads: false`.
6. Off-peak: `06_validate_fk.sql` to VALIDATE the `prices_ban_id_fk`.

Dropping the legacy write path + the `index` field is a **separate follow-up PR**,
not this one.

## Known limitations

- Screener (`GetMoversLong`) and buylist metrics (`GetAggregatePriceStatsLong`)
  are Magic-scoped (`mtgjson_uuid IS NOT NULL`); on a non-Magic deployment they
  return empty, not error. Charts are fully game-agnostic.
- Non-Magic charts have no legacy baseline to diff against (the non-Magic wide
  table was never charted), so `07_verify` there confirms rows landed by count,
  not chart-for-chart parity — hand-check a few.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt` clean
- Unit tests pass (`chart_resolve_test`, `timeseries` unit tests). Live DB tests
  guarded behind `TCGLIVE_HOST`.
- Pre-existing `TestClosestCardName` failure is environmental (missing local
  datastore file), unrelated to this change.
