### PR TITLE
perf: write the price-filter cache synchronously

### DIFF
--- a/searchfilter.go
+++ b/searchfilter.go
@@ -95,7 +95,11 @@ type FilterPriceElem struct {
 	// All stores sources (shorthands) present in the map
 	Stores []string
 
-	// Cache of cardId:prices used in the filter
+	// Cache of cardId:prices used in the filter. The retail and buylist
+	// searches run concurrently and can share one filter (e.g. noSussy spans
+	// TCGDirect retail and TCGDirectNet buylist), so cached slices are read
+	// from multiple goroutines: never mutate one after it is stored — build a
+	// new slice instead.
 	PriceCache map[string][]float64
 
 	// Mutex protecting PriceCache map from concurrent access
@@ -2171,15 +2175,16 @@ func shouldSkipPriceNG(cardId string, entry mtgban.GenericEntry, filters []*Filt
 				prices = []float64{filters[i].Value}
 			}
 
-			// Update cache
-			go func() {
-				filters[i].Mutex.Lock()
-				if filters[i].PriceCache == nil {
-					filters[i].PriceCache = map[string][]float64{}
-				}
-				filters[i].PriceCache[cardId] = prices
-				filters[i].Mutex.Unlock()
-			}()
+			// Update cache synchronously so the card's next entries hit it: an
+			// async write lands after the burst of same-card lookups has already
+			// missed, recomputing the store prices for nearly every entry (and
+			// spawning a goroutine per miss).
+			filters[i].Mutex.Lock()
+			if filters[i].PriceCache == nil {
+				filters[i].PriceCache = map[string][]float64{}
+			}
+			filters[i].PriceCache[cardId] = prices
+			filters[i].Mutex.Unlock()
 		}
 
 		res := applyPriceFilter(filters[i].Name, prices, entry.Pricing())

--- a/searchfilter_bench_test.go
+++ b/searchfilter_bench_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/mtgban/go-mtgban/mtgban"
+)
+
+// The retail and buylist searches evaluate a shared filter concurrently (the
+// noSussy guard spans TCGDirect retail and TCGDirectNet buylist), so the cache
+// must stay race-free under exactly that pattern. Meaningful under -race.
+func TestPriceFilterCacheConcurrent(t *testing.T) {
+	scrapers := []string{"SCR0", "SCR1", "SCR2"}
+	filter := &FilterPriceElem{
+		Name:        "price_greater_than",
+		Price4Store: benchPrice4Store(scrapers),
+		Stores:      []string{"SCR1"},
+	}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		runPriceFilterRequest(500, filter)
+	}()
+	go func() {
+		defer wg.Done()
+		filters := []*FilterPriceElem{filter}
+		for c := range 500 {
+			cardId := "bench-card-" + strconv.Itoa(c)
+			shouldSkipPriceNG(cardId, mtgban.BuylistEntry{BuyPrice: 6.0, Conditions: "NM"}, filters, "SCR050")
+		}
+	}()
+	wg.Wait()
+}
+
+// benchStoreLookups counts Price4Store invocations across a benchmark run, so
+// the report shows how much redundant recomputation the cache absorbs.
+var benchStoreLookups atomic.Int64
+
+// benchPrice4Store stands in for price4seller: findSellerInventory linear-scans
+// every scraper with EqualFold before the map lookup, so model that cost with a
+// same-sized scan over fake shorthands.
+func benchPrice4Store(scrapers []string) func(string, string) float64 {
+	return func(cardId, shorthand string) float64 {
+		benchStoreLookups.Add(1)
+		for _, code := range scrapers {
+			if strings.EqualFold(code, shorthand) {
+				return 10.0
+			}
+		}
+		return 0
+	}
+}
+
+// runPriceFilterRequest pushes one search-request-shaped workload through
+// shouldSkipPriceNG: nCards cards with four condition entries each, all
+// evaluated against a single price filter, mirroring searchSellersNG's loop.
+func runPriceFilterRequest(nCards int, filter *FilterPriceElem) {
+	filters := []*FilterPriceElem{filter}
+	entries := []mtgban.InventoryEntry{
+		{Price: 5.0, Conditions: "NM"},
+		{Price: 4.0, Conditions: "SP"},
+		{Price: 3.0, Conditions: "MP"},
+		{Price: 2.0, Conditions: "HP"},
+	}
+	for c := range nCards {
+		cardId := "bench-card-" + strconv.Itoa(c)
+		for _, entry := range entries {
+			shouldSkipPriceNG(cardId, entry, filters, "SCR050")
+		}
+	}
+}
+
+// A store-backed filter (e.g. "arb_price>CK" or the noSussy guard): every cache
+// miss pays a Price4Store lookup per configured store.
+func BenchmarkPriceFilterStoreLookup(b *testing.B) {
+	scrapers := make([]string, 100)
+	for i := range scrapers {
+		scrapers[i] = "SCR" + strconv.Itoa(i)
+	}
+	benchStoreLookups.Store(0)
+	b.ReportAllocs()
+	for b.Loop() {
+		filter := &FilterPriceElem{
+			Name:        "price_greater_than",
+			Price4Store: benchPrice4Store(scrapers),
+			Stores:      []string{"SCR050"},
+		}
+		runPriceFilterRequest(5000, filter)
+	}
+	b.ReportMetric(float64(benchStoreLookups.Load())/float64(b.N), "storeLookups/req")
+}
+
+// A constant-value filter (e.g. "price>10"): no store lookups, so this isolates
+// the cache-write machinery itself.
+func BenchmarkPriceFilterConstantValue(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		filter := &FilterPriceElem{
+			Name:  "price_greater_than",
+			Value: 10.0,
+		}
+		runPriceFilterRequest(5000, filter)
+	}
+}


### PR DESCRIPTION
Second follow-up from the site-wide bottleneck review: the price-filter cache in `shouldSkipPriceNG`.

## Problem

`shouldSkipPriceNG` populated its per-card price cache from a **goroutine spawned on every cache miss**. The write landed after the burst of same-card lookups (the card's other conditions, the next store carrying it) had already missed, so within a request the cache absorbed almost nothing — and the `FilterPriceElem` is request-scoped, so the late writes bought nothing afterward either. Every filtered search (`price>`, `buy_price>`, `arb_price>`, `rev_price>`, or the noSussy toggle) paid:

- a goroutine spawn per miss — tens of thousands per large search;
- redundant `Price4Store` recomputation per miss, each a `findSellerInventory` **linear scan over every scraper**.

## Fix

Write the cache synchronously under the existing lock. Same slices, same lifecycle — just published before first use instead of asynchronously after.

**The mutex stays**: retail and buylist searches run concurrently (`searchParallelNG`) and can share one filter — `noSussy` applies to **TCGDirect (a seller) and TCGDirectNet (a vendor)** — so an unsynchronized map would race. Concurrent same-card misses remain benign: each side builds its own fresh slice, last write wins with identical content. The `PriceCache` field now documents the contract (stored slices are read across goroutines; never mutate one after storing).

## Measured (benchmark in the first commit, runnable on either side of the fix)

Request-shaped workload: 5,000 cards × 4 condition entries through one filter, Apple M3 Max.

| | before (async) | after (sync) | |
|---|---|---|---|
| store-backed filter | 21.9 ms, 48.8k allocs, 4.98 MB | **3.9 ms**, 30.0k allocs, 3.44 MB | 5.6× |
| — `storeLookups/req` | 18,680 (93% of evaluations recomputed) | **5,000** (exactly one per card) | |
| constant-value filter | 23.2 ms, 68.9k allocs, 5.18 MB | **1.7 ms**, 34.9k allocs, 3.50 MB | 13.9× |

The `storeLookups/req` row is the direct proof: the async cache had a 6.6% hit rate inside a request; the sync cache hits every entry after a card's first.

## Verification

- `TestPriceFilterCacheConcurrent` runs the concurrent retail/buylist sharing pattern; passes under `-race` (×4).
- Full main-package suite passes with the card datastore loaded; `gofmt`/`vet`/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
