### PR TITLE
perf: resolve SYP card metadata after pagination

### DIFF
--- a/news.go
+++ b/news.go
@@ -1151,12 +1151,6 @@ func Newspaper(w http.ResponseWriter, r *http.Request) {
 					Quantity:       entry.Quantity,
 				})
 			}
-
-			_, found := pageVars.Metadata[cardId]
-			if found {
-				continue
-			}
-			pageVars.Metadata[cardId] = uuid2card(cardId, true, false, preferFlavor)
 		}
 
 		switch sorting {
@@ -1189,6 +1183,17 @@ func Newspaper(w http.ResponseWriter, r *http.Request) {
 		if len(arbit) > MaxSYPResults {
 			pageIndex, _ := strconv.Atoi(r.FormValue("p"))
 			arbit, pageVars.Pagination = Paginate(arbit, pageIndex, MaxSYPResults, MaxSYPTotalResults)
+		}
+
+		// Resolve card metadata only for the visible page: the full SYP list
+		// runs to tens of thousands of cards and all the template reads are
+		// keyed by the paginated entries.
+		for _, entry := range arbit {
+			_, found := pageVars.Metadata[entry.CardId]
+			if found {
+				continue
+			}
+			pageVars.Metadata[entry.CardId] = uuid2card(entry.CardId, true, false, preferFlavor)
 		}
 
 		entry := Arbitrage{


### PR DESCRIPTION
First follow-up from the site-wide bottleneck review.

## Problem

The newspaper **SYP page** (`/newspaper?page=syp`) built `uuid2card` metadata for **every card in the full SYP buylist** before paginating, then rendered at most one page — 2,500 rows out of up to `MaxSYPTotalResults = 100,000`. `uuid2card` linear-scans the scraper lists several times per call (SYP/STKS/CK lookups), so on a big SYP list ~97% of that work was thrown away on every page load.

## Fix

Move the `Metadata` population **after** `Paginate`, iterating the paginated slice (with the per-cardId dedupe kept, since a card's multiple conditions produce multiple rows). This is the same order the regular newspaper pages (`news.go` main table) and the screener already use.

## Safety

Every template read of `$.Metadata` in `arbit.html` is keyed by entries of the same paginated slice — the two row loops and the CK/CSI deckbuilder hidden inputs all `range` over `$arb.Arbit`, which is the post-pagination list — so the visible page resolves exactly the same cards as before.

## Verification

- `go build`, `go vet`, `gofmt` clean.
- Full main-package test suite passes with the card datastore loaded.
- (`TestClosestCardName` fails without a datastore on clean master too — pre-existing, unrelated; it's missing the skip-guard its sibling tests have.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
