### PR TITLE
fix: suggestion names paired correctly, prefix-searched, capped

### DIFF
--- a/api_suggest.go
+++ b/api_suggest.go
@@ -51,8 +51,12 @@ func buildSuggestEntries(names []string) []suggestEntry {
 	return entries
 }
 
-// prefixMatches returns the entries whose lowercase form starts with prefix,
-// located by binary search over the sorted index.
+// maxSuggestions caps a response: the search box renders at most 30
+// candidates, and every match costs a printings-line render.
+const maxSuggestions = 30
+
+// prefixMatches returns the first entries whose lowercase form starts with
+// prefix, located by binary search over the sorted index.
 func (idx *suggestIndex) prefixMatches(prefix string, sealed bool) []suggestEntry {
 	entries := idx.singles
 	if sealed {
@@ -62,7 +66,7 @@ func (idx *suggestIndex) prefixMatches(prefix string, sealed bool) []suggestEntr
 		return entries[i].lower >= prefix
 	})
 	end := start
-	for end < len(entries) && strings.HasPrefix(entries[end].lower, prefix) {
+	for end < len(entries) && end-start < maxSuggestions && strings.HasPrefix(entries[end].lower, prefix) {
 		end++
 	}
 	return entries[start:end]

--- a/api_suggest.go
+++ b/api_suggest.go
@@ -4,18 +4,75 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 
 	"github.com/mtgban/go-mtgban/mtgmatcher"
 	"github.com/mtgban/mtgban-website/internal/embed"
 )
 
+// suggestEntry pairs the lowercase form a typed prefix is matched against
+// with the name to display for it.
+type suggestEntry struct {
+	lower string
+	name  string
+}
+
+// suggestIndex is the autocomplete index: name entries sorted by their
+// lowercase form, per game side. The pairing is rebuilt here because the
+// datastore's canonical and lowercase name lists are each sorted on their
+// own, so equal indexes in the two lists do not name the same card.
+type suggestIndex struct {
+	singles []suggestEntry
+	sealed  []suggestEntry
+}
+
+var suggestIndexPtr atomic.Pointer[suggestIndex]
+
+// rebuildSuggestIndex derives the autocomplete index from the loaded card
+// data. Called from loadDatastore, the one place the card data swaps.
+func rebuildSuggestIndex() {
+	suggestIndexPtr.Store(&suggestIndex{
+		singles: buildSuggestEntries(mtgmatcher.AllNames("canonical", false)),
+		sealed:  buildSuggestEntries(mtgmatcher.AllNames("canonical", true)),
+	})
+}
+
+func buildSuggestEntries(names []string) []suggestEntry {
+	entries := make([]suggestEntry, len(names))
+	for i, name := range names {
+		entries[i] = suggestEntry{lower: strings.ToLower(name), name: name}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].lower < entries[j].lower
+	})
+	return entries
+}
+
+// prefixMatches returns the entries whose lowercase form starts with prefix,
+// located by binary search over the sorted index.
+func (idx *suggestIndex) prefixMatches(prefix string, sealed bool) []suggestEntry {
+	entries := idx.singles
+	if sealed {
+		entries = idx.sealed
+	}
+	start := sort.Search(len(entries), func(i int) bool {
+		return entries[i].lower >= prefix
+	})
+	end := start
+	for end < len(entries) && strings.HasPrefix(entries[end].lower, prefix) {
+		end++
+	}
+	return entries[start:end]
+}
+
 func SuggestAPI(w http.ResponseWriter, r *http.Request) {
 	sealed, _ := strconv.ParseBool(r.FormValue("sealed"))
 
-	AllNames := mtgmatcher.AllNames("canonical", sealed)
 	if r.FormValue("all") == "true" {
+		AllNames := mtgmatcher.AllNames("canonical", sealed)
 		json.NewEncoder(w).Encode(&AllNames)
 		return
 	}
@@ -26,18 +83,21 @@ func SuggestAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	AllLowerCaseNames := mtgmatcher.AllNames("lowercase", false)
+	idx := suggestIndexPtr.Load()
+	if idx == nil {
+		// Datastore not loaded yet
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
 
 	var suggestions []string
 	var results []string
 	var links []string
-	for i, name := range AllLowerCaseNames {
-		if strings.HasPrefix(name, prefix) {
-			suggestions = append(suggestions, AllNames[i])
-			printings, _ := mtgmatcher.Printings4Card(name)
-			results = append(results, embed.PrintingsLine(printings))
-			links = append(links, ServerURL+"/search?q="+url.QueryEscape(AllNames[i]))
-		}
+	for _, entry := range idx.prefixMatches(prefix, sealed) {
+		suggestions = append(suggestions, entry.name)
+		printings, _ := mtgmatcher.Printings4Card(entry.lower)
+		results = append(results, embed.PrintingsLine(printings))
+		links = append(links, ServerURL+"/search?q="+url.QueryEscape(entry.name))
 	}
 	// This argument is mandatory
 	if suggestions == nil {

--- a/api_suggest_test.go
+++ b/api_suggest_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mtgban/go-mtgban/mtgmatcher"
+)
+
+// suggestResponse invokes SuggestAPI for a query and decodes the OpenSearch
+// response shape: [query, [names], [printings], [links]].
+func suggestResponse(t *testing.T, query string, sealed bool) (int, []string) {
+	t.Helper()
+	url := "/api/suggest?q=" + query
+	if sealed {
+		url += "&sealed=true"
+	}
+	req := httptest.NewRequest("GET", url, nil)
+	rec := httptest.NewRecorder()
+	SuggestAPI(rec, req)
+	if rec.Code != http.StatusOK {
+		return rec.Code, nil
+	}
+	var out []json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("bad response: %v", err)
+	}
+	if len(out) < 2 {
+		t.Fatalf("response too short: %s", rec.Body.String())
+	}
+	var names []string
+	if err := json.Unmarshal(out[1], &names); err != nil {
+		t.Fatalf("bad names: %v", err)
+	}
+	return rec.Code, names
+}
+
+func BenchmarkSuggestCommonPrefix(b *testing.B) {
+	if len(mtgmatcher.GetUUIDs()) == 0 {
+		b.Skip("mtgmatcher datastore not loaded")
+	}
+	req := httptest.NewRequest("GET", "/api/suggest?q=the", nil)
+	b.ReportAllocs()
+	for b.Loop() {
+		rec := httptest.NewRecorder()
+		SuggestAPI(rec, req)
+	}
+}
+
+func BenchmarkSuggestRarePrefix(b *testing.B) {
+	if len(mtgmatcher.GetUUIDs()) == 0 {
+		b.Skip("mtgmatcher datastore not loaded")
+	}
+	req := httptest.NewRequest("GET", "/api/suggest?q=zzyzx", nil)
+	b.ReportAllocs()
+	for b.Loop() {
+		rec := httptest.NewRecorder()
+		SuggestAPI(rec, req)
+	}
+}

--- a/api_suggest_test.go
+++ b/api_suggest_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/mtgban/go-mtgban/mtgmatcher"
@@ -37,10 +38,72 @@ func suggestResponse(t *testing.T, query string, sealed bool) (int, []string) {
 	return rec.Code, names
 }
 
+func TestSuggestSingles(t *testing.T) {
+	if len(mtgmatcher.GetUUIDs()) == 0 {
+		t.Skip("mtgmatcher datastore not loaded")
+	}
+	// loadDatastore builds the index in the background; build it here so the
+	// test can't race that goroutine.
+	rebuildSuggestIndex()
+
+	// Every suggested name must actually start with the prefix (case
+	// folded): a suggestion paired with the wrong display name betrays a
+	// misaligned index.
+	code, names := suggestResponse(t, "lightning+bo", false)
+	if code != http.StatusOK || len(names) == 0 {
+		t.Fatalf("no suggestions (code %d)", code)
+	}
+	var hasBolt bool
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		if !strings.HasPrefix(strings.ToLower(name), "lightning bo") {
+			t.Errorf("suggestion %q does not match the typed prefix", name)
+		}
+		if name == "Lightning Bolt" {
+			hasBolt = true
+		}
+	}
+	if !hasBolt {
+		t.Error("Lightning Bolt missing from lightning bo suggestions")
+	}
+
+	// Short prefixes don't suggest
+	code, _ = suggestResponse(t, "li", false)
+	if code != http.StatusNoContent {
+		t.Errorf("short prefix code = %d, want 204", code)
+	}
+}
+
+// The sealed autocomplete used to iterate the singles list while indexing
+// the sealed one - wrong names at best, an index-out-of-range panic as soon
+// as the singles list was longer.
+func TestSuggestSealed(t *testing.T) {
+	if len(mtgmatcher.GetUUIDs()) == 0 {
+		t.Skip("mtgmatcher datastore not loaded")
+	}
+	rebuildSuggestIndex()
+
+	code, names := suggestResponse(t, "booster", true)
+	if code != http.StatusOK {
+		t.Fatalf("sealed suggestions code = %d", code)
+	}
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		if !strings.HasPrefix(strings.ToLower(name), "booster") {
+			t.Errorf("sealed suggestion %q does not match the typed prefix", name)
+		}
+	}
+}
+
 func BenchmarkSuggestCommonPrefix(b *testing.B) {
 	if len(mtgmatcher.GetUUIDs()) == 0 {
 		b.Skip("mtgmatcher datastore not loaded")
 	}
+	rebuildSuggestIndex()
 	req := httptest.NewRequest("GET", "/api/suggest?q=the", nil)
 	b.ReportAllocs()
 	for b.Loop() {
@@ -53,6 +116,7 @@ func BenchmarkSuggestRarePrefix(b *testing.B) {
 	if len(mtgmatcher.GetUUIDs()) == 0 {
 		b.Skip("mtgmatcher datastore not loaded")
 	}
+	rebuildSuggestIndex()
 	req := httptest.NewRequest("GET", "/api/suggest?q=zzyzx", nil)
 	b.ReportAllocs()
 	for b.Loop() {

--- a/main.go
+++ b/main.go
@@ -1029,6 +1029,7 @@ func loadDatastore(bucket simplecloud.Reader, ds string) error {
 
 	ServerNotify("init", "Datastore installed")
 	SetLastDatastoreUpdate(time.Now())
+	go rebuildSuggestIndex()
 	go updateStaticData()
 	go cacheNewspaper()
 	go paletteService.BuildSetsCache()


### PR DESCRIPTION
Sixth follow-up from the site-wide bottleneck review — and this one turned out to be **two live correctness bugs**, not just perf.

## The bugs

`SuggestAPI` iterated the lowercase name list while indexing the canonical list at the same position. But mtgmatcher sorts the two lists **independently**, so equal indexes don't name the same card wherever ASCII case changes relative order. Verified live: typing **`lightning bo` suggested "Lightning Elemental" and never "Lightning Bolt"** — every user's autocomplete has been showing misaligned names.

Worse, the lowercase list was fetched with a hardcoded `sealed=false`: with `sealed=true` the loop walked the (longer) singles list while indexing the (shorter) sealed canonical list — **index out of range panic**, swallowed by the recover middleware, so sealed autocomplete silently 500'd.

## The fix — one commit per change

1. **`test: benchmark the suggestion endpoint`** — common-prefix and no-match benchmarks via httptest, datastore-gated.
2. **`fix: pair suggestion names correctly, search them by prefix range`** — the site builds its own index: `{lowercase, display}` entries derived from the canonical list alone, sorted by the lowercase form, per game side, rebuilt **eagerly in `loadDatastore`** — the one place the card data swaps (no lazy machinery). Matching becomes a **binary search** for the prefix range instead of a scan over all ~30k names per keystroke. Regression tests cover the misalignment (every suggestion must start with the typed prefix; Lightning Bolt must appear) and the sealed panic.
3. **`perf: cap suggestions at what the search box shows`** — the frontend renders at most 30 candidates (`autocomplete.js` slices to 30), so return only the first 30 of the prefix range; every match costs a printings-line render.

## Measured (this is the highest-QPS endpoint — it fires per keystroke)

| | before | after | |
|---|---|---|---|
| no-match prefix | 141 µs | **2.8 µs** | 50× |
| common prefix ("the") | 449 µs, 2.5k allocs | **17.6 µs, 205 allocs** | 25× |
| sealed request | panic → 500 | works | — |

## Verification

- Regression tests pass under `-race`; the misalignment test **fails on master** (demonstrating the live bug) and passes here.
- Full main-package suite green with the card datastore loaded; `gofmt`/`vet`/build clean; each commit builds independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
