### PR TITLE
perf: keep ban_id resolution off chartless render paths

### DIFF
--- a/chart_resolve.go
+++ b/chart_resolve.go
@@ -43,6 +43,14 @@ type chartTarget struct {
 // map), then a non-Magic product in the variants table. Prefix ban: or tcg: to
 // force one interpretation.
 func resolveChartTarget(ctx context.Context, raw string) (*chartTarget, error) {
+	// Every resolution branch can reach the variants table (targetFromBanID,
+	// targetFromTCGID, and matcherTarget's retired-uuid fallback dereference
+	// PricesArchiveDB directly). Both current callers are behind their own nil
+	// checks; this guard keeps a future caller from turning a chartless deploy
+	// into a panic.
+	if PricesArchiveDB == nil {
+		return nil, errChartIDNotFound
+	}
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return nil, errChartIDNotFound

--- a/chart_resolve.go
+++ b/chart_resolve.go
@@ -157,6 +157,27 @@ func cachedBanIDForCard(co *mtgmatcher.CardObject) int64 {
 	return 0
 }
 
+// chartIDForCard maps a card id to the id the UI hands the chart system: the
+// internal ban:<id> once long-form reads serve charts (so lookups skip the
+// canonical re-resolution), else the card id itself (legacy path). It costs a
+// variant-cache lookup per call, so it is invoked only while rendering pages
+// that chart cards (search results) — not from uuid2card, which also feeds
+// chartless pages (upload, arbit, news, ...) at thousands of cards a request.
+func chartIDForCard(cardId string) string {
+	if !Config.TimeseriesConfig.LongFormReads {
+		return cardId
+	}
+	co, err := mtgmatcher.GetUUID(cardId)
+	if err != nil {
+		return cardId
+	}
+	banID := cachedBanIDForCard(co)
+	if banID == 0 {
+		return cardId
+	}
+	return "ban:" + strconv.FormatInt(banID, 10)
+}
+
 // resolveBanIDForCard is cachedBanIDForCard for the single chart-open path, where a
 // DB round-trip is affordable: on an in-memory miss it resolves a non-Magic product
 // against the variants table, so a cold cache (or a product ingested since warm-up)

--- a/search.go
+++ b/search.go
@@ -543,7 +543,12 @@ func Search(w http.ResponseWriter, r *http.Request) {
 		if found {
 			continue
 		}
-		pageVars.Metadata[cardId] = uuid2card(cardId, false, true, preferFlavor)
+		card := uuid2card(cardId, false, true, preferFlavor)
+		// Search results chart cards, so upgrade the chart handle to the cached
+		// ban:<id> here rather than inside uuid2card, which also feeds pages
+		// that never chart.
+		card.ChartID = chartIDForCard(cardId)
+		pageVars.Metadata[cardId] = card
 	}
 
 	// Optionally sort according to price

--- a/search.go
+++ b/search.go
@@ -281,6 +281,10 @@ func Search(w http.ResponseWriter, r *http.Request) {
 	chartIds, chartTruncated := parseChartIDs(chartParam)
 
 	chartId := ""
+	// Roster id -> resolved search id, computed once per request: a ban:<id>
+	// resolution costs a DB round-trip and each id is consulted three times
+	// (results query, display query, metadata aliasing).
+	chartSearchIDs := map[string]string{}
 	if len(chartIds) > 0 && !pageVars.DisableChart {
 		// A crafted or over-long chart= URL that names more cards than the chart
 		// can render lands here; say so rather than silently dropping the tail.
@@ -308,6 +312,7 @@ func Search(w http.ResponseWriter, r *http.Request) {
 			searchIDs := make([]string, len(chartIds))
 			for i, id := range chartIds {
 				searchIDs[i] = chartIDToSearchID(r.Context(), id)
+				chartSearchIDs[id] = searchIDs[i]
 			}
 			query = strings.Join(searchIDs, ",")
 			pageVars.Title = strings.Replace(pageVars.Title, "Search", "Chart", 1)
@@ -772,7 +777,7 @@ func Search(w http.ResponseWriter, r *http.Request) {
 		// mtgmatcher id (a ban:<id> doesn't parse as a query), so SearchQuery is
 		// non-empty and the template renders the results+chart layout rather than
 		// the empty-query editions browse.
-		cfg := parseSearchOptionsNG(chartIDToSearchID(r.Context(), chartId), nil, nil, nil)
+		cfg := parseSearchOptionsNG(chartSearchIDs[chartId], nil, nil, nil)
 		pageVars.SearchQuery = cfg.FullQuery
 
 		// Retrieve data
@@ -783,10 +788,12 @@ func Search(w http.ResponseWriter, r *http.Request) {
 		// results Metadata map is keyed by the resolved mtgmatcher id. Alias each
 		// ban:<id> roster entry to its resolved card so those lookups resolve.
 		for _, id := range chartIds {
-			if sid := chartIDToSearchID(r.Context(), id); sid != id {
-				if card, ok := pageVars.Metadata[sid]; ok {
-					pageVars.Metadata[id] = card
-				}
+			sid := chartSearchIDs[id]
+			if sid == "" || sid == id {
+				continue
+			}
+			if card, ok := pageVars.Metadata[sid]; ok {
+				pageVars.Metadata[id] = card
 			}
 		}
 

--- a/utils.go
+++ b/utils.go
@@ -39,12 +39,10 @@ var colorRarityMap = map[string]map[string]string{
 
 type GenericCard struct {
 	UUID string
-	// BanID is the internal long-form variant id (see the card_prices redesign),
-	// cached here so charts open by ban:<id> without re-resolving. 0 when unknown
-	// (cache cold / new printing / no DB); callers fall back to UUID.
-	BanID int64
-	// ChartID is the id the UI passes to the chart system: ban:<BanID> when
-	// long-form reads are on, else the mtgmatcher card id (legacy path).
+	// ChartID is the id the UI passes to the chart system. uuid2card leaves it
+	// as the mtgmatcher card id; chart-capable pages override it with ban:<id>
+	// via chartIDForCard, so chartless pages (upload, arbit, news, ...) don't
+	// pay the variant-cache lookup for every card they render.
 	ChartID      string
 	Name         string
 	FlavorName   string
@@ -433,19 +431,6 @@ func uuid2card(cardId string, useThumbs, genPrints, preferFlavorName bool) Gener
 		return GenericCard{}
 	}
 
-	// Cache the internal ban_id onto the card so charts open by ban:<id> off the
-	// warmed variant cache (no per-card DB round-trip), game-agnostically: a Magic
-	// printing resolves by uuid, a non-Magic product by its TCGplayer id. 0 falls
-	// back to the game-native id.
-	banID := cachedBanIDForCard(co)
-	// ChartID is what the UI hands the chart system. It is the internal ban:<id>
-	// once long-form reads serve charts (so lookups go through the new path), and
-	// the mtgmatcher id otherwise, keeping the legacy chart path working pre-cutover.
-	chartID := cardId
-	if banID != 0 && Config.TimeseriesConfig.LongFormReads {
-		chartID = "ban:" + strconv.FormatInt(banID, 10)
-	}
-
 	var stocksURL string
 	var sypList bool
 
@@ -651,8 +636,7 @@ func uuid2card(cardId string, useThumbs, genPrints, preferFlavorName bool) Gener
 
 	return GenericCard{
 		UUID:         co.UUID,
-		BanID:        banID,
-		ChartID:      chartID,
+		ChartID:      cardId,
 		Name:         name,
 		FlavorName:   flavor,
 		Edition:      co.Edition,


### PR DESCRIPTION
Follow-ups from a review of `v13.21..master` (the card_prices long-form redesign + game-agnostic charts). Three independent commits, all on the chart render path.

## 1. `perf: resolve chart ids only on pages that chart`

`uuid2card` ran `cachedBanIDForCard` for **every** card it converted, but only the search templates read the resulting `ChartID`. The other seven callers — upload, arbit, news, screener, sleep, popular, discord — render pages with **no chart affordance**, and they convert the biggest batches: a thousand-row upload or arbitrage table paid a variant-cache lookup per row for nothing. Each lookup also boxes the `MagicVariant` key into an interface (`sync.Map.Load(any)`), so it **allocates even on a cache hit** — and with `LongFormReads` off, the result was discarded entirely.

- The mapping moves to `chartIDForCard`, invoked only from the search results metadata loop; `uuid2card` stamps `ChartID` with the id it was given.
- The helper short-circuits before any lookup while `LongFormReads` is off → **zero pre-cutover cost everywhere**; post-cutover only search pages pay, one warm cache hit per row.
- `GenericCard.BanID` is **dropped: nothing read it** (no Go consumer, no template) — the chart open path re-resolves via `resolveChartTarget` anyway.

## 2. `perf: resolve each chart roster id once per request`

`Search` resolved every roster id through `chartIDToSearchID` up to **three times** per request (results query, display query, metadata aliasing), and each `ban:<id>` resolution is a `LookupVariant` DB round-trip: a full 10-card `ban:` roster paid ~21 sequential round-trips before any chart data was fetched. Now memoized in a per-request map filled where the results query is built. The later two sites can never see a missing entry — `chartId` is only ever assigned in the same branch that fills the map (verified: single assignment site).

## 3. `charts: guard resolveChartTarget against a nil price DB`

Every resolution branch can dereference `PricesArchiveDB` (`ban:`/`tcg:` paths directly; `matcherTarget` via its retired-uuid fallback). Both existing callers sit behind their own nil checks, so this is unreachable today — the guard turns a future caller's panic on a chartless deploy into a clean not-found.

## Verification

- `go build`, `go vet`, `gofmt` clean.
- Full main-package test run **with the card datastore loaded** passes (includes the datastore-gated chart id tests), plus `./timeseries/...` and `./tcgcsv/...`.
- Behavior-identical by construction: `chartIDForCard(cardId)` performs the same `GetUUID` + `cachedBanIDForCard` sequence `uuid2card` did, relocated; the memo map returns the same values `chartIDToSearchID` returned per id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
