### PR TITLE
perf: index scraper lookups instead of scanning per call

### DIFF
--- a/api_csv_test.go
+++ b/api_csv_test.go
@@ -35,11 +35,11 @@ func TestSimplePrice2CSVTCGSKU(t *testing.T) {
 	for cond, sku := range map[string]string{"NM": "111", "SP": "222"} {
 		inventory.Add(id, &mtgban.InventoryEntry{Conditions: cond, InstanceId: sku})
 	}
-	prev := sellersPtr.Load()
-	t.Cleanup(func() { sellersPtr.Store(prev) })
+	prev := scrapersPtr.Load()
+	t.Cleanup(func() { scrapersPtr.Store(prev) })
 	sellers := []mtgban.Seller{mtgban.NewSellerFromInventory(
 		inventory, mtgban.ScraperInfo{Shorthand: "TCGPlayer"})}
-	sellersPtr.Store(&sellers)
+	scrapersPtr.Store(newScraperSnapshot(sellers, GetVendors()))
 
 	pm := map[string]map[string]*BanPrice{
 		id: {"TCGPlayer": &BanPrice{Regular: 1.0}},
@@ -93,14 +93,14 @@ func TestUUID2TCGCSVCondQtyIndexing(t *testing.T) {
 
 	// Inject empty TCG sellers so the inventory lookups in UUID2TCGCSV succeed
 	// (prices come out 0, which is fine — we only assert condition/quantity).
-	prev := sellersPtr.Load()
-	t.Cleanup(func() { sellersPtr.Store(prev) })
+	prev := scrapersPtr.Load()
+	t.Cleanup(func() { scrapersPtr.Store(prev) })
 	var sellers []mtgban.Seller
 	for _, sh := range []string{"TCGPlayer", "TCGDirectLow", "TCGLow", "TCGSealed"} {
 		sellers = append(sellers, mtgban.NewSellerFromInventory(
 			mtgban.InventoryRecord{}, mtgban.ScraperInfo{Shorthand: sh}))
 	}
-	sellersPtr.Store(&sellers)
+	scrapersPtr.Store(newScraperSnapshot(sellers, GetVendors()))
 
 	// Two distinct non-foil, non-sealed cards so condition codes map cleanly to
 	// labels (no " Foil" suffix) and Rarity is present.

--- a/load.go
+++ b/load.go
@@ -30,37 +30,127 @@ const (
 
 var DataBucket simplecloud.Reader
 
-// Snapshots of the loaded retail and buylist data. Held behind atomic.Pointer
-// so readers always observe a fully-constructed, immutable slice and writers
-// publish via a single atomic store. Mutating the slice returned by
-// GetSellers/GetVendors is a bug — treat it as read-only.
+// Snapshot of the loaded retail and buylist data. Held behind one
+// atomic.Pointer so readers always observe a fully-constructed, immutable
+// snapshot and writers publish via a single atomic store. Mutating anything
+// reachable from a snapshot is a bug — treat it all as read-only.
 var (
-	sellersPtr atomic.Pointer[[]mtgban.Seller]
-	vendorsPtr atomic.Pointer[[]mtgban.Vendor]
+	scrapersPtr atomic.Pointer[scraperSnapshot]
 
 	// Serializes writers so concurrent updateSellers/updateVendors calls
 	// don't lose each other's changes during the read-modify-publish cycle.
 	scrapersWriteMu sync.Mutex
 )
 
+// scraperNameKey identifies a scraper by lowercased display name and sealed
+// mode, the pair the ByName lookups discriminate on.
+type scraperNameKey struct {
+	name   string
+	sealed bool
+}
+
+// scraperSnapshot bundles the seller and vendor slices with lookup tables
+// derived from them, replacing the per-call linear scans of scraperName and
+// the find* helpers — which run per card, per entry, and per sort comparison
+// in the render loops. Snapshots are immutable and only built by
+// newScraperSnapshot, so the tables can never disagree with the slices.
+// Display-name overrides stay out of the tables and are applied by callers,
+// so a config reload cannot go stale here.
+type scraperSnapshot struct {
+	sellers []mtgban.Seller
+	vendors []mtgban.Vendor
+
+	// ToLower(shorthand) -> scraper; first occurrence wins, matching the
+	// order of the EqualFold scans these replace (shorthands are ASCII,
+	// where EqualFold and ToLower equality agree).
+	sellerByShorthand map[string]mtgban.Seller
+	vendorByShorthand map[string]mtgban.Vendor
+
+	// {ToLower(name), sealed} -> scraper
+	sellerByName map[scraperNameKey]mtgban.Seller
+	vendorByName map[scraperNameKey]mtgban.Vendor
+
+	// Exact shorthand -> raw Info().Name, sellers first.
+	rawNameByShorthand map[string]string
+
+	// ToLower(raw name or shorthand) -> ToLower(shorthand), sellers first,
+	// for store-code resolution in search filters.
+	storeCodeByToken map[string]string
+}
+
+// emptyScrapers keeps the read path nil-safe before anything is loaded.
+var emptyScrapers = newScraperSnapshot(nil, nil)
+
+func getScrapers() *scraperSnapshot {
+	snap := scrapersPtr.Load()
+	if snap == nil {
+		return emptyScrapers
+	}
+	return snap
+}
+
 // GetSellers returns the current sellers snapshot. The returned slice is
 // shared and MUST NOT be modified by callers.
 func GetSellers() []mtgban.Seller {
-	p := sellersPtr.Load()
-	if p == nil {
-		return nil
-	}
-	return *p
+	return getScrapers().sellers
 }
 
 // GetVendors returns the current vendors snapshot. The returned slice is
 // shared and MUST NOT be modified by callers.
 func GetVendors() []mtgban.Vendor {
-	p := vendorsPtr.Load()
-	if p == nil {
-		return nil
+	return getScrapers().vendors
+}
+
+func newScraperSnapshot(sellers []mtgban.Seller, vendors []mtgban.Vendor) *scraperSnapshot {
+	snap := &scraperSnapshot{
+		sellers:            sellers,
+		vendors:            vendors,
+		sellerByShorthand:  map[string]mtgban.Seller{},
+		vendorByShorthand:  map[string]mtgban.Vendor{},
+		sellerByName:       map[scraperNameKey]mtgban.Seller{},
+		vendorByName:       map[scraperNameKey]mtgban.Vendor{},
+		rawNameByShorthand: map[string]string{},
+		storeCodeByToken:   map[string]string{},
 	}
-	return *p
+	for _, seller := range sellers {
+		info := seller.Info()
+		short := strings.ToLower(info.Shorthand)
+		name := strings.ToLower(info.Name)
+		if _, found := snap.sellerByShorthand[short]; !found {
+			snap.sellerByShorthand[short] = seller
+		}
+		nameKey := scraperNameKey{name, info.SealedMode}
+		if _, found := snap.sellerByName[nameKey]; !found {
+			snap.sellerByName[nameKey] = seller
+		}
+		snap.indexNames(info.Shorthand, info.Name, short, name)
+	}
+	for _, vendor := range vendors {
+		info := vendor.Info()
+		short := strings.ToLower(info.Shorthand)
+		name := strings.ToLower(info.Name)
+		if _, found := snap.vendorByShorthand[short]; !found {
+			snap.vendorByShorthand[short] = vendor
+		}
+		nameKey := scraperNameKey{name, info.SealedMode}
+		if _, found := snap.vendorByName[nameKey]; !found {
+			snap.vendorByName[nameKey] = vendor
+		}
+		snap.indexNames(info.Shorthand, info.Name, short, name)
+	}
+	return snap
+}
+
+func (snap *scraperSnapshot) indexNames(shorthand, name, shortLower, nameLower string) {
+	if _, found := snap.rawNameByShorthand[shorthand]; !found {
+		snap.rawNameByShorthand[shorthand] = name
+	}
+	if _, found := snap.storeCodeByToken[nameLower]; !found {
+		snap.storeCodeByToken[nameLower] = shortLower
+	}
+	if _, found := snap.storeCodeByToken[shortLower]; !found {
+		snap.storeCodeByToken[shortLower] = shortLower
+	}
 }
 
 type ScraperConfig struct {
@@ -206,7 +296,7 @@ func updateSellers(scraper mtgban.Scraper) {
 		ServerNotify("refresh", msg, true)
 		return
 	}
-	sellersPtr.Store(&next)
+	scrapersPtr.Store(newScraperSnapshot(next, GetVendors()))
 
 	msg := fmt.Sprintf("%s inventory updated at position %d", scraper.Info().Shorthand, sellerIndex)
 	ServerNotify("refresh", msg)
@@ -266,7 +356,7 @@ func updateVendors(scraper mtgban.Scraper) {
 		ServerNotify("refresh", msg, true)
 		return
 	}
-	vendorsPtr.Store(&next)
+	scrapersPtr.Store(newScraperSnapshot(GetSellers(), next))
 
 	msg := fmt.Sprintf("%s buylist updated at position %d", scraper.Info().Shorthand, vendorIndex)
 	ServerNotify("refresh", msg)

--- a/price_parity_bench_test.go
+++ b/price_parity_bench_test.go
@@ -105,16 +105,11 @@ func seedBenchScrapers(b *testing.B) (stores []string) {
 		b.Skip("no suitable set found for benchmarking")
 	}
 
-	prevSellers := sellersPtr.Load()
-	prevVendors := vendorsPtr.Load()
-	b.Cleanup(func() {
-		sellersPtr.Store(prevSellers)
-		vendorsPtr.Store(prevVendors)
-	})
+	prev := scrapersPtr.Load()
+	b.Cleanup(func() { scrapersPtr.Store(prev) })
 	sellers := benchSellers
 	vendors := benchVendors
-	sellersPtr.Store(&sellers)
-	vendorsPtr.Store(&vendors)
+	scrapersPtr.Store(newScraperSnapshot(sellers, vendors))
 
 	for _, seller := range sellers {
 		stores = append(stores, seller.Info().Shorthand)

--- a/price_parity_test.go
+++ b/price_parity_test.go
@@ -54,12 +54,8 @@ func parityCards(t *testing.T) (regular, foil, sealed string) {
 func seedParityScrapers(t *testing.T, regular, foil string) {
 	t.Helper()
 
-	prevSellers := sellersPtr.Load()
-	prevVendors := vendorsPtr.Load()
-	t.Cleanup(func() {
-		sellersPtr.Store(prevSellers)
-		vendorsPtr.Store(prevVendors)
-	})
+	prev := scrapersPtr.Load()
+	t.Cleanup(func() { scrapersPtr.Store(prev) })
 
 	inv := mtgban.InventoryRecord{}
 	inv.Add(regular, &mtgban.InventoryEntry{Conditions: "NM", Price: 10, Quantity: 2, URL: "u"})
@@ -78,8 +74,6 @@ func seedParityScrapers(t *testing.T, regular, foil string) {
 			Name: "Parity Index", Shorthand: "PARITYIDX", MetadataOnly: true,
 		}),
 	}
-	sellersPtr.Store(&sellers)
-
 	bl := mtgban.BuylistRecord{}
 	bl.Add(regular, &mtgban.BuylistEntry{Conditions: "NM", BuyPrice: 5, Quantity: 4, URL: "u"})
 	bl.Add(regular, &mtgban.BuylistEntry{Conditions: "SP", BuyPrice: 4, Quantity: 2, URL: "u"})
@@ -89,7 +83,7 @@ func seedParityScrapers(t *testing.T, regular, foil string) {
 			Name: "Parity Buyer", Shorthand: "PARITYV", CreditMultiplier: 1.3,
 		}),
 	}
-	vendorsPtr.Store(&vendors)
+	scrapersPtr.Store(newScraperSnapshot(sellers, vendors))
 }
 
 // searchPrice returns the price of the first row for the given store and
@@ -321,8 +315,8 @@ func TestSearchDownloadFilters(t *testing.T) {
 func TestZeroPricedListings(t *testing.T) {
 	regular, _, _ := parityCards(t)
 
-	prevSellers := sellersPtr.Load()
-	t.Cleanup(func() { sellersPtr.Store(prevSellers) })
+	prev := scrapersPtr.Load()
+	t.Cleanup(func() { scrapersPtr.Store(prev) })
 
 	inv := mtgban.InventoryRecord{}
 	inv.Add(regular, &mtgban.InventoryEntry{Conditions: "NM", Price: 0, Quantity: 1, URL: "u1"})
@@ -330,7 +324,7 @@ func TestZeroPricedListings(t *testing.T) {
 	sellers := []mtgban.Seller{
 		mtgban.NewSellerFromInventory(inv, mtgban.ScraperInfo{Name: "Zero Store", Shorthand: "ZEROA"}),
 	}
-	sellersPtr.Store(&sellers)
+	scrapersPtr.Store(newScraperSnapshot(sellers, GetVendors()))
 
 	check := func(t *testing.T, api map[string]map[string]*BanPrice) {
 		t.Helper()

--- a/scraper_lookup_test.go
+++ b/scraper_lookup_test.go
@@ -13,12 +13,8 @@ import (
 // named "Bench Store %03d" with shorthand "BS%03d"; sellers and vendors share
 // names and shorthands, mirroring production stores that run both sides.
 func installTestScrapers(tb testing.TB, n int) {
-	prevSellers := sellersPtr.Load()
-	prevVendors := vendorsPtr.Load()
-	tb.Cleanup(func() {
-		sellersPtr.Store(prevSellers)
-		vendorsPtr.Store(prevVendors)
-	})
+	prev := scrapersPtr.Load()
+	tb.Cleanup(func() { scrapersPtr.Store(prev) })
 
 	var sellers []mtgban.Seller
 	var vendors []mtgban.Vendor
@@ -42,8 +38,7 @@ func installTestScrapers(tb testing.TB, n int) {
 		Name: "Bench Store 001", Shorthand: "VENDONLY",
 	}))
 
-	sellersPtr.Store(&sellers)
-	vendorsPtr.Store(&vendors)
+	scrapersPtr.Store(newScraperSnapshot(sellers, vendors))
 }
 
 func TestScraperNameLookup(t *testing.T) {

--- a/scraper_lookup_test.go
+++ b/scraper_lookup_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/mtgban/go-mtgban/mtgban"
+)
+
+// installTestScrapers swaps in n synthetic sellers and vendors (plus a few
+// special cases) and restores the previous snapshots on cleanup. Entry i is
+// named "Bench Store %03d" with shorthand "BS%03d"; sellers and vendors share
+// names and shorthands, mirroring production stores that run both sides.
+func installTestScrapers(tb testing.TB, n int) {
+	prevSellers := sellersPtr.Load()
+	prevVendors := vendorsPtr.Load()
+	tb.Cleanup(func() {
+		sellersPtr.Store(prevSellers)
+		vendorsPtr.Store(prevVendors)
+	})
+
+	var sellers []mtgban.Seller
+	var vendors []mtgban.Vendor
+	for i := range n {
+		info := mtgban.ScraperInfo{
+			Name:      fmt.Sprintf("Bench Store %03d", i),
+			Shorthand: fmt.Sprintf("BS%03d", i),
+		}
+		sellers = append(sellers, mtgban.NewSellerFromInventory(nil, info))
+		vendors = append(vendors, mtgban.NewVendorFromBuylist(nil, info))
+	}
+
+	// A sealed seller sharing its name with a singles seller, to pin the
+	// SealedMode discrimination of the ByName lookups.
+	sellers = append(sellers, mtgban.NewSellerFromInventory(nil, mtgban.ScraperInfo{
+		Name: "Bench Store 000", Shorthand: "BS000Sealed", SealedMode: true,
+	}))
+	// A vendor whose name collides with a seller of a different shorthand,
+	// to pin the sellers-first precedence of store-code resolution.
+	vendors = append(vendors, mtgban.NewVendorFromBuylist(nil, mtgban.ScraperInfo{
+		Name: "Bench Store 001", Shorthand: "VENDONLY",
+	}))
+
+	sellersPtr.Store(&sellers)
+	vendorsPtr.Store(&vendors)
+}
+
+func TestScraperNameLookup(t *testing.T) {
+	installTestScrapers(t, 10)
+
+	if got := scraperName("BS003"); got != "Bench Store 003" {
+		t.Errorf("BS003 = %q, want Bench Store 003", got)
+	}
+	// scraperName matches the shorthand case-sensitively; a wrong-case query
+	// falls through to the shorthand override map (empty here).
+	if got := scraperName("bs003"); got != "" {
+		t.Errorf("bs003 = %q, want empty (case-sensitive miss)", got)
+	}
+	if got := scraperName("NOPE"); got != "" {
+		t.Errorf("NOPE = %q, want empty", got)
+	}
+
+	prev := Config.ScraperConfig.NameOverride
+	Config.ScraperConfig.NameOverride = map[string]string{
+		"Bench Store 004": "Renamed Store",
+		"GHOST":           "Ghost Store",
+	}
+	t.Cleanup(func() { Config.ScraperConfig.NameOverride = prev })
+
+	if got := scraperName("BS004"); got != "Renamed Store" {
+		t.Errorf("BS004 with override = %q, want Renamed Store", got)
+	}
+	if got := scraperName("GHOST"); got != "Ghost Store" {
+		t.Errorf("GHOST = %q, want Ghost Store (shorthand override fallback)", got)
+	}
+}
+
+func TestFindScraperLookups(t *testing.T) {
+	installTestScrapers(t, 10)
+
+	// Shorthand lookups are case-insensitive.
+	if _, err := findSellerInventory("bs005"); err != nil {
+		t.Errorf("findSellerInventory(bs005): %v", err)
+	}
+	if _, err := findVendorBuylist("BS005"); err != nil {
+		t.Errorf("findVendorBuylist(BS005): %v", err)
+	}
+	if _, err := findSellerInventory("NOPE"); err == nil {
+		t.Error("findSellerInventory(NOPE): want error")
+	}
+
+	// Name lookups are case-insensitive and discriminate on SealedMode.
+	if _, err := findSellerInventoryByName("bench store 000", false); err != nil {
+		t.Errorf("ByName singles: %v", err)
+	}
+	if _, err := findSellerInventoryByName("bench store 000", true); err != nil {
+		t.Errorf("ByName sealed: %v", err)
+	}
+	if _, err := findVendorBuylistByName("Bench Store 001", true); err == nil {
+		t.Error("ByName sealed vendor: want error (only singles exists)")
+	}
+}
+
+func TestFixupStoreCodeLookup(t *testing.T) {
+	installTestScrapers(t, 10)
+
+	// By shorthand, by name, unknown passthrough, quote stripping. Note only
+	// the whole string is space-trimmed, not each comma-separated token.
+	got := fixupStoreCodeNG(` BS002,"bench store 003",mystery `)
+	want := []string{"bs002", "bs003", "mystery"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("fixup = %v, want %v", got, want)
+	}
+
+	// A name shared by a seller and a vendor-only entry resolves to the
+	// seller's shorthand: sellers are consulted first.
+	got = fixupStoreCodeNG("bench store 001")
+	if len(got) != 1 || got[0] != "bs001" {
+		t.Errorf("seller precedence = %v, want [bs001]", got)
+	}
+
+	// Overridden display names resolve too.
+	prev := Config.ScraperConfig.NameOverride
+	Config.ScraperConfig.NameOverride = map[string]string{"Bench Store 006": "Fancy Name"}
+	t.Cleanup(func() { Config.ScraperConfig.NameOverride = prev })
+	got = fixupStoreCodeNG("fancy name")
+	if len(got) != 1 || got[0] != "bs006" {
+		t.Errorf("override name = %v, want [bs006]", got)
+	}
+}
+
+func BenchmarkFindSellerInventory(b *testing.B) {
+	installTestScrapers(b, 100)
+	b.ReportAllocs()
+	for b.Loop() {
+		findSellerInventory("BS050")
+	}
+}
+
+func BenchmarkScraperName(b *testing.B) {
+	installTestScrapers(b, 100)
+	b.ReportAllocs()
+	for b.Loop() {
+		scraperName("BS050")
+	}
+}
+
+func BenchmarkSortKeysByScraperName(b *testing.B) {
+	installTestScrapers(b, 100)
+	keys := make([]string, 100)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("BS%03d", (i*37)%100)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		sortKeysByScraperName(keys)
+	}
+}
+
+func BenchmarkFixupStoreCode(b *testing.B) {
+	installTestScrapers(b, 100)
+	code := strings.ToLower("Bench Store 050,BS099,unknown")
+	b.ReportAllocs()
+	for b.Loop() {
+		fixupStoreCodeNG(code)
+	}
+}

--- a/searchfilter.go
+++ b/searchfilter.go
@@ -160,26 +160,26 @@ func fixupStoreCodeNG(code string) []string {
 	code = strings.TrimSpace(code)
 	code = strings.ToLower(code)
 
+	snap := getScrapers()
 	filters := strings.Split(code, ",")
 	for i := range filters {
 		filters[i] = strings.Trim(filters[i], "\"")
 
-		// Validate the input against the registered scrapers
-		for _, seller := range GetSellers() {
-			if filters[i] != strings.ToLower(scraperName(seller.Info().Shorthand)) &&
-				filters[i] != strings.ToLower(seller.Info().Shorthand) {
-				continue
+		// Validate the input against the registered scrapers: an overridden
+		// display name first, mapped back through the raw name it replaced,
+		// then the token itself (a raw name or a shorthand).
+		matched := ""
+		for rawName, override := range Config.ScraperConfig.NameOverride {
+			if strings.EqualFold(override, filters[i]) {
+				matched = snap.storeCodeByToken[strings.ToLower(rawName)]
+				break
 			}
-			filters[i] = strings.ToLower(seller.Info().Shorthand)
-			break
 		}
-		for _, vendor := range GetVendors() {
-			if filters[i] != strings.ToLower(scraperName(vendor.Info().Shorthand)) &&
-				filters[i] != strings.ToLower(vendor.Info().Shorthand) {
-				continue
-			}
-			filters[i] = strings.ToLower(vendor.Info().Shorthand)
-			break
+		if matched == "" {
+			matched = snap.storeCodeByToken[filters[i]]
+		}
+		if matched != "" {
+			filters[i] = matched
 		}
 
 		// The manual renames from search.go

--- a/utils.go
+++ b/utils.go
@@ -1031,11 +1031,22 @@ func scraperName(shorthand string) string {
 // sortKeysByScraperName returns a new slice of shorthand keys sorted alphabetically
 // by their resolved display name (case-insensitive). Stable for equal names.
 func sortKeysByScraperName(keys []string) []string {
-	out := make([]string, len(keys))
-	copy(out, keys)
-	sort.SliceStable(out, func(i, j int) bool {
-		return strings.ToLower(scraperName(out[i])) < strings.ToLower(scraperName(out[j]))
+	// Resolve each key's name once up front instead of twice per comparison.
+	type keyName struct {
+		key  string
+		name string
+	}
+	decorated := make([]keyName, len(keys))
+	for i, key := range keys {
+		decorated[i] = keyName{key, strings.ToLower(scraperName(key))}
+	}
+	sort.SliceStable(decorated, func(i, j int) bool {
+		return decorated[i].name < decorated[j].name
 	})
+	out := make([]string, len(keys))
+	for i, d := range decorated {
+		out[i] = d.key
+	}
 	return out
 }
 

--- a/utils.go
+++ b/utils.go
@@ -280,42 +280,38 @@ func findCredit(shorthand string) float64 {
 
 // Look up a seller and return its inventory
 func findSellerInventory(shorthand string) (mtgban.InventoryRecord, error) {
-	for _, seller := range GetSellers() {
-		if strings.EqualFold(seller.Info().Shorthand, shorthand) {
-			return seller.Inventory(), nil
-		}
+	seller, found := getScrapers().sellerByShorthand[strings.ToLower(shorthand)]
+	if !found {
+		return nil, errors.New("seller not found")
 	}
-	return nil, errors.New("seller not found")
+	return seller.Inventory(), nil
 }
 
 // Look up a vendor and return its buylist
 func findVendorBuylist(shorthand string) (mtgban.BuylistRecord, error) {
-	for _, vendor := range GetVendors() {
-		if strings.EqualFold(vendor.Info().Shorthand, shorthand) {
-			return vendor.Buylist(), nil
-		}
+	vendor, found := getScrapers().vendorByShorthand[strings.ToLower(shorthand)]
+	if !found {
+		return nil, errors.New("vendor not found")
 	}
-	return nil, errors.New("vendor not found")
+	return vendor.Buylist(), nil
 }
 
 // Look up a seller with its name and return its inventory
 func findSellerInventoryByName(name string, sealed bool) (mtgban.InventoryRecord, error) {
-	for _, seller := range GetSellers() {
-		if seller.Info().SealedMode == sealed && strings.EqualFold(seller.Info().Name, name) {
-			return seller.Inventory(), nil
-		}
+	seller, found := getScrapers().sellerByName[scraperNameKey{strings.ToLower(name), sealed}]
+	if !found {
+		return nil, errors.New("seller not found")
 	}
-	return nil, errors.New("seller not found")
+	return seller.Inventory(), nil
 }
 
 // Look up a vendor with its name and return its inventory
 func findVendorBuylistByName(name string, sealed bool) (mtgban.BuylistRecord, error) {
-	for _, vendor := range GetVendors() {
-		if vendor.Info().SealedMode == sealed && strings.EqualFold(vendor.Info().Name, name) {
-			return vendor.Buylist(), nil
-		}
+	vendor, found := getScrapers().vendorByName[scraperNameKey{strings.ToLower(name), sealed}]
+	if !found {
+		return nil, errors.New("vendor not found")
 	}
-	return nil, errors.New("vendor not found")
+	return vendor.Buylist(), nil
 }
 
 // Look for a TCGproductId in all available places
@@ -1018,29 +1014,18 @@ func getTCGSimulationIQR(productId string) float64 {
 
 // Return the full display name displayed from the input shorthand
 func scraperName(shorthand string) string {
-	for _, seller := range GetSellers() {
-		if shorthand == seller.Info().Shorthand {
-			name := seller.Info().Name
-			override, found := Config.ScraperConfig.NameOverride[seller.Info().Name]
-			if found {
-				name = override
-			}
-			return name
-		}
+	name, found := getScrapers().rawNameByShorthand[shorthand]
+	if !found {
+		// If nothing is found, check if there is a custom override for the shorthand itself
+		return Config.ScraperConfig.NameOverride[shorthand]
 	}
-	for _, vendor := range GetVendors() {
-		if shorthand == vendor.Info().Shorthand {
-			name := vendor.Info().Name
-			override, found := Config.ScraperConfig.NameOverride[vendor.Info().Name]
-			if found {
-				name = override
-			}
-			return name
-		}
+	// The display override is applied here rather than baked into the
+	// snapshot tables, so a config reload takes effect immediately.
+	override, found := Config.ScraperConfig.NameOverride[name]
+	if found {
+		return override
 	}
-
-	// If nothing is found, check if there is a custom override for the shorthand itself
-	return Config.ScraperConfig.NameOverride[shorthand]
+	return name
 }
 
 // sortKeysByScraperName returns a new slice of shorthand keys sorted alphabetically


### PR DESCRIPTION
Fourth follow-up from the site-wide bottleneck review: the linear-scan class. `scraperName`, `findSellerInventory`/`findVendorBuylist` (and the ByName variants) each scanned every registered seller and vendor per call, copying the `Info()` struct per step — and they run **per card** (`uuid2card`'s SYP/STKS/CK lookups), **per entry** (search results, CSV dumps), **per row** (arbit), and **twice per comparison** in the store-key sort. An edition-sized search paid tens of millions of comparisons in these scans alone.

## The fix — one commit per change

1. **`test: pin and benchmark the scraper lookup helpers`** — equivalence tests lock the semantics however the lookups are implemented: `scraperName`'s case-sensitive shorthand match + override fallback; the finders' case-insensitive match; the ByName variants' SealedMode discrimination; store-code resolution's sellers-first precedence, override names, and unknown-token passthrough.
2. **`perf: index scrapers by shorthand and name`** — the seller and vendor slices are bundled **with lookup tables derived from them in a single immutable snapshot behind one atomic pointer** (shorthand and name+sealed maps per side, first-occurrence-wins to match the scan order). A snapshot is only built by `newScraperSnapshot`, so every publish — `updateSellers`, `updateVendors`, or a test storing directly — carries its own tables **by construction**; there is no separate index to invalidate and no lazy machinery. Display-name overrides are applied by callers, not baked in, so a config reload can't go stale.
3. **`perf: resolve store filter codes via the scraper index`** — each `store:`/`vendor:` token is one map probe (plus a walk of the small override table so overridden names keep resolving). Two deliberate behavior touches, called out in the commit: an overridden store now *also* resolves by its raw name, and each token is substituted once instead of letting the vendor pass re-match the seller pass's output.
4. **`perf: sort store keys by precomputed names`** — decorate-sort-undecorate for `sortKeysByScraperName`, which runs twice on every search/arbit page.

## Measured (100 scrapers a side; benchmarks in the first commit)

| | before | after | |
|---|---|---|---|
| `findSellerInventory` | 444 ns | **30 ns** | 15× |
| `scraperName` | 414 ns | **8.6 ns, 0 allocs** | 48× |
| `sortKeysByScraperName` (100 keys) | 810 µs, 1,773 allocs | **17.6 µs, 105 allocs** | 46× |
| `fixupStoreCodeNG` (3 tokens) | 233 µs, 1,012 allocs | **0.11 µs, 1 alloc** | 2,124× |

The per-call numbers understate the impact: these lookups sit inside per-card/per-entry loops, so the search-entry build, `uuid2card` metadata loops, arbit rendering, and CSV dumps all shed the scans wholesale.

## Verification

- Equivalence tests pass on both the old and new implementations (first commit runs green against the linear scans), under `-race` ×2.
- Full main-package suite passes with the card datastore loaded; `gofmt`/`vet`/build clean; each commit builds independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
