### PR TITLE
fix: stash non-Magic snapshots into the long form, not the uuid table

### DIFF
--- a/chart.go
+++ b/chart.go
@@ -476,26 +476,22 @@ func IsStashingInProgress() bool {
 	return stashingInProgress.Load()
 }
 
-func stashInTimeseries() {
-	// Only one stash may run at a time. The cron fires every 12h and the
-	// admin button can fire at any moment; CompareAndSwap is the real gate.
-	if !stashingInProgress.CompareAndSwap(false, true) {
-		log.Println("stashInTimeseries: another stash is already running, skipping")
-		return
-	}
-	defer stashingInProgress.Store(false)
+// snapshotPrice is one priced card in a stash snapshot: the resolved card, the
+// dataset (and therefore the provider) the price belongs to, the observation
+// date, and the condition-graded price.
+type snapshotPrice struct {
+	card  *mtgmatcher.CardObject
+	ds    DatasetConfig
+	date  string
+	price float64
+}
 
-	if PricesArchiveDB == nil {
-		log.Println("PricesArchiveDB not initialized, skipping stash")
-		return
-	}
-
-	start := time.Now()
-	ServerNotify("timeseries", "Taking snapshot...")
-
-	// Accumulate all prices into a single row per (date, uuid, foil, etched).
-	accumulated := map[string]*timeseries.PriceRow{}
-
+// eachSnapshotPrice walks every configured dataset's retail sellers and buylist
+// vendors, resolves each entry to a card and a graded price, and hands the result
+// to fn. It is the game-agnostic half of the stash — what the prices get keyed on
+// (an mtgjson uuid for Magic, a TCGplayer product for every other game) is the
+// caller's business.
+func eachSnapshotPrice(start time.Time, fn func(snapshotPrice)) {
 	// Collect retail prices from sellers
 	for _, seller := range GetSellers() {
 		for _, config := range Config.TimeseriesConfig.Datasets {
@@ -525,8 +521,7 @@ func stashInTimeseries() {
 					continue
 				}
 
-				row := getRow(accumulated, card.UUID, card.Foil, card.Etched, card.IsAlternative, card.Language, date)
-				row.SetPriceForDataset(config.Index, price)
+				fn(snapshotPrice{card: card, ds: config, date: date, price: price})
 			}
 		}
 	}
@@ -553,11 +548,42 @@ func stashInTimeseries() {
 					continue
 				}
 
-				row := getRow(accumulated, card.UUID, card.Foil, card.Etched, card.IsAlternative, card.Language, date)
-				row.SetPriceForDataset(config.Index, price)
+				fn(snapshotPrice{card: card, ds: config, date: date, price: price})
 			}
 		}
 	}
+}
+
+func stashInTimeseries() {
+	// Only one stash may run at a time. The cron fires every 12h and the
+	// admin button can fire at any moment; CompareAndSwap is the real gate.
+	if !stashingInProgress.CompareAndSwap(false, true) {
+		log.Println("stashInTimeseries: another stash is already running, skipping")
+		return
+	}
+	defer stashingInProgress.Store(false)
+
+	if PricesArchiveDB == nil {
+		log.Println("PricesArchiveDB not initialized, skipping stash")
+		return
+	}
+
+	start := time.Now()
+	ServerNotify("timeseries", "Taking snapshot...")
+
+	// Every other game is keyed by TCGplayer product, not by an mtgjson uuid,
+	// and takes the long-form-only path below.
+	if Config.Game != "" && Config.Game != DefaultGame {
+		stashNonMagicSnapshot(start)
+		return
+	}
+
+	// Accumulate all prices into a single row per (date, uuid, foil, etched).
+	accumulated := map[string]*timeseries.PriceRow{}
+	eachSnapshotPrice(start, func(sp snapshotPrice) {
+		row := getRow(accumulated, sp.card.UUID, sp.card.Foil, sp.card.Etched, sp.card.IsAlternative, sp.card.Language, sp.date)
+		row.SetPriceForDataset(sp.ds.Index, sp.price)
+	})
 
 	// Upsert all accumulated rows in batches
 	rows := make([]timeseries.PriceRow, 0, len(accumulated))
@@ -586,6 +612,95 @@ func stashInTimeseries() {
 	SetLastStashUpdate(time.Now())
 	msg := fmt.Sprintf("Snapshot completed in %s: %d upserted, %d errors", time.Since(start), upserted, errCount)
 	ServerNotify("timeseries", msg)
+}
+
+// stashNonMagicSnapshot stores the snapshot of a deployment serving any game but
+// Magic. Those cards have no mtgjson uuid — mtgmatcher keys them by their own
+// numeric id ("1459", "808_f" for Lorcana) — so the legacy wide product_prices
+// table cannot hold them at all: its mtgjson_uuid column is a Postgres uuid and
+// every batch dies on the first game-native id. The long form is their only home,
+// and it is where the non-Magic read path already looks.
+//
+// Each card resolves to the ban_id of its TCGplayer product in the card's finish
+// (minted by the tcgcsv ingest) and contributes one price row per provider.
+func stashNonMagicSnapshot(start time.Time) {
+	// Long-form writes gate the startup work this path depends on: the price
+	// partitions and the warm variant cache. Without them there is nowhere to
+	// put a non-Magic price, so say so instead of silently dropping the run.
+	if !Config.TimeseriesConfig.LongFormWrites {
+		ServerNotify("timeseries", "Snapshot skipped: "+Config.Game+" prices need long_form_writes, the wide table is Magic-only")
+		return
+	}
+
+	// The long form addresses providers by id, so a dataset without one has no
+	// column to write to. A config predating the field would stash nothing at
+	// all — bail loudly rather than warm the cache and upsert an empty batch.
+	if !slices.ContainsFunc(Config.TimeseriesConfig.Datasets, func(ds DatasetConfig) bool {
+		return ds.Provider != 0
+	}) {
+		ServerNotify("timeseries", "Snapshot skipped: no timeseries dataset carries a provider id")
+		return
+	}
+
+	ctx := context.Background()
+	if err := PricesArchiveDB.WarmVariantCache(ctx); err != nil {
+		ServerNotify("timeseries", fmt.Sprintf("warm variant cache error: %s", err))
+		return
+	}
+
+	type longKey struct {
+		banID    int64
+		date     string
+		provider int16
+	}
+	// Last price wins per (variant, date, provider), matching how the wide path
+	// collapses two sellers feeding the same dataset column.
+	prices := map[longKey]float64{}
+	var unresolved int
+	eachSnapshotPrice(start, func(sp snapshotPrice) {
+		if sp.ds.Provider == 0 {
+			return
+		}
+		banID, ok := nonMagicBanID(sp.card)
+		if !ok {
+			unresolved++
+			return
+		}
+		prices[longKey{banID: banID, date: sp.date, provider: sp.ds.Provider}] = sp.price
+	})
+
+	rows := make([]timeseries.LongPrice, 0, len(prices))
+	for key, price := range prices {
+		rows = append(rows, timeseries.LongPrice{
+			BanID:    key.banID,
+			Date:     key.date,
+			Provider: key.provider,
+			Price:    price,
+		})
+	}
+
+	upserted, err := PricesArchiveDB.UpsertLongPrices(ctx, rows, 0)
+	if err != nil {
+		ServerNotify("timeseries", fmt.Sprintf("long-form upsert error: %s", err))
+	}
+
+	SetLastStashUpdate(time.Now())
+	ServerNotify("timeseries", fmt.Sprintf("Snapshot completed in %s: %d upserted, %d unresolved",
+		time.Since(start), upserted, unresolved))
+}
+
+// nonMagicBanID resolves a non-Magic card to the variant of its TCGplayer product
+// in the card's finish. Both finishes share one product id and differ only by
+// sub-type, whose name is per-game ("Holofoil" / "Cold Foil" in Lorcana), so the
+// lookup goes through the variants the tcgcsv ingest already minted rather than
+// guessing a name from the foil flag. A product with no variant in that finish
+// drops its price for this run; the next ingest mints it.
+func nonMagicBanID(co *mtgmatcher.CardObject) (int64, bool) {
+	pid, ok := tcgProductID(co)
+	if !ok {
+		return 0, false
+	}
+	return PricesArchiveDB.CachedTCGBanIDForFinish(pid, co.Foil)
 }
 
 // stashLongForm mirrors the accumulated wide rows into the long prices table. It

--- a/chart.go
+++ b/chart.go
@@ -656,14 +656,18 @@ func stashNonMagicSnapshot(start time.Time) {
 	// Last price wins per (variant, date, provider), matching how the wide path
 	// collapses two sellers feeding the same dataset column.
 	prices := map[longKey]float64{}
-	var unresolved int
+	var unknown, ambiguous int
 	eachSnapshotPrice(start, func(sp snapshotPrice) {
 		if sp.ds.Provider == 0 {
 			return
 		}
-		banID, ok := nonMagicBanID(sp.card)
-		if !ok {
-			unresolved++
+		banID, match := nonMagicBanID(sp.card)
+		switch match {
+		case timeseries.TCGPrintingUnknown:
+			unknown++
+			return
+		case timeseries.TCGPrintingAmbiguous:
+			ambiguous++
 			return
 		}
 		prices[longKey{banID: banID, date: sp.date, provider: sp.ds.Provider}] = sp.price
@@ -685,20 +689,20 @@ func stashNonMagicSnapshot(start time.Time) {
 	}
 
 	SetLastStashUpdate(time.Now())
-	ServerNotify("timeseries", fmt.Sprintf("Snapshot completed in %s: %d upserted, %d unresolved",
-		time.Since(start), upserted, unresolved))
+	ServerNotify("timeseries", fmt.Sprintf("Snapshot completed in %s: %d upserted, %d unknown, %d ambiguous",
+		time.Since(start), upserted, unknown, ambiguous))
 }
 
-// nonMagicBanID resolves a non-Magic card to the variant of its TCGplayer product
-// in the card's finish. Both finishes share one product id and differ only by
-// sub-type, whose name is per-game ("Holofoil" / "Cold Foil" in Lorcana), so the
-// lookup goes through the variants the tcgcsv ingest already minted rather than
-// guessing a name from the foil flag. A product with no variant in that finish
-// drops its price for this run; the next ingest mints it.
-func nonMagicBanID(co *mtgmatcher.CardObject) (int64, bool) {
+// nonMagicBanID resolves a non-Magic card to the printing of its TCGplayer
+// product that its price belongs to. All of a product's printings share one
+// product id and differ only by sub-type, so the lookup goes through the variants
+// the tcgcsv ingest already minted rather than guessing a sub-type name from a
+// foil flag. Prices it can't place — an un-ingested product, or one carrying
+// several alternate sub-types — are dropped for this run and counted.
+func nonMagicBanID(co *mtgmatcher.CardObject) (int64, timeseries.TCGPrintingMatch) {
 	pid, ok := tcgProductID(co)
 	if !ok {
-		return 0, false
+		return 0, timeseries.TCGPrintingUnknown
 	}
 	return PricesArchiveDB.CachedTCGBanIDForFinish(pid, co.Foil)
 }

--- a/timeseries/variants.go
+++ b/timeseries/variants.go
@@ -59,51 +59,51 @@ type TCGVariant struct {
 type variantCache struct {
 	magic sync.Map // MagicVariant -> int64
 	tcg   sync.Map // TCGVariant   -> int64
-	// tcgByProduct maps a TCGplayer product id to its canonical ban_id (the
-	// "Normal" sub-type, else the smallest ban_id), so a rendered non-Magic card
-	// resolves its ban_id from memory by product id alone — the read-path analogue
-	// of magic's uuid-keyed lookup, with no per-card DB round-trip. Mirrors
-	// LookupTCGBanID's precedence.
-	tcgByProduct sync.Map // int (product id) -> int64
-	// tcgNormalByProduct and tcgFoilByProduct split the same lookup by finish.
-	// A game's foil and non-foil printings share one product id and differ only
-	// by sub-type, so the write path needs them apart: folding both onto the
-	// canonical ban_id would have each finish overwrite the other's price.
-	tcgNormalByProduct sync.Map // int (product id) -> int64
-	tcgFoilByProduct   sync.Map // int (product id) -> int64
+	// tcgPrintingsByProduct maps a TCGplayer product id to its printings, so a
+	// non-Magic card resolves a ban_id from memory by product id alone — the
+	// analogue of magic's uuid-keyed lookup, with no per-card DB round-trip.
+	tcgPrintingsByProduct sync.Map // int (product id) -> tcgPrintings
 }
 
-// tcgFinishes collects one TCGplayer product's printings while the variant cache
-// is warmed: the "Normal" sub-type is the non-foil printing, anything else is the
-// foil one. Sub-type names are per-game ("Holofoil" and "Cold Foil" in Lorcana,
-// "Reverse Holofoil" in Pokemon, ...), so a foil flag can't name one — the only
-// reliable mapping is "not Normal". Either field is 0 when the product has no
-// printing in that finish (foil-only enchanted cards, non-foil-only sealed).
-type tcgFinishes struct {
-	normal int64
-	foil   int64
+// tcgPrintings collects one TCGplayer product's variant rows while the cache is
+// warmed. TCGplayer splits a product into sub-types, and that vocabulary is
+// per-game and open-ended: the catalog holds 16 today, and they are not all
+// finishes — "Foil", "Holofoil", "Reverse Holofoil", "Cold Foil" and "Rainbow
+// Foil" sit next to the Yu-Gi-Oh printings "1st Edition", "Unlimited" and
+// "Limited", and compounds like "1st Edition Rainbow Foil". Only "Normal", the
+// base printing, means the same thing in every game.
+//
+// So a product is modelled as its base printing plus however many alternates it
+// carries, and the alternates are counted rather than collapsed: see
+// CachedTCGBanIDForFinish for why a count of one is the only attributable case.
+type tcgPrintings struct {
+	normal   int64 // the "Normal" sub-type, 0 when the product has none
+	alt      int64 // the smallest-ban_id alternate sub-type, 0 when there are none
+	altCount int   // how many alternate sub-types the product carries
 }
 
-// observe folds one variant row into the product's picks, keeping the smallest
-// ban_id for the foil finish since a few products carry two foil sub-types.
-func (f tcgFinishes) observe(banID int64, subType string) tcgFinishes {
+// observe folds one variant row into the product's printings, keeping the
+// smallest ban_id among the alternates so canonical stays deterministic.
+func (p tcgPrintings) observe(banID int64, subType string) tcgPrintings {
 	if subType == "Normal" {
-		f.normal = banID
-		return f
+		p.normal = banID
+		return p
 	}
-	if f.foil == 0 || banID < f.foil {
-		f.foil = banID
+	p.altCount++
+	if p.alt == 0 || banID < p.alt {
+		p.alt = banID
 	}
-	return f
+	return p
 }
 
 // canonical is the product's default printing — "Normal" when it has one, else
-// its foil printing — mirroring LookupTCGBanID's ORDER BY.
-func (f tcgFinishes) canonical() int64 {
-	if f.normal != 0 {
-		return f.normal
+// the smallest alternate — mirroring LookupTCGBanID's ORDER BY. It is what the
+// read path charts for a bare product id.
+func (p tcgPrintings) canonical() int64 {
+	if p.normal != 0 {
+		return p.normal
 	}
-	return f.foil
+	return p.alt
 }
 
 // WarmVariantCache bulk-loads every existing variant into the in-memory cache in
@@ -120,7 +120,7 @@ func (c *Client) WarmVariantCache(ctx context.Context) error {
 	defer rows.Close()
 
 	// Per-product printings, resolved after the scan since rows arrive unordered.
-	byProduct := map[int]tcgFinishes{}
+	byProduct := map[int]tcgPrintings{}
 
 	var loadedMagic, loadedTCG int
 	for rows.Next() {
@@ -154,14 +154,8 @@ func (c *Client) WarmVariantCache(ctx context.Context) error {
 	if err := rows.Err(); err != nil {
 		return err
 	}
-	for pid, finishes := range byProduct {
-		c.variants.tcgByProduct.Store(pid, finishes.canonical())
-		if finishes.normal != 0 {
-			c.variants.tcgNormalByProduct.Store(pid, finishes.normal)
-		}
-		if finishes.foil != 0 {
-			c.variants.tcgFoilByProduct.Store(pid, finishes.foil)
-		}
+	for pid, printings := range byProduct {
+		c.variants.tcgPrintingsByProduct.Store(pid, printings)
 	}
 	return nil
 }
@@ -173,32 +167,65 @@ func (c *Client) WarmVariantCache(ctx context.Context) error {
 // (new product, or an unwarmed cache) returns ok=false and the caller falls back
 // to the game-native id.
 func (c *Client) CachedTCGBanID(productID int) (int64, bool) {
-	if id, ok := c.variants.tcgByProduct.Load(productID); ok {
-		return id.(int64), true
+	p, ok := c.variants.tcgPrintingsByProduct.Load(productID)
+	if !ok {
+		return 0, false
 	}
-	return 0, false
+	return p.(tcgPrintings).canonical(), true
 }
 
-// CachedTCGBanIDForFinish returns the ban_id of a non-Magic product's printing in
-// one finish: the "Normal" sub-type for a non-foil card, the product's foil
-// sub-type otherwise. It is the write-path counterpart of CachedTCGBanID, which
-// answers with the product's canonical printing and so can't tell the two
-// finishes apart.
+// TCGPrintingMatch is the outcome of resolving a non-Magic card to the printing
+// its price belongs to.
+type TCGPrintingMatch int
+
+const (
+	// TCGPrintingResolved: exactly one printing matches; the ban_id is usable.
+	TCGPrintingResolved TCGPrintingMatch = iota
+	// TCGPrintingUnknown: the product has no matching printing in the cache —
+	// not ingested yet, or it exists only in the other finish. Transient: the
+	// next tcgcsv ingest mints it.
+	TCGPrintingUnknown
+	// TCGPrintingAmbiguous: several printings match and nothing in the source
+	// says which one was priced. Permanent for that product until the source
+	// carries a sub-type.
+	TCGPrintingAmbiguous
+)
+
+// CachedTCGBanIDForFinish returns the ban_id of the printing a non-Magic card's
+// price can be attributed to. It is the write-path counterpart of CachedTCGBanID,
+// which answers with the product's canonical printing and so would have every
+// alternate overwrite the base one's prices.
 //
-// A miss (ok=false) means the product has no printing in that finish yet — it
-// hasn't been ingested, or it only exists in the other finish. Skip the price
-// rather than mint: the sub-type's real name varies by game and can't be derived
-// from a foil flag, so minting would create a variant the tcgcsv ingest never
-// matches. The next ingest mints the real one.
-func (c *Client) CachedTCGBanIDForFinish(productID int, foil bool) (int64, bool) {
-	byProduct := &c.variants.tcgNormalByProduct
-	if foil {
-		byProduct = &c.variants.tcgFoilByProduct
+// The caller has a single foil bool — that is all mtgmatcher carries for a
+// non-Magic card — while the product may hold any number of sub-types. So a base
+// card takes "Normal", and a foil card takes the product's alternate only when it
+// has exactly one. Two alternates (a Lorcana card sold as both Cold Foil and
+// Holofoil, a Yu-Gi-Oh product as 1st Edition and Unlimited) make the price
+// unattributable, and guessing would silently file it under the wrong printing —
+// so it returns TCGPrintingAmbiguous and the caller drops it.
+//
+// Nothing is minted on a miss: a sub-type's real name can't be derived from a
+// foil flag, and inventing one would create a variant the tcgcsv ingest never
+// matches.
+func (c *Client) CachedTCGBanIDForFinish(productID int, foil bool) (int64, TCGPrintingMatch) {
+	v, ok := c.variants.tcgPrintingsByProduct.Load(productID)
+	if !ok {
+		return 0, TCGPrintingUnknown
 	}
-	if id, ok := byProduct.Load(productID); ok {
-		return id.(int64), true
+	p := v.(tcgPrintings)
+	if !foil {
+		if p.normal == 0 {
+			return 0, TCGPrintingUnknown
+		}
+		return p.normal, TCGPrintingResolved
 	}
-	return 0, false
+	switch {
+	case p.altCount == 0:
+		return 0, TCGPrintingUnknown
+	case p.altCount > 1:
+		return 0, TCGPrintingAmbiguous
+	}
+	return p.alt, TCGPrintingResolved
 }
 
 // ResolveMagicBanID returns the ban_id for a Magic variant, minting it if new.

--- a/timeseries/variants.go
+++ b/timeseries/variants.go
@@ -65,6 +65,45 @@ type variantCache struct {
 	// of magic's uuid-keyed lookup, with no per-card DB round-trip. Mirrors
 	// LookupTCGBanID's precedence.
 	tcgByProduct sync.Map // int (product id) -> int64
+	// tcgNormalByProduct and tcgFoilByProduct split the same lookup by finish.
+	// A game's foil and non-foil printings share one product id and differ only
+	// by sub-type, so the write path needs them apart: folding both onto the
+	// canonical ban_id would have each finish overwrite the other's price.
+	tcgNormalByProduct sync.Map // int (product id) -> int64
+	tcgFoilByProduct   sync.Map // int (product id) -> int64
+}
+
+// tcgFinishes collects one TCGplayer product's printings while the variant cache
+// is warmed: the "Normal" sub-type is the non-foil printing, anything else is the
+// foil one. Sub-type names are per-game ("Holofoil" and "Cold Foil" in Lorcana,
+// "Reverse Holofoil" in Pokemon, ...), so a foil flag can't name one — the only
+// reliable mapping is "not Normal". Either field is 0 when the product has no
+// printing in that finish (foil-only enchanted cards, non-foil-only sealed).
+type tcgFinishes struct {
+	normal int64
+	foil   int64
+}
+
+// observe folds one variant row into the product's picks, keeping the smallest
+// ban_id for the foil finish since a few products carry two foil sub-types.
+func (f tcgFinishes) observe(banID int64, subType string) tcgFinishes {
+	if subType == "Normal" {
+		f.normal = banID
+		return f
+	}
+	if f.foil == 0 || banID < f.foil {
+		f.foil = banID
+	}
+	return f
+}
+
+// canonical is the product's default printing — "Normal" when it has one, else
+// its foil printing — mirroring LookupTCGBanID's ORDER BY.
+func (f tcgFinishes) canonical() int64 {
+	if f.normal != 0 {
+		return f.normal
+	}
+	return f.foil
 }
 
 // WarmVariantCache bulk-loads every existing variant into the in-memory cache in
@@ -80,14 +119,8 @@ func (c *Client) WarmVariantCache(ctx context.Context) error {
 	}
 	defer rows.Close()
 
-	// Best canonical ban_id per product id, resolved after the scan since rows
-	// arrive unordered: prefer the "Normal" sub-type, else the smallest ban_id
-	// (matching LookupTCGBanID's ORDER BY).
-	type tcgBest struct {
-		banID  int64
-		normal bool
-	}
-	byProduct := map[int]tcgBest{}
+	// Per-product printings, resolved after the scan since rows arrive unordered.
+	byProduct := map[int]tcgFinishes{}
 
 	var loadedMagic, loadedTCG int
 	for rows.Next() {
@@ -115,19 +148,20 @@ func (c *Client) WarmVariantCache(ctx context.Context) error {
 			loadedTCG++
 
 			pid := int(prodID.Int64)
-			isNormal := subType.String == "Normal"
-			if cur, ok := byProduct[pid]; !ok ||
-				(isNormal && !cur.normal) ||
-				(isNormal == cur.normal && banID < cur.banID) {
-				byProduct[pid] = tcgBest{banID: banID, normal: isNormal}
-			}
+			byProduct[pid] = byProduct[pid].observe(banID, subType.String)
 		}
 	}
 	if err := rows.Err(); err != nil {
 		return err
 	}
-	for pid, best := range byProduct {
-		c.variants.tcgByProduct.Store(pid, best.banID)
+	for pid, finishes := range byProduct {
+		c.variants.tcgByProduct.Store(pid, finishes.canonical())
+		if finishes.normal != 0 {
+			c.variants.tcgNormalByProduct.Store(pid, finishes.normal)
+		}
+		if finishes.foil != 0 {
+			c.variants.tcgFoilByProduct.Store(pid, finishes.foil)
+		}
 	}
 	return nil
 }
@@ -140,6 +174,28 @@ func (c *Client) WarmVariantCache(ctx context.Context) error {
 // to the game-native id.
 func (c *Client) CachedTCGBanID(productID int) (int64, bool) {
 	if id, ok := c.variants.tcgByProduct.Load(productID); ok {
+		return id.(int64), true
+	}
+	return 0, false
+}
+
+// CachedTCGBanIDForFinish returns the ban_id of a non-Magic product's printing in
+// one finish: the "Normal" sub-type for a non-foil card, the product's foil
+// sub-type otherwise. It is the write-path counterpart of CachedTCGBanID, which
+// answers with the product's canonical printing and so can't tell the two
+// finishes apart.
+//
+// A miss (ok=false) means the product has no printing in that finish yet — it
+// hasn't been ingested, or it only exists in the other finish. Skip the price
+// rather than mint: the sub-type's real name varies by game and can't be derived
+// from a foil flag, so minting would create a variant the tcgcsv ingest never
+// matches. The next ingest mints the real one.
+func (c *Client) CachedTCGBanIDForFinish(productID int, foil bool) (int64, bool) {
+	byProduct := &c.variants.tcgNormalByProduct
+	if foil {
+		byProduct = &c.variants.tcgFoilByProduct
+	}
+	if id, ok := byProduct.Load(productID); ok {
 		return id.(int64), true
 	}
 	return 0, false

--- a/timeseries/variants_test.go
+++ b/timeseries/variants_test.go
@@ -2,6 +2,86 @@ package timeseries
 
 import "testing"
 
+// Sub-type names are per-game, so the split is "Normal" vs everything else, and
+// the rows arrive in whatever order the warm-up scan reads them.
+func TestTCGFinishes(t *testing.T) {
+	type row struct {
+		banID   int64
+		subType string
+	}
+	cases := []struct {
+		name          string
+		rows          []row
+		normal        int64
+		foil          int64
+		canonicalWant int64
+	}{
+		{
+			name:          "normal and holofoil",
+			rows:          []row{{10, "Holofoil"}, {20, "Normal"}},
+			normal:        20,
+			foil:          10,
+			canonicalWant: 20,
+		},
+		{
+			name:          "foil only product keeps no normal",
+			rows:          []row{{30, "Cold Foil"}},
+			foil:          30,
+			canonicalWant: 30,
+		},
+		{
+			name:          "two foil sub-types pick the smallest ban_id",
+			rows:          []row{{50, "Holofoil"}, {40, "Cold Foil"}, {60, "Normal"}},
+			normal:        60,
+			foil:          40,
+			canonicalWant: 60,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var f tcgFinishes
+			for _, r := range tc.rows {
+				f = f.observe(r.banID, r.subType)
+			}
+			if f.normal != tc.normal || f.foil != tc.foil {
+				t.Errorf("finishes = %+v, want normal=%d foil=%d", f, tc.normal, tc.foil)
+			}
+			if got := f.canonical(); got != tc.canonicalWant {
+				t.Errorf("canonical() = %d, want %d", got, tc.canonicalWant)
+			}
+		})
+	}
+}
+
+// The write path must never fall back to the other finish: a non-foil price
+// landing on the foil variant (or the reverse) silently overwrites it.
+func TestCachedTCGBanIDForFinish(t *testing.T) {
+	var c Client
+	c.variants.tcgNormalByProduct.Store(100, int64(1))
+	c.variants.tcgFoilByProduct.Store(100, int64(2))
+	c.variants.tcgFoilByProduct.Store(200, int64(3))
+
+	cases := []struct {
+		productID int
+		foil      bool
+		want      int64
+		wantOK    bool
+	}{
+		{productID: 100, foil: false, want: 1, wantOK: true},
+		{productID: 100, foil: true, want: 2, wantOK: true},
+		{productID: 200, foil: true, want: 3, wantOK: true},
+		{productID: 200, foil: false},
+		{productID: 999, foil: true},
+	}
+	for _, tc := range cases {
+		got, ok := c.CachedTCGBanIDForFinish(tc.productID, tc.foil)
+		if got != tc.want || ok != tc.wantOK {
+			t.Errorf("CachedTCGBanIDForFinish(%d, %t) = (%d, %t), want (%d, %t)",
+				tc.productID, tc.foil, got, ok, tc.want, tc.wantOK)
+		}
+	}
+}
+
 func TestMagicVariantNormalized(t *testing.T) {
 	cases := []struct {
 		name string

--- a/timeseries/variants_test.go
+++ b/timeseries/variants_test.go
@@ -2,83 +2,113 @@ package timeseries
 
 import "testing"
 
-// Sub-type names are per-game, so the split is "Normal" vs everything else, and
-// the rows arrive in whatever order the warm-up scan reads them.
-func TestTCGFinishes(t *testing.T) {
+// Sub-type names are per-game and open-ended, so the split is "Normal" against
+// however many alternates a product carries, and the rows arrive in whatever
+// order the warm-up scan reads them.
+func TestTCGPrintings(t *testing.T) {
 	type row struct {
 		banID   int64
 		subType string
 	}
 	cases := []struct {
-		name          string
-		rows          []row
-		normal        int64
-		foil          int64
-		canonicalWant int64
+		name      string
+		rows      []row
+		want      tcgPrintings
+		canonical int64
 	}{
 		{
-			name:          "normal and holofoil",
-			rows:          []row{{10, "Holofoil"}, {20, "Normal"}},
-			normal:        20,
-			foil:          10,
-			canonicalWant: 20,
+			name:      "normal and holofoil",
+			rows:      []row{{10, "Holofoil"}, {20, "Normal"}},
+			want:      tcgPrintings{normal: 20, alt: 10, altCount: 1},
+			canonical: 20,
 		},
 		{
-			name:          "foil only product keeps no normal",
-			rows:          []row{{30, "Cold Foil"}},
-			foil:          30,
-			canonicalWant: 30,
+			name:      "foil only product has no normal",
+			rows:      []row{{30, "Cold Foil"}},
+			want:      tcgPrintings{alt: 30, altCount: 1},
+			canonical: 30,
 		},
 		{
-			name:          "two foil sub-types pick the smallest ban_id",
-			rows:          []row{{50, "Holofoil"}, {40, "Cold Foil"}, {60, "Normal"}},
-			normal:        60,
-			foil:          40,
-			canonicalWant: 60,
+			name:      "two foil sub-types are both counted",
+			rows:      []row{{50, "Holofoil"}, {40, "Cold Foil"}, {60, "Normal"}},
+			want:      tcgPrintings{normal: 60, alt: 40, altCount: 2},
+			canonical: 60,
+		},
+		{
+			name:      "editions are alternates too, and there can be many",
+			rows:      []row{{70, "1st Edition"}, {80, "Unlimited"}, {90, "Limited"}},
+			want:      tcgPrintings{alt: 70, altCount: 3},
+			canonical: 70,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var f tcgFinishes
+			var p tcgPrintings
 			for _, r := range tc.rows {
-				f = f.observe(r.banID, r.subType)
+				p = p.observe(r.banID, r.subType)
 			}
-			if f.normal != tc.normal || f.foil != tc.foil {
-				t.Errorf("finishes = %+v, want normal=%d foil=%d", f, tc.normal, tc.foil)
+			if p != tc.want {
+				t.Errorf("printings = %+v, want %+v", p, tc.want)
 			}
-			if got := f.canonical(); got != tc.canonicalWant {
-				t.Errorf("canonical() = %d, want %d", got, tc.canonicalWant)
+			if got := p.canonical(); got != tc.canonical {
+				t.Errorf("canonical() = %d, want %d", got, tc.canonical)
 			}
 		})
 	}
 }
 
-// The write path must never fall back to the other finish: a non-foil price
-// landing on the foil variant (or the reverse) silently overwrites it.
+// The write path must never fall back to another printing: a base price landing
+// on an alternate (or the reverse) silently overwrites it, and a product with
+// several alternates can't be resolved from a foil bool at all.
 func TestCachedTCGBanIDForFinish(t *testing.T) {
 	var c Client
-	c.variants.tcgNormalByProduct.Store(100, int64(1))
-	c.variants.tcgFoilByProduct.Store(100, int64(2))
-	c.variants.tcgFoilByProduct.Store(200, int64(3))
+	c.variants.tcgPrintingsByProduct.Store(100, tcgPrintings{normal: 1, alt: 2, altCount: 1})
+	c.variants.tcgPrintingsByProduct.Store(200, tcgPrintings{alt: 3, altCount: 1})
+	c.variants.tcgPrintingsByProduct.Store(300, tcgPrintings{normal: 4})
+	c.variants.tcgPrintingsByProduct.Store(400, tcgPrintings{normal: 5, alt: 6, altCount: 2})
 
 	cases := []struct {
+		name      string
 		productID int
 		foil      bool
 		want      int64
-		wantOK    bool
+		wantMatch TCGPrintingMatch
 	}{
-		{productID: 100, foil: false, want: 1, wantOK: true},
-		{productID: 100, foil: true, want: 2, wantOK: true},
-		{productID: 200, foil: true, want: 3, wantOK: true},
-		{productID: 200, foil: false},
-		{productID: 999, foil: true},
+		{"base card takes Normal", 100, false, 1, TCGPrintingResolved},
+		{"foil card takes the only alternate", 100, true, 2, TCGPrintingResolved},
+		{"alternate-only product has no base printing", 200, false, 0, TCGPrintingUnknown},
+		{"alternate-only product resolves its alternate", 200, true, 3, TCGPrintingResolved},
+		{"base-only product has no alternate", 300, true, 0, TCGPrintingUnknown},
+		{"two alternates can't be told apart", 400, true, 0, TCGPrintingAmbiguous},
+		{"two alternates still resolve the base", 400, false, 5, TCGPrintingResolved},
+		{"product not in the cache", 999, true, 0, TCGPrintingUnknown},
 	}
 	for _, tc := range cases {
-		got, ok := c.CachedTCGBanIDForFinish(tc.productID, tc.foil)
-		if got != tc.want || ok != tc.wantOK {
-			t.Errorf("CachedTCGBanIDForFinish(%d, %t) = (%d, %t), want (%d, %t)",
-				tc.productID, tc.foil, got, ok, tc.want, tc.wantOK)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			got, match := c.CachedTCGBanIDForFinish(tc.productID, tc.foil)
+			if got != tc.want || match != tc.wantMatch {
+				t.Errorf("CachedTCGBanIDForFinish(%d, %t) = (%d, %v), want (%d, %v)",
+					tc.productID, tc.foil, got, match, tc.want, tc.wantMatch)
+			}
+		})
+	}
+}
+
+// The read path charts a bare product id, so it must keep answering with the
+// canonical printing even where the write path refuses to guess.
+func TestCachedTCGBanID(t *testing.T) {
+	var c Client
+	c.variants.tcgPrintingsByProduct.Store(100, tcgPrintings{normal: 1, alt: 2, altCount: 2})
+	c.variants.tcgPrintingsByProduct.Store(200, tcgPrintings{alt: 3, altCount: 1})
+
+	if got, ok := c.CachedTCGBanID(100); got != 1 || !ok {
+		t.Errorf("CachedTCGBanID(100) = (%d, %t), want (1, true)", got, ok)
+	}
+	if got, ok := c.CachedTCGBanID(200); got != 3 || !ok {
+		t.Errorf("CachedTCGBanID(200) = (%d, %t), want (3, true)", got, ok)
+	}
+	if got, ok := c.CachedTCGBanID(999); got != 0 || ok {
+		t.Errorf("CachedTCGBanID(999) = (%d, %t), want (0, false)", got, ok)
 	}
 }
 


### PR DESCRIPTION
Fixes #291.

### The bug

Every game but Magic keys its cards by a game-native id — LorcanaJSON's `1459`, `808_f` — but `stashInTimeseries` writes every snapshot into the wide `product_prices` table, whose `mtgjson_uuid` column is a Postgres `uuid`. So a Lorcana deployment fails on every batch, every run:

```
batch starting at row 0: pq: invalid input syntax for type uuid: "1459" (22P02)
```

The rest of the codebase already treats the long form as the only home for non-Magic prices — `genPageNav` hides the chart UI for those games unless `long_form_reads` is on, because "the legacy wide table is mtgjson-uuid keyed and has no rows for them." The write path just never learned the same thing.

### The fix

- The seller/vendor walk becomes `eachSnapshotPrice`, shared by both paths (it also collapses the near-identical retail and buylist loops).
- Magic keeps the wide upsert and its long-form dual-write, unchanged.
- Any other game goes to the new `stashNonMagicSnapshot`, which skips the wide table entirely and writes long-form `prices` rows keyed by ban_id.

### Which printing a price belongs to

A card resolves to a ban_id through its TCGplayer product id, but a product is split into sub-types, and all of a card's printings share the one product id. That vocabulary is per-game and open-ended — 16 sub-types across the ingested games, and several aren't finishes at all:

| sub-type | variants | | sub-type | variants |
|---|---|---|---|---|
| Normal | 79,038 | | Reverse Holofoil | 13,812 |
| 1st Edition | 37,017 | | Holofoil | 11,224 |
| Unlimited | 21,982 | | Cold Foil | 3,978 |
| Foil | 21,925 | | Rainbow Foil | 3,567 |

Only `Normal` means the same thing in every game. So a product is modelled as its base printing plus however many alternates it carries. The stash has one foil bool per card — that is all mtgmatcher carries for a non-Magic card — so a base card takes `Normal`, and a foil card takes the product's alternate **only when there is exactly one**.

Where there are several — 28 Lorcana products sold as both Cold Foil and Holofoil, every Yu-Gi-Oh 1st Edition/Unlimited pair — the price is unattributable, and it is dropped rather than filed under whichever printing sorts first. Those are counted separately from un-ingested products in the completion notification, since an ambiguous product stays ambiguous until the source carries a sub-type, while an un-ingested one clears with the next tcgcsv run.

Nothing is minted on a miss either: a sub-type's real name can't be derived from a foil flag, and inventing one (`"Foil"`, say, which Lorcana never uses) would create thousands of variants the tcgcsv ingest never matches.

The read path is unchanged — a bare product id still charts the canonical printing, now derived from the same per-product record.

### Deployment notes

Two things the Lorcana instance's config needs. Both now report loudly instead of stashing nothing:

- `long_form_writes: true` — it gates the startup partition-ensure and cache warm this path depends on.
- a `provider` id on each `timeseries_config` dataset — the long form addresses providers by id, not by the positional `index`.

Providers 3/4/5/6 already have Lorcana history back to 2024-02-08 from the tcgcsv ingest, so this mainly adds whatever non-TCGplayer sellers that deployment loads.

### Not covered

`/api/chart` with `long_form_reads` off still takes the legacy uuid-only read path, which would hit the same `22P02` on a Lorcana id. The chart UI is hidden in that configuration, so it's only reachable by direct API call, and flipping reads on resolves it.

### Testing

`go build ./...`, `go vet ./...`, and `go test ./...` pass. New unit tests cover the per-product printing record and every branch of the lookup: base-only and alternate-only products, the single-alternate resolve, and the multi-alternate refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhV1gHXokmP1HG5vbg9XJb