### PR TITLE
perf: parse the signature once, build the error nav lazily

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -680,14 +680,23 @@ func sign(tierTitle string, userData *PatreonUserData) string {
 	return str
 }
 
-func GetParamFromSig(sig, param string) string {
+// parseSig decodes the query values packed in a signature. A sig that doesn't
+// decode returns nil, which behaves as an empty url.Values on Get. Decoding
+// the full ~2KB sig costs a few microseconds, so code reading several params
+// (like genPageNav's feature loop) should parse once and Get from the result
+// rather than calling GetParamFromSig per param.
+func parseSig(sig string) url.Values {
 	raw, err := base64.StdEncoding.DecodeString(sig)
 	if err != nil {
-		return ""
+		return nil
 	}
 	v, err := url.ParseQuery(string(raw))
 	if err != nil {
-		return ""
+		return nil
 	}
-	return v.Get(param)
+	return v
+}
+
+func GetParamFromSig(sig, param string) string {
+	return parseSig(sig).Get(param)
 }

--- a/auth.go
+++ b/auth.go
@@ -488,9 +488,11 @@ func enforceSigning(next http.Handler) http.Handler {
 			return
 		}
 
-		pageVars := genPageNav("Error", sig)
-
+		// The error nav is built lazily inside each failing branch: on the
+		// happy path — nearly every request — it would be thrown away, and
+		// the handler builds its own right after.
 		if !UserRateLimiter.Allow(GetParamFromSig(sig, "UserEmail")) && r.URL.Path != "/admin" {
+			pageVars := genPageNav("Error", sig)
 			pageVars.Title = "Too Many Requests"
 			pageVars.ErrorMessage = ErrMsgUseAPI
 
@@ -500,6 +502,7 @@ func enforceSigning(next http.Handler) http.Handler {
 
 		raw, err := base64.StdEncoding.DecodeString(sig)
 		if SigCheck && err != nil {
+			pageVars := genPageNav("Error", sig)
 			pageVars.Title = "Unauthorized"
 			pageVars.ErrorMessage = ErrMsg
 			if DevMode {
@@ -512,6 +515,7 @@ func enforceSigning(next http.Handler) http.Handler {
 
 		v, err := url.ParseQuery(string(raw))
 		if SigCheck && err != nil {
+			pageVars := genPageNav("Error", sig)
 			pageVars.Title = "Unauthorized"
 			pageVars.ErrorMessage = ErrMsg
 			if DevMode {
@@ -545,6 +549,7 @@ func enforceSigning(next http.Handler) http.Handler {
 				http.Error(w, "405 Method Not Allowed", http.StatusMethodNotAllowed)
 				return
 			}
+			pageVars := genPageNav("Error", sig)
 			pageVars.Title = "Unauthorized"
 			pageVars.ErrorMessage = ErrMsg
 			if valid == expectedSig && expires < time.Now().Unix() {
@@ -576,7 +581,7 @@ func enforceSigning(next http.Handler) http.Handler {
 					canDo = true
 				}
 				if SigCheck && !canDo {
-					pageVars = genPageNav(nav.Name, sig)
+					pageVars := genPageNav(nav.Name, sig)
 					pageVars.Title = "This feature is BANned"
 					pageVars.ErrorMessage = ErrMsgPlus
 
@@ -588,6 +593,7 @@ func enforceSigning(next http.Handler) http.Handler {
 				for _, subPage := range nav.SubPages {
 					if strings.HasPrefix(subPage.Link, r.URL.Path) &&
 						subPage.ShouldHide != nil && subPage.ShouldHide() {
+						pageVars := genPageNav("Error", sig)
 						pageVars.Title = "Unauthorized"
 						render(w, "home.html", pageVars)
 						break

--- a/auth.go
+++ b/auth.go
@@ -300,7 +300,7 @@ func signedUserEmail(r *http.Request) string {
 	}
 
 	q := url.Values{}
-	for _, optional := range append(OrderNav, OptionalFields...) {
+	for _, optional := range SignedFields {
 		if val := v.Get(optional); val != "" {
 			q.Set(optional, val)
 		}
@@ -527,7 +527,7 @@ func enforceSigning(next http.Handler) http.Handler {
 		}
 
 		q := url.Values{}
-		for _, optional := range append(OrderNav, OptionalFields...) {
+		for _, optional := range SignedFields {
 			val := v.Get(optional)
 			if val != "" {
 				q.Set(optional, val)
@@ -660,6 +660,11 @@ func getValuesForTier(tierTitle string) url.Values {
 	}
 	return v
 }
+
+// Every sig-encoded permission field in signing order: OrderNav then
+// OptionalFields. Both lists are fixed at startup, so the concatenation the
+// signing and verification paths walk is computed once instead of per request.
+var SignedFields = slices.Concat(OrderNav, OptionalFields)
 
 func sign(tierTitle string, userData *PatreonUserData) string {
 	v := getValuesForTier(tierTitle)

--- a/auth_bench_test.go
+++ b/auth_bench_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"encoding/base64"
+	"net/url"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+// benchSig builds a signature shaped like production ones: every nav
+// permission, the optional fields, expiry, and the HMAC blob.
+func benchSig(seed string) string {
+	v := url.Values{}
+	for _, opt := range OptionalFields {
+		v.Set(opt, "some,option,values")
+	}
+	for _, feat := range OrderNav {
+		v.Set(feat, "true")
+	}
+	// After the loops: UserEmail and UserTier are themselves OptionalFields.
+	// Expiry must stay in the future or genPageNav skips its feature loop.
+	v.Set("Expires", strconv.FormatInt(time.Now().AddDate(1, 0, 0).Unix(), 10))
+	v.Set("UserEmail", "someone"+seed+"@example.com")
+	v.Set("UserTier", "Vintage")
+	v.Set("Signature", "aGVsbG8gd29ybGQgdGhpcyBpcyBhIGZha2UgaG1hYyBzaWduYXR1cmU=")
+	return base64.StdEncoding.EncodeToString([]byte(v.Encode()))
+}
+
+func TestGetParamFromSig(t *testing.T) {
+	sig := benchSig("")
+	if got := GetParamFromSig(sig, "UserTier"); got != "Vintage" {
+		t.Errorf("UserTier = %q, want Vintage", got)
+	}
+	if got := GetParamFromSig(sig, "Search"); got != "true" {
+		t.Errorf("Search = %q, want true", got)
+	}
+	if got := GetParamFromSig(sig, "NoSuchParam"); got != "" {
+		t.Errorf("NoSuchParam = %q, want empty", got)
+	}
+	if got := GetParamFromSig("", "UserTier"); got != "" {
+		t.Errorf("empty sig = %q, want empty", got)
+	}
+	if got := GetParamFromSig("not!!base64", "UserTier"); got != "" {
+		t.Errorf("invalid sig = %q, want empty", got)
+	}
+	// Many distinct sigs (settings changes, many users) must all read back
+	// correctly, whatever reuse the parsing path may employ.
+	for i := range 600 {
+		s := benchSig(strconv.Itoa(i))
+		want := "someone" + strconv.Itoa(i) + "@example.com"
+		if got := GetParamFromSig(s, "UserEmail"); got != want {
+			t.Fatalf("sig %d: UserEmail = %q, want %q", i, got, want)
+		}
+	}
+}
+
+// Meaningful under -race: page requests read the same sig from the handler
+// goroutine while API calls with other sigs run alongside.
+func TestGetParamFromSigConcurrent(t *testing.T) {
+	shared := benchSig("shared")
+	var wg sync.WaitGroup
+	for g := range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range 500 {
+				GetParamFromSig(shared, "UserTier")
+				GetParamFromSig(benchSig(strconv.Itoa(g*1000+i)), "UserEmail")
+			}
+		}()
+	}
+	wg.Wait()
+	if got := GetParamFromSig(shared, "UserTier"); got != "Vintage" {
+		t.Errorf("shared sig after churn = %q, want Vintage", got)
+	}
+}
+
+// One sig-param read, as handlers do for their feature flags.
+func BenchmarkGetParamFromSig(b *testing.B) {
+	sig := benchSig("")
+	b.ReportAllocs()
+	for b.Loop() {
+		GetParamFromSig(sig, "UserEmail")
+	}
+}
+
+// The full nav build for a signed-in user, as every handler runs it (and as
+// the signing middleware ran it a second time).
+func BenchmarkGenPageNav(b *testing.B) {
+	sig := benchSig("")
+	b.ReportAllocs()
+	for b.Loop() {
+		genPageNav("Search", sig)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -656,8 +656,11 @@ func ServeFile(w http.ResponseWriter, r *http.Request) {
 }
 
 func genPageNav(activeTab, sig string) PageVars {
-	exp := GetParamFromSig(sig, "Expires")
-	expires, _ := strconv.ParseInt(exp, 10, 64)
+	// Decode the sig once; this function reads it for expiry, every nav
+	// feature, and the user email, and each GetParamFromSig call would
+	// re-parse the whole thing.
+	sigParams := parseSig(sig)
+	expires, _ := strconv.ParseInt(sigParams.Get("Expires"), 10, 64)
 	msg := ""
 	showPatreonLogin := false
 	if sig != "" {
@@ -718,8 +721,7 @@ func genPageNav(activeTab, sig string) PageVars {
 
 		allowed := devMode || noAuth || alwaysOnDev || offline
 		if !allowed {
-			param := GetParamFromSig(sig, feat)
-			allowed, _ = strconv.ParseBool(param)
+			allowed, _ = strconv.ParseBool(sigParams.Get(feat))
 		}
 
 		if !allowed {
@@ -754,7 +756,7 @@ func genPageNav(activeTab, sig string) PageVars {
 	pageVars.HasSettings = pageVars.Nav[mainNavIndex].HasSettings
 
 	// Add user information if needed, or public
-	user := GetParamFromSig(sig, "UserEmail")
+	user := sigParams.Get("UserEmail")
 	if user == "" {
 		if !showPatreonLogin {
 			user = "Anonymous"


### PR DESCRIPTION
Third follow-up from the site-wide bottleneck review: signature re-parsing and the double nav build. No caching, no shared state — just parsing once where the code reads many params.

## Problem

`GetParamFromSig` base64-decodes and `url.ParseQuery`'s the **entire ~2KB signature on every call** (~6µs, 64 allocs per call), and a page request made dozens of calls: `genPageNav` consulted it for the expiry, every `OrderNav` feature, and the user email — a dozen full parses per nav build — while `enforceSigning` ran a **second, throwaway** `genPageNav("Error")` on every request (its feature-gate branch even built a third on top). Net effect: ~25 full parses, ~200KB of garbage, ~1,800 allocations per page view spent re-reading an immutable cookie.

## Fix — one commit per change

1. **`perf: parse the signature once in genPageNav`** — the decoding splits into a pure `parseSig(sig) url.Values` helper; `genPageNav` parses once and `Get`s its dozen params from the result. `GetParamFromSig` stays the one-shot wrapper for callers reading a single flag, with a comment steering multi-param readers to `parseSig`.
2. **`perf: build enforceSigning's error nav lazily`** — the error nav is constructed only inside the failing branches; nearly every request now runs `genPageNav` exactly once, in its handler.
3. **`perf: precompute the signed permission fields`** — `SignedFields` replaces the per-request `append(OrderNav, OptionalFields...)` in the signing and verification paths; both lists are fixed at startup, so the concatenation is computed once.

`enforceSigning`'s own decode/parse for HMAC verification is deliberately left inline: it runs once per request and its two error branches report distinct decode-vs-parse detail in DevMode.

## Measured (benchmarks in the first commit, reproducible on either side)

| | before | after | |
|---|---|---|---|
| `genPageNav` (full nav build) | 70.5 µs, 94 KB, 712 allocs | **8.1 µs, 14 KB, 74 allocs** | **8.7×** |
| `GetParamFromSig` (single read) | 5.9 µs, 64 allocs | unchanged by design | — |

Per request: ~2 nav builds + ~8 single reads ≈ **190 µs** before → 1 nav build + ~8 single reads ≈ **55 µs** after, with no global state added. The remaining cost is a handful of straight-line parses; if that ever matters, a request-scoped parse (context) is the next step — a global cache was considered and rejected.

## Verification

- Correctness tests: valid/invalid/empty sigs, 600 distinct sigs, concurrent readers — all under `-race`.
- Full main-package suite passes with the card datastore loaded; `gofmt`/`vet`/build clean; each commit builds green independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
