### PR TITLE
perf: resolve sorting data and prices once per sort

### DIFF
--- a/api.go
+++ b/api.go
@@ -741,18 +741,19 @@ func SearchAPI(w http.ResponseWriter, r *http.Request) {
 
 	// Sort results to match the search page order
 	sortOpt := r.FormValue("sort")
+	sortData := resolveSortingData(allKeys)
 	switch sortOpt {
 	case "alpha":
 		sort.Slice(allKeys, func(i, j int) bool {
-			return sortSetsAlphabetical(allKeys[i], allKeys[j], false)
+			return cmpSetsAlphabetical(sortData[allKeys[i]], sortData[allKeys[j]], false)
 		})
 	case "number":
 		sort.Slice(allKeys, func(i, j int) bool {
-			return sortByNumberAndFinish(allKeys[i], allKeys[j], false)
+			return cmpNumberAndFinish(sortData[allKeys[i]], sortData[allKeys[j]], false)
 		})
 	default:
 		sort.Slice(allKeys, func(i, j int) bool {
-			return sortSets(allKeys[i], allKeys[j])
+			return cmpSets(sortData[allKeys[i]], sortData[allKeys[j]])
 		})
 	}
 	reverseSort, _ := strconv.ParseBool(r.FormValue("reverse"))

--- a/arbit.go
+++ b/arbit.go
@@ -287,10 +287,20 @@ func init() {
 	}
 }
 
-// arbitLess returns the comparator for the given sort mode, or nil for
-// unknown modes (caller leaves the slice unsorted, matching the prior
-// switch's absence of a default case).
-func arbitLess(mode string, globalMode, preferFlavor bool) func(a, b *mtgban.ArbitEntry) bool {
+// arbitCardIds collects the card id of every entry, for resolving their
+// sorting data in one pass.
+func arbitCardIds(entries []mtgban.ArbitEntry) []string {
+	cardIds := make([]string, len(entries))
+	for i := range entries {
+		cardIds[i] = entries[i].CardId
+	}
+	return cardIds
+}
+
+// arbitLess returns the comparator for sorting entries in the given
+// mode, or nil for unknown modes (caller leaves the slice unsorted,
+// matching the prior switch's absence of a default case).
+func arbitLess(entries []mtgban.ArbitEntry, mode string, globalMode, preferFlavor bool) func(a, b *mtgban.ArbitEntry) bool {
 	switch mode {
 	case "available":
 		return func(a, b *mtgban.ArbitEntry) bool {
@@ -327,18 +337,20 @@ func arbitLess(mode string, globalMode, preferFlavor bool) func(a, b *mtgban.Arb
 			return a.Spread > b.Spread
 		}
 	case "edition":
+		sortData := resolveSortingData(arbitCardIds(entries))
 		return func(a, b *mtgban.ArbitEntry) bool {
 			if a.CardId == b.CardId {
 				return a.InventoryEntry.Conditions < b.InventoryEntry.Conditions
 			}
-			return sortSets(a.CardId, b.CardId)
+			return cmpSets(sortData[a.CardId], sortData[b.CardId])
 		}
 	case "alpha":
+		sortData := resolveSortingData(arbitCardIds(entries))
 		return func(a, b *mtgban.ArbitEntry) bool {
 			if a.CardId == b.CardId {
 				return a.InventoryEntry.Conditions < b.InventoryEntry.Conditions
 			}
-			return sortSetsAlphabetical(a.CardId, b.CardId, preferFlavor)
+			return cmpSetsAlphabetical(sortData[a.CardId], sortData[b.CardId], preferFlavor)
 		}
 	}
 	return nil
@@ -880,7 +892,8 @@ func scraperCompare(w http.ResponseWriter, r *http.Request, pageVars PageVars, a
 		if sorting == "" {
 			sorting = DefaultSortingOption
 		}
-		if less := arbitLess(sorting, pageVars.GlobalMode, preferFlavor); less != nil {
+		less := arbitLess(arbit, sorting, pageVars.GlobalMode, preferFlavor)
+		if less != nil {
 			sort.Slice(arbit, func(i, j int) bool { return less(&arbit[i], &arbit[j]) })
 		}
 		pageVars.SortOption = sorting

--- a/discord.go
+++ b/discord.go
@@ -207,8 +207,9 @@ func parseMessage(content string, sealed bool) (*EmbedSearchResult, string) {
 	}
 
 	// Keep the first (most recent) result
+	sortData := resolveSortingData(uuids)
 	sort.Slice(uuids, func(i, j int) bool {
-		return sortSets(uuids[i], uuids[j])
+		return cmpSets(sortData[uuids[i]], sortData[uuids[j]])
 	})
 	cardId := uuids[0]
 

--- a/embed.go
+++ b/embed.go
@@ -60,8 +60,9 @@ func ProcessEmbedSearchResultsSellers(foundSellers map[string]map[string][]Searc
 		sortedKeysSeller = append(sortedKeysSeller, cardId)
 	}
 	if len(sortedKeysSeller) > 1 {
+		sortData := resolveSortingData(sortedKeysSeller)
 		sort.Slice(sortedKeysSeller, func(i, j int) bool {
-			return sortSets(sortedKeysSeller[i], sortedKeysSeller[j])
+			return cmpSets(sortData[sortedKeysSeller[i]], sortData[sortedKeysSeller[j]])
 		})
 	}
 
@@ -131,8 +132,9 @@ func ProcessEmbedSearchResultsVendors(foundVendors map[string]map[string][]Searc
 		sortedKeysVendor = append(sortedKeysVendor, cardId)
 	}
 	if len(sortedKeysVendor) > 1 {
+		sortData := resolveSortingData(sortedKeysVendor)
 		sort.Slice(sortedKeysVendor, func(i, j int) bool {
-			return sortSets(sortedKeysVendor[i], sortedKeysVendor[j])
+			return cmpSets(sortData[sortedKeysVendor[i]], sortData[sortedKeysVendor[j]])
 		})
 	}
 

--- a/news.go
+++ b/news.go
@@ -1155,18 +1155,20 @@ func Newspaper(w http.ResponseWriter, r *http.Request) {
 
 		switch sorting {
 		default:
+			sortData := resolveSortingData(arbitCardIds(arbit))
 			sort.Slice(arbit, func(i, j int) bool {
 				if arbit[i].CardId == arbit[j].CardId {
 					return arbit[i].InventoryEntry.Conditions < arbit[j].InventoryEntry.Conditions
 				}
-				return sortSets(arbit[i].CardId, arbit[j].CardId)
+				return cmpSets(sortData[arbit[i].CardId], sortData[arbit[j].CardId])
 			})
 		case "alpha":
+			sortData := resolveSortingData(arbitCardIds(arbit))
 			sort.Slice(arbit, func(i, j int) bool {
 				if arbit[i].CardId == arbit[j].CardId {
 					return arbit[i].InventoryEntry.Conditions < arbit[j].InventoryEntry.Conditions
 				}
-				return sortSetsAlphabetical(arbit[i].CardId, arbit[j].CardId, preferFlavor)
+				return cmpSetsAlphabetical(sortData[arbit[i].CardId], sortData[arbit[j].CardId], preferFlavor)
 			})
 		case "available":
 			sort.Slice(arbit, func(i, j int) bool {

--- a/popular.go
+++ b/popular.go
@@ -69,8 +69,14 @@ func getPopularSearches() []PopularSearch {
 		// searchAndFilter doesn't apply sort:retail (that needs live
 		// prices), so sort here and take the top-retail card as the tile.
 		if config.SortMode == "retail" {
+			sortData := resolveSortingData(uuids)
+			prices := resolveBestPrices(uuids, defaultSellerPriorityOpt, price4seller)
 			sort.Slice(uuids, func(i, j int) bool {
-				return sortSetsByRetail(uuids[i], uuids[j], defaultSellerPriorityOpt)
+				priceI, priceJ := prices[uuids[i]], prices[uuids[j]]
+				if priceI == priceJ {
+					return cmpSets(sortData[uuids[i]], sortData[uuids[j]])
+				}
+				return priceI > priceJ
 			})
 		}
 		imageID := uuids[0]

--- a/search.go
+++ b/search.go
@@ -511,8 +511,14 @@ func Search(w http.ResponseWriter, r *http.Request) {
 			retSellers = append([]string{retSeller}, defaultSellerPriorityOpt...)
 		}
 
+		sortData := resolveSortingData(allKeys)
+		prices := resolveBestPrices(allKeys, retSellers, price4seller)
 		sort.Slice(allKeys, func(i, j int) bool {
-			return sortSetsByRetail(allKeys[i], allKeys[j], retSellers)
+			priceI, priceJ := prices[allKeys[i]], prices[allKeys[j]]
+			if priceI == priceJ {
+				return cmpSets(sortData[allKeys[i]], sortData[allKeys[j]])
+			}
+			return priceI > priceJ
 		})
 	case "buylist":
 		blVendors := defaultVendorPriorityOpt
@@ -521,8 +527,19 @@ func Search(w http.ResponseWriter, r *http.Request) {
 			blVendors = append([]string{blVendor}, defaultVendorPriorityOpt...)
 		}
 
+		sortData := resolveSortingData(allKeys)
+		buyPrices := resolveBestPrices(allKeys, blVendors, price4vendor)
+		retPrices := resolveBestPrices(allKeys, defaultSellerPriorityOpt, price4seller)
 		sort.Slice(allKeys, func(i, j int) bool {
-			return sortSetsByBuylist(allKeys[i], allKeys[j], blVendors)
+			priceI, priceJ := buyPrices[allKeys[i]], buyPrices[allKeys[j]]
+			if priceI != priceJ {
+				return priceI > priceJ
+			}
+			priceI, priceJ = retPrices[allKeys[i]], retPrices[allKeys[j]]
+			if priceI != priceJ {
+				return priceI > priceJ
+			}
+			return cmpSets(sortData[allKeys[i]], sortData[allKeys[j]])
 		})
 	default:
 		sortData := resolveSortingData(allKeys)
@@ -1627,6 +1644,29 @@ func resolveSortingData(cardIds []string) map[string]*SortingData {
 	return data
 }
 
+// resolveBestPrices records the highest price every given id fetches
+// among the listed stores: each price4seller/price4vendor call walks
+// the scraper list, so the price sorts must not repeat it per
+// comparison, let alone N log N times.
+func resolveBestPrices(cardIds []string, stores []string, price4 func(cardId, shorthand string) float64) map[string]float64 {
+	prices := make(map[string]float64, len(cardIds))
+	for _, cardId := range cardIds {
+		_, found := prices[cardId]
+		if found {
+			continue
+		}
+		var best float64
+		for _, store := range stores {
+			price := price4(cardId, store)
+			if price > best {
+				best = price
+			}
+		}
+		prices[cardId] = best
+	}
+	return prices
+}
+
 // Sort cards by their collector number and finish (nonfoil-foil-etched)
 func sortByNumberAndFinish(uuidI, uuidJ string, strip bool) bool {
 	sortingI, _ := getSortingData(uuidI)
@@ -1816,52 +1856,4 @@ func cmpSetsAlphabeticalSet(sortingI, sortingJ *SortingData, preferFlavor bool) 
 	}
 
 	return sortingI.editionLower < sortingJ.editionLower
-}
-
-// Sort cards using the highest price among to the sellers in the input slice
-// If same price is found, sort as normal
-func sortSetsByRetail(uuidI, uuidJ string, retSellers []string) bool {
-	var priceI, priceJ float64
-	for _, retSeller := range retSellers {
-		price := price4seller(uuidI, retSeller)
-		if price > priceI {
-			priceI = price
-		}
-	}
-	for _, retSeller := range retSellers {
-		price := price4seller(uuidJ, retSeller)
-		if price > priceJ {
-			priceJ = price
-		}
-	}
-
-	if priceI == priceJ {
-		return sortSets(uuidI, uuidJ)
-	}
-
-	return priceI > priceJ
-}
-
-// Sort cards using the highest price among to the vendors in the input slice
-// If same price is found, sort by the highest retail price
-func sortSetsByBuylist(uuidI, uuidJ string, blVendors []string) bool {
-	var priceI, priceJ float64
-	for _, blVendor := range blVendors {
-		price := price4vendor(uuidI, blVendor)
-		if price > priceI {
-			priceI = price
-		}
-	}
-	for _, blVendor := range blVendors {
-		price := price4vendor(uuidJ, blVendor)
-		if price > priceJ {
-			priceJ = price
-		}
-	}
-
-	if priceI == priceJ {
-		return sortSetsByRetail(uuidI, uuidJ, defaultSellerPriorityOpt)
-	}
-
-	return priceI > priceJ
 }

--- a/search.go
+++ b/search.go
@@ -490,16 +490,19 @@ func Search(w http.ResponseWriter, r *http.Request) {
 	// Sort sets as requested, default to chronological
 	switch pageVars.SearchSort {
 	case "alpha":
+		sortData := resolveSortingData(allKeys)
 		sort.Slice(allKeys, func(i, j int) bool {
-			return sortSetsAlphabetical(allKeys[i], allKeys[j], preferFlavor)
+			return cmpSetsAlphabetical(sortData[allKeys[i]], sortData[allKeys[j]], preferFlavor)
 		})
 	case "hybrid":
+		sortData := resolveSortingData(allKeys)
 		sort.Slice(allKeys, func(i, j int) bool {
-			return sortSetsAlphabeticalSet(allKeys[i], allKeys[j], preferFlavor)
+			return cmpSetsAlphabeticalSet(sortData[allKeys[i]], sortData[allKeys[j]], preferFlavor)
 		})
 	case "number":
+		sortData := resolveSortingData(allKeys)
 		sort.Slice(allKeys, func(i, j int) bool {
-			return sortByNumberAndFinish(allKeys[i], allKeys[j], false)
+			return cmpNumberAndFinish(sortData[allKeys[i]], sortData[allKeys[j]], false)
 		})
 	case "retail":
 		retSellers := defaultSellerPriorityOpt
@@ -522,8 +525,9 @@ func Search(w http.ResponseWriter, r *http.Request) {
 			return sortSetsByBuylist(allKeys[i], allKeys[j], blVendors)
 		})
 	default:
+		sortData := resolveSortingData(allKeys)
 		sort.Slice(allKeys, func(i, j int) bool {
-			return sortSets(allKeys[i], allKeys[j])
+			return cmpSets(sortData[allKeys[i]], sortData[allKeys[j]])
 		})
 	}
 
@@ -1573,6 +1577,12 @@ type SortingData struct {
 	co          *mtgmatcher.CardObject
 	releaseDate time.Time
 	parentCode  string
+
+	// Lowercased fields the comparators order by, so the N log N
+	// comparisons don't re-lower them every time.
+	nameLower    string
+	flavorLower  string
+	editionLower string
 }
 
 func getSortingData(uuid string) (*SortingData, error) {
@@ -1589,10 +1599,32 @@ func getSortingData(uuid string) (*SortingData, error) {
 		return nil, err
 	}
 	return &SortingData{
-		co:          co,
-		releaseDate: releaseDate,
-		parentCode:  set.ParentCode,
+		co:           co,
+		releaseDate:  releaseDate,
+		parentCode:   set.ParentCode,
+		nameLower:    strings.ToLower(co.Name),
+		flavorLower:  strings.ToLower(co.FlavorName),
+		editionLower: strings.ToLower(co.Edition),
 	}, nil
+}
+
+// resolveSortingData resolves the sorting data of every given id up
+// front, so the N log N comparisons of a sort look each card up instead
+// of re-resolving it every time they see it; a sort visits all of its
+// elements, so nothing is saved by resolving lazily. Unknown ids get a
+// nil entry, which the cmp* comparators order like the lookup error it
+// stands for.
+func resolveSortingData(cardIds []string) map[string]*SortingData {
+	data := make(map[string]*SortingData, len(cardIds))
+	for _, cardId := range cardIds {
+		_, found := data[cardId]
+		if found {
+			continue
+		}
+		sorting, _ := getSortingData(cardId)
+		data[cardId] = sorting
+	}
+	return data
 }
 
 // Sort cards by their collector number and finish (nonfoil-foil-etched)
@@ -1710,7 +1742,7 @@ func cmpSets(sortingI, sortingJ *SortingData) bool {
 					return true
 				}
 
-				return strings.ToLower(cI.Name) < strings.ToLower(cJ.Name)
+				return sortingI.nameLower < sortingJ.nameLower
 			}
 
 			return cmpNumberAndFinish(sortingI, sortingJ, true)
@@ -1720,7 +1752,7 @@ func cmpSets(sortingI, sortingJ *SortingData) bool {
 		} else if sortingJ.parentCode == "" && sortingI.parentCode != "" {
 			return false
 		} else {
-			return strings.ToLower(cI.Edition) < strings.ToLower(cJ.Edition)
+			return sortingI.editionLower < sortingJ.editionLower
 		}
 	}
 
@@ -1743,13 +1775,13 @@ func cmpSetsAlphabetical(sortingI, sortingJ *SortingData, preferFlavor bool) boo
 	cI, setDateI := sortingI.co, sortingI.releaseDate
 	cJ, setDateJ := sortingJ.co, sortingJ.releaseDate
 
-	cIname := cI.Name
-	cJname := cJ.Name
+	cIname, cInameLower := cI.Name, sortingI.nameLower
+	cJname, cJnameLower := cJ.Name, sortingJ.nameLower
 	if preferFlavor && cI.FlavorName != "" && allLanguageFlags[cI.Language] != "" {
-		cIname = cI.FlavorName
+		cIname, cInameLower = cI.FlavorName, sortingI.flavorLower
 	}
 	if preferFlavor && cJ.FlavorName != "" && allLanguageFlags[cJ.Language] != "" {
-		cJname = cJ.FlavorName
+		cJname, cJnameLower = cJ.FlavorName, sortingJ.flavorLower
 	}
 
 	if cIname == cJname {
@@ -1761,7 +1793,7 @@ func cmpSetsAlphabetical(sortingI, sortingJ *SortingData, preferFlavor bool) boo
 		return setDateI.After(setDateJ)
 	}
 
-	return strings.ToLower(cIname) < strings.ToLower(cJname)
+	return cInameLower < cJnameLower
 }
 
 // Sort card by their names, keeping cards grouped by edition alphabetically
@@ -1783,7 +1815,7 @@ func cmpSetsAlphabeticalSet(sortingI, sortingJ *SortingData, preferFlavor bool) 
 		return cmpSetsAlphabetical(sortingI, sortingJ, preferFlavor)
 	}
 
-	return strings.ToLower(cI.Edition) < strings.ToLower(cJ.Edition)
+	return sortingI.editionLower < sortingJ.editionLower
 }
 
 // Sort cards using the highest price among to the sellers in the input slice

--- a/search.go
+++ b/search.go
@@ -1597,12 +1597,15 @@ func getSortingData(uuid string) (*SortingData, error) {
 
 // Sort cards by their collector number and finish (nonfoil-foil-etched)
 func sortByNumberAndFinish(uuidI, uuidJ string, strip bool) bool {
-	sortingI, err := getSortingData(uuidI)
-	if err != nil {
-		return false
-	}
-	sortingJ, err := getSortingData(uuidJ)
-	if err != nil {
+	sortingI, _ := getSortingData(uuidI)
+	sortingJ, _ := getSortingData(uuidJ)
+	return cmpNumberAndFinish(sortingI, sortingJ, strip)
+}
+
+// cmpNumberAndFinish is sortByNumberAndFinish over already-resolved sorting
+// data; nil data (an unknown id) sorts like the lookup error it stands for.
+func cmpNumberAndFinish(sortingI, sortingJ *SortingData, strip bool) bool {
+	if sortingI == nil || sortingJ == nil {
 		return false
 	}
 	cI := sortingI.co
@@ -1667,12 +1670,14 @@ func sortByNumberAndFinish(uuidI, uuidJ string, strip bool) bool {
 
 // Sort cards grouping them by edition, and then by their collector number
 func sortSets(uuidI, uuidJ string) bool {
-	sortingI, err := getSortingData(uuidI)
-	if err != nil {
-		return false
-	}
-	sortingJ, err := getSortingData(uuidJ)
-	if err != nil {
+	sortingI, _ := getSortingData(uuidI)
+	sortingJ, _ := getSortingData(uuidJ)
+	return cmpSets(sortingI, sortingJ)
+}
+
+// cmpSets is sortSets over already-resolved sorting data.
+func cmpSets(sortingI, sortingJ *SortingData) bool {
+	if sortingI == nil || sortingJ == nil {
 		return false
 	}
 	cI, setDateI := sortingI.co, sortingI.releaseDate
@@ -1708,7 +1713,7 @@ func sortSets(uuidI, uuidJ string) bool {
 				return strings.ToLower(cI.Name) < strings.ToLower(cJ.Name)
 			}
 
-			return sortByNumberAndFinish(uuidI, uuidJ, true)
+			return cmpNumberAndFinish(sortingI, sortingJ, true)
 			// For the special case of set promos, always keeps them after
 		} else if sortingI.parentCode == "" && sortingJ.parentCode != "" {
 			return true
@@ -1725,12 +1730,14 @@ func sortSets(uuidI, uuidJ string) bool {
 // Sort card by their names, trying to keep cards grouped by edition, following
 // the same rules as sortSets
 func sortSetsAlphabetical(uuidI, uuidJ string, preferFlavor bool) bool {
-	sortingI, err := getSortingData(uuidI)
-	if err != nil {
-		return false
-	}
-	sortingJ, err := getSortingData(uuidJ)
-	if err != nil {
+	sortingI, _ := getSortingData(uuidI)
+	sortingJ, _ := getSortingData(uuidJ)
+	return cmpSetsAlphabetical(sortingI, sortingJ, preferFlavor)
+}
+
+// cmpSetsAlphabetical is sortSetsAlphabetical over already-resolved sorting data.
+func cmpSetsAlphabetical(sortingI, sortingJ *SortingData, preferFlavor bool) bool {
+	if sortingI == nil || sortingJ == nil {
 		return false
 	}
 	cI, setDateI := sortingI.co, sortingI.releaseDate
@@ -1748,7 +1755,7 @@ func sortSetsAlphabetical(uuidI, uuidJ string, preferFlavor bool) bool {
 	if cIname == cJname {
 		if setDateI.Equal(setDateJ) {
 			// We need not to strip to keep set ordered wrt Promos etc
-			return sortByNumberAndFinish(uuidI, uuidJ, false)
+			return cmpNumberAndFinish(sortingI, sortingJ, false)
 		}
 
 		return setDateI.After(setDateJ)
@@ -1759,19 +1766,21 @@ func sortSetsAlphabetical(uuidI, uuidJ string, preferFlavor bool) bool {
 
 // Sort card by their names, keeping cards grouped by edition alphabetically
 func sortSetsAlphabeticalSet(uuidI, uuidJ string, preferFlavor bool) bool {
-	sortingI, err := getSortingData(uuidI)
-	if err != nil {
-		return false
-	}
-	sortingJ, err := getSortingData(uuidJ)
-	if err != nil {
+	sortingI, _ := getSortingData(uuidI)
+	sortingJ, _ := getSortingData(uuidJ)
+	return cmpSetsAlphabeticalSet(sortingI, sortingJ, preferFlavor)
+}
+
+// cmpSetsAlphabeticalSet is sortSetsAlphabeticalSet over already-resolved sorting data.
+func cmpSetsAlphabeticalSet(sortingI, sortingJ *SortingData, preferFlavor bool) bool {
+	if sortingI == nil || sortingJ == nil {
 		return false
 	}
 	cI := sortingI.co
 	cJ := sortingJ.co
 
 	if cI.SetCode == cJ.SetCode {
-		return sortSetsAlphabetical(uuidI, uuidJ, preferFlavor)
+		return cmpSetsAlphabetical(sortingI, sortingJ, preferFlavor)
 	}
 
 	return strings.ToLower(cI.Edition) < strings.ToLower(cJ.Edition)

--- a/sort_bench_test.go
+++ b/sort_bench_test.go
@@ -32,8 +32,9 @@ func BenchmarkSortSets(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		keys := slices.Clone(uuids)
+		sortData := resolveSortingData(keys)
 		sort.Slice(keys, func(i, j int) bool {
-			return sortSets(keys[i], keys[j])
+			return cmpSets(sortData[keys[i]], sortData[keys[j]])
 		})
 	}
 }
@@ -43,8 +44,9 @@ func BenchmarkSortSetsAlphabetical(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		keys := slices.Clone(uuids)
+		sortData := resolveSortingData(keys)
 		sort.Slice(keys, func(i, j int) bool {
-			return sortSetsAlphabetical(keys[i], keys[j], false)
+			return cmpSetsAlphabetical(sortData[keys[i]], sortData[keys[j]], false)
 		})
 	}
 }
@@ -54,8 +56,9 @@ func BenchmarkSortSetsAlphabeticalSet(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		keys := slices.Clone(uuids)
+		sortData := resolveSortingData(keys)
 		sort.Slice(keys, func(i, j int) bool {
-			return sortSetsAlphabeticalSet(keys[i], keys[j], false)
+			return cmpSetsAlphabeticalSet(sortData[keys[i]], sortData[keys[j]], false)
 		})
 	}
 }
@@ -65,8 +68,9 @@ func BenchmarkSortByNumberAndFinish(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		keys := slices.Clone(uuids)
+		sortData := resolveSortingData(keys)
 		sort.Slice(keys, func(i, j int) bool {
-			return sortByNumberAndFinish(keys[i], keys[j], false)
+			return cmpNumberAndFinish(sortData[keys[i]], sortData[keys[j]], false)
 		})
 	}
 }

--- a/sort_bench_test.go
+++ b/sort_bench_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"slices"
+	"sort"
+	"testing"
+
+	"github.com/mtgban/go-mtgban/mtgban"
+	"github.com/mtgban/go-mtgban/mtgmatcher"
+)
+
+// benchSortUUIDs picks n uuids spread across the datastore pool,
+// deterministically so every run sorts the same input.
+func benchSortUUIDs(b *testing.B, n int) []string {
+	all := mtgmatcher.GetUUIDs()
+	if len(all) == 0 {
+		b.Skip("mtgmatcher datastore not loaded")
+	}
+	if len(all) < n {
+		n = len(all)
+	}
+	uuids := make([]string, n)
+	step := len(all) / n
+	for i := range n {
+		uuids[i] = all[i*step]
+	}
+	return uuids
+}
+
+func BenchmarkSortSets(b *testing.B) {
+	uuids := benchSortUUIDs(b, 5000)
+	b.ReportAllocs()
+	for b.Loop() {
+		keys := slices.Clone(uuids)
+		sort.Slice(keys, func(i, j int) bool {
+			return sortSets(keys[i], keys[j])
+		})
+	}
+}
+
+func BenchmarkSortSetsAlphabetical(b *testing.B) {
+	uuids := benchSortUUIDs(b, 5000)
+	b.ReportAllocs()
+	for b.Loop() {
+		keys := slices.Clone(uuids)
+		sort.Slice(keys, func(i, j int) bool {
+			return sortSetsAlphabetical(keys[i], keys[j], false)
+		})
+	}
+}
+
+func BenchmarkSortSetsAlphabeticalSet(b *testing.B) {
+	uuids := benchSortUUIDs(b, 5000)
+	b.ReportAllocs()
+	for b.Loop() {
+		keys := slices.Clone(uuids)
+		sort.Slice(keys, func(i, j int) bool {
+			return sortSetsAlphabeticalSet(keys[i], keys[j], false)
+		})
+	}
+}
+
+func BenchmarkSortByNumberAndFinish(b *testing.B) {
+	uuids := benchSortUUIDs(b, 5000)
+	b.ReportAllocs()
+	for b.Loop() {
+		keys := slices.Clone(uuids)
+		sort.Slice(keys, func(i, j int) bool {
+			return sortByNumberAndFinish(keys[i], keys[j], false)
+		})
+	}
+}
+
+// The retail sort consults seller prices per comparison, so give the priority
+// sellers a price for every benched uuid.
+func BenchmarkSortSetsByRetail(b *testing.B) {
+	uuids := benchSortUUIDs(b, 5000)
+
+	prevSellers := sellersPtr.Load()
+	b.Cleanup(func() { sellersPtr.Store(prevSellers) })
+	var sellers []mtgban.Seller
+	for _, shorthand := range defaultSellerPriorityOpt {
+		inv := mtgban.InventoryRecord{}
+		for i, uuid := range uuids {
+			inv.Add(uuid, &mtgban.InventoryEntry{
+				Conditions: "NM", Price: float64(i%500) + 0.5, URL: "u",
+			})
+		}
+		sellers = append(sellers, mtgban.NewSellerFromInventory(inv, mtgban.ScraperInfo{
+			Name: "Bench " + shorthand, Shorthand: shorthand,
+		}))
+	}
+	sellersPtr.Store(&sellers)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		keys := slices.Clone(uuids)
+		sort.Slice(keys, func(i, j int) bool {
+			return sortSetsByRetail(keys[i], keys[j], defaultSellerPriorityOpt)
+		})
+	}
+}
+
+// The buylist sort consults vendor prices and breaks ties through the whole
+// retail chain, so give the priority vendors and sellers a price for every
+// benched uuid; the repeating prices force the tie-breaks to run.
+func BenchmarkSortSetsByBuylist(b *testing.B) {
+	uuids := benchSortUUIDs(b, 5000)
+
+	prevSellers := sellersPtr.Load()
+	prevVendors := vendorsPtr.Load()
+	b.Cleanup(func() {
+		sellersPtr.Store(prevSellers)
+		vendorsPtr.Store(prevVendors)
+	})
+	var sellers []mtgban.Seller
+	for _, shorthand := range defaultSellerPriorityOpt {
+		inv := mtgban.InventoryRecord{}
+		for i, uuid := range uuids {
+			inv.Add(uuid, &mtgban.InventoryEntry{
+				Conditions: "NM", Price: float64(i%500) + 0.5, URL: "u",
+			})
+		}
+		sellers = append(sellers, mtgban.NewSellerFromInventory(inv, mtgban.ScraperInfo{
+			Name: "Bench " + shorthand, Shorthand: shorthand,
+		}))
+	}
+	sellersPtr.Store(&sellers)
+	var vendors []mtgban.Vendor
+	for _, shorthand := range defaultVendorPriorityOpt {
+		bl := mtgban.BuylistRecord{}
+		for i, uuid := range uuids {
+			bl.Add(uuid, &mtgban.BuylistEntry{
+				Conditions: "NM", BuyPrice: float64(i%500) + 0.5, URL: "u",
+			})
+		}
+		vendors = append(vendors, mtgban.NewVendorFromBuylist(bl, mtgban.ScraperInfo{
+			Name: "Bench " + shorthand, Shorthand: shorthand,
+		}))
+	}
+	vendorsPtr.Store(&vendors)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		keys := slices.Clone(uuids)
+		sort.Slice(keys, func(i, j int) bool {
+			return sortSetsByBuylist(keys[i], keys[j], defaultVendorPriorityOpt)
+		})
+	}
+}
+
+// Sorting must be deterministic: the same input in any starting order lands in
+// one order. Also serves as a fixture to eyeball order stability across
+// implementations of the comparators.
+func TestSortSetsDeterministic(t *testing.T) {
+	all := mtgmatcher.GetUUIDs()
+	if len(all) == 0 {
+		t.Skip("mtgmatcher datastore not loaded")
+	}
+	uuids := make([]string, 0, 500)
+	step := max(len(all)/500, 1)
+	for i := 0; i < len(all) && len(uuids) < 500; i += step {
+		uuids = append(uuids, all[i])
+	}
+
+	a := slices.Clone(uuids)
+	sort.SliceStable(a, func(i, j int) bool { return sortSets(a[i], a[j]) })
+
+	b := slices.Clone(uuids)
+	slices.Reverse(b)
+	sort.SliceStable(b, func(i, j int) bool { return sortSets(b[i], b[j]) })
+
+	// Compare as sets of positions: equal elements may tie, so require the
+	// comparator to consider adjacent out-of-order pairs equal rather than
+	// demanding identical slices.
+	for i := range a {
+		if a[i] == b[i] {
+			continue
+		}
+		if sortSets(a[i], b[i]) || sortSets(b[i], a[i]) {
+			t.Fatalf("order diverges at %d: %s vs %s", i, a[i], b[i])
+		}
+	}
+}

--- a/sort_bench_test.go
+++ b/sort_bench_test.go
@@ -99,8 +99,14 @@ func BenchmarkSortSetsByRetail(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		keys := slices.Clone(uuids)
+		sortData := resolveSortingData(keys)
+		prices := resolveBestPrices(keys, defaultSellerPriorityOpt, price4seller)
 		sort.Slice(keys, func(i, j int) bool {
-			return sortSetsByRetail(keys[i], keys[j], defaultSellerPriorityOpt)
+			priceI, priceJ := prices[keys[i]], prices[keys[j]]
+			if priceI == priceJ {
+				return cmpSets(sortData[keys[i]], sortData[keys[j]])
+			}
+			return priceI > priceJ
 		})
 	}
 }
@@ -147,8 +153,19 @@ func BenchmarkSortSetsByBuylist(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		keys := slices.Clone(uuids)
+		sortData := resolveSortingData(keys)
+		buyPrices := resolveBestPrices(keys, defaultVendorPriorityOpt, price4vendor)
+		retPrices := resolveBestPrices(keys, defaultSellerPriorityOpt, price4seller)
 		sort.Slice(keys, func(i, j int) bool {
-			return sortSetsByBuylist(keys[i], keys[j], defaultVendorPriorityOpt)
+			priceI, priceJ := buyPrices[keys[i]], buyPrices[keys[j]]
+			if priceI != priceJ {
+				return priceI > priceJ
+			}
+			priceI, priceJ = retPrices[keys[i]], retPrices[keys[j]]
+			if priceI != priceJ {
+				return priceI > priceJ
+			}
+			return cmpSets(sortData[keys[i]], sortData[keys[j]])
 		})
 	}
 }

--- a/upload.go
+++ b/upload.go
@@ -1279,6 +1279,21 @@ func Upload(w http.ResponseWriter, r *http.Request) {
 }
 
 func sortResults(uploadedData []UploadEntry, optimizedResults map[string][]OptimizedUploadEntry, sorting string, preferFlavor bool) {
+	// The card-data sorts below order both the uploaded rows and every
+	// per-store optimized list, so resolve the ids of both up front.
+	resolveUploadSortingData := func() map[string]*SortingData {
+		cardIds := make([]string, 0, len(uploadedData))
+		for i := range uploadedData {
+			cardIds = append(cardIds, uploadedData[i].CardId)
+		}
+		for _, entries := range optimizedResults {
+			for i := range entries {
+				cardIds = append(cardIds, entries[i].CardId)
+			}
+		}
+		return resolveSortingData(cardIds)
+	}
+
 	switch sorting {
 	case "highprice":
 		sort.Slice(uploadedData, func(i, j int) bool {
@@ -1291,33 +1306,36 @@ func sortResults(uploadedData []UploadEntry, optimizedResults map[string][]Optim
 			})
 		}
 	case "alphabetical":
+		sortData := resolveUploadSortingData()
 		sort.Slice(uploadedData, func(i, j int) bool {
-			return sortSetsAlphabetical(uploadedData[i].CardId, uploadedData[j].CardId, preferFlavor)
+			return cmpSetsAlphabetical(sortData[uploadedData[i].CardId], sortData[uploadedData[j].CardId], preferFlavor)
 		})
 
 		for store := range optimizedResults {
 			sort.Slice(optimizedResults[store], func(i, j int) bool {
-				return sortSetsAlphabetical(optimizedResults[store][i].CardId, optimizedResults[store][j].CardId, preferFlavor)
+				return cmpSetsAlphabetical(sortData[optimizedResults[store][i].CardId], sortData[optimizedResults[store][j].CardId], preferFlavor)
 			})
 		}
 	case "setalpha":
+		sortData := resolveUploadSortingData()
 		sort.Slice(uploadedData, func(i, j int) bool {
-			return sortSetsAlphabeticalSet(uploadedData[i].CardId, uploadedData[j].CardId, preferFlavor)
+			return cmpSetsAlphabeticalSet(sortData[uploadedData[i].CardId], sortData[uploadedData[j].CardId], preferFlavor)
 		})
 
 		for store := range optimizedResults {
 			sort.Slice(optimizedResults[store], func(i, j int) bool {
-				return sortSetsAlphabeticalSet(optimizedResults[store][i].CardId, optimizedResults[store][j].CardId, preferFlavor)
+				return cmpSetsAlphabeticalSet(sortData[optimizedResults[store][i].CardId], sortData[optimizedResults[store][j].CardId], preferFlavor)
 			})
 		}
 	case "setchrono":
+		sortData := resolveUploadSortingData()
 		sort.Slice(uploadedData, func(i, j int) bool {
-			return sortSets(uploadedData[i].CardId, uploadedData[j].CardId)
+			return cmpSets(sortData[uploadedData[i].CardId], sortData[uploadedData[j].CardId])
 		})
 
 		for store := range optimizedResults {
 			sort.Slice(optimizedResults[store], func(i, j int) bool {
-				return sortSets(optimizedResults[store][i].CardId, optimizedResults[store][j].CardId)
+				return cmpSets(sortData[optimizedResults[store][i].CardId], sortData[optimizedResults[store][j].CardId])
 			})
 		}
 	case "highspread":


### PR DESCRIPTION
Fifth follow-up from the site-wide bottleneck review: the card sort comparators recomputed everything per comparison — a CardObject map copy, a set lookup, and a release-date `time.Parse` per side, N log N times, multiplied by comparator nesting (up to six resolutions per comparison), plus scraper-list price walks in the price sorts. A 5,000-card chronological sort built **132MB of garbage across 333k allocations**.

## The fix — one commit per change

1. **`test: benchmark card sorting`** — 5,000 datastore uuids through every comparator behind a search sort mode, plus a determinism check. Datastore-gated.
2. **`perf: compare cards on already-resolved sorting data`** — each comparator splits into a `cmp*` form taking `*SortingData`; the uuid form stays as a resolve-and-delegate wrapper (nil data sorts exactly like the lookup error it stands for). Nested comparator calls now pass data through instead of re-resolving.
3. **`perf: resolve sorting data once per sort`** — `resolveSortingData` builds a plain map over the sorted slice **up front** at each call site (search, SearchAPI, arbit, newspaper SYP, upload, embed, discord). No lazy state and no memo: a sort visits every element anyway, so one eager pass is all there is. `SortingData` also gains the lowercased name/flavor/edition fields the comparators order by.
4. **`perf: resolve prices once in the price sorts`** — `resolveBestPrices` records each card's best price across the priority stores in the same kind of up-front pass at the three price-sort sites, preserving the buy → retail → sets tie-break chain; the orphaned uuid price comparators are deleted.

## Measured (5,000 cards, Apple M3 Max; benchmarks in the first commit)

All six sort modes the search page offers:

| sort mode | before | after | |
|---|---|---|---|
| chronological (default) | 39.7 ms, 132 MB, 333k allocs | **6.4 ms, 5.0 MB, 28k allocs** | 6.2× |
| alphabetical | 38.6 ms, 106 MB, 378k allocs | **5.6 ms, 4.8 MB, 20k allocs** | 6.9× |
| set-alphabetical (hybrid) | 51.6 ms, 139 MB, 462k allocs | **6.0 ms, 4.8 MB, 20k allocs** | 8.6× |
| collector number | 37.2 ms, 100 MB, 272k allocs | **7.7 ms, 5.6 MB, 50k allocs** | 4.9× |
| retail price | 24.8 ms, 22.7 MB, 55k allocs | **7.0 ms, 5.1 MB, 20k allocs** | 3.6× |
| buylist price | 29.9 ms, 22.7 MB, 55k allocs | **7.6 ms, 5.3 MB, 20k allocs** | 3.9× |

(The price numbers use small synthetic inventories; production inventories make the before side worse. Set-alphabetical was the heaviest of the lot — it nests the chronological comparator, so every tie re-resolved both cards a second time.) These sorts run on every search page, SearchAPI call, upload, arbit table, and newspaper SYP view.

## Verification

- `TestSortSetsDeterministic` (same input in any starting order lands in one order) passes before and after.
- Full main-package suite passes with the card datastore loaded; `gofmt`/`vet`/build clean; each commit builds independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
