### PR TITLE
suggest: skip the closest-name test when the datastore isn't loaded

### DIFF
--- a/suggestions_test.go
+++ b/suggestions_test.go
@@ -11,6 +11,9 @@ import (
 // live here rather than in internal/suggest.
 
 func TestClosestCardName(t *testing.T) {
+	if !datastoreLoaded() {
+		t.Skip("mtgmatcher datastore not loaded")
+	}
 	if got := suggest.Closest("lightnig bolt", false); got != "Lightning Bolt" {
 		t.Errorf("typo: Closest = %q, want Lightning Bolt", got)
 	}


### PR DESCRIPTION
## Problem

Running the package tests without a local `allprintings5.json` **fails** instead of skipping:

```
--- FAIL: TestClosestCardName (0.00s)
    suggestions_test.go:15: typo: Closest = "", want Lightning Bolt
```

`TestMain`'s datastore load is deliberately best-effort: data-dependent tests are expected to guard themselves (`datastoreLoaded()` in the search tests, `nRealUUIDs` in the chart tests). `TestClosestCardName` asserts on real card names — `Closest("lightnig bolt") == "Lightning Bolt"` — but never checks that any data is loaded, so with an empty matcher `Closest` returns `""` and the assertion fires.

## Fix

Guard the test with the same `datastoreLoaded()` check the search tests already use:

```go
if !datastoreLoaded() {
    t.Skip("mtgmatcher datastore not loaded")
}
```

`TestAppliedFiltersCapture` (the only other test in the file) stays unguarded — it only exercises filter parsing and passes without card data.

## Verification

- Without `allprintings5.json`: `--- SKIP: TestClosestCardName ... mtgmatcher datastore not loaded`
- With the datastore symlinked in, `-count=1` to bypass the test cache: `--- PASS: TestClosestCardName (0.05s)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
