### PR TITLE
admin: per-row ✕ to remove a Patreon grant

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -578,6 +578,58 @@ func Admin(w http.ResponseWriter, r *http.Request) {
 	})
 	pageVars.Tables = append(pageVars.Tables, pageTable)
 
+	// -- People: quick-add a Patreon grant --
+	// Reuses the config editor's persistence: the amended config is written
+	// to the config source and swapped in memory, so the grant survives
+	// restarts and shows in the table below immediately.
+	grantEmail := strings.ToLower(strings.TrimSpace(r.FormValue("grantEmail")))
+	if grantEmail != "" {
+		grantTier := r.FormValue("grantTier")
+		newGrant := PatreonGrant{
+			Category: strings.TrimSpace(r.FormValue("grantCategory")),
+			Email:    grantEmail,
+			Name:     strings.TrimSpace(r.FormValue("grantName")),
+			Tier:     grantTier,
+		}
+
+		duplicate := false
+		for _, person := range Config.Patreon.Grants {
+			if strings.EqualFold(person.Email, grantEmail) {
+				duplicate = true
+				break
+			}
+		}
+		_, tierExists := Config.ACL[grantTier]
+
+		switch {
+		case !strings.Contains(grantEmail, "@"):
+			pageVars.WarningMessage = "invalid grant email: " + grantEmail
+		case duplicate:
+			pageVars.WarningMessage = grantEmail + " already has a grant"
+		case !tierExists:
+			pageVars.WarningMessage = "unknown tier: " + grantTier
+		default:
+			newConfig := Config
+			newConfig.Patreon.Grants = append(slices.Clone(Config.Patreon.Grants), newGrant)
+
+			writer, err := simplecloud.InitWriter(r.Context(), ConfigBucket, Config.sourcePath)
+			if err != nil {
+				pageVars.WarningMessage = err.Error()
+			} else {
+				err = writeConfigFile(newConfig, writer)
+				writer.Close()
+				if err != nil {
+					log.Println(err)
+					pageVars.WarningMessage = err.Error()
+				} else {
+					Config = newConfig
+					pageVars.InfoMessage = fmt.Sprintf("Granted %s tier to %s", newGrant.Tier, newGrant.Email)
+					LogPages["Admin"].Printf("Grant added: %+v", newGrant)
+				}
+			}
+		}
+	}
+
 	// -- People: Patreon Grants --
 	var userTable [][]string
 	for i, person := range Config.Patreon.Grants {

--- a/admin.go
+++ b/admin.go
@@ -630,6 +630,39 @@ func Admin(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// -- People: remove a Patreon grant --
+	// Persists like the quick-add above, so the row disappears from the
+	// table rendered below and stays gone after a restart.
+	revokeEmail := strings.ToLower(strings.TrimSpace(r.FormValue("revokeEmail")))
+	if revokeEmail != "" {
+		idx := slices.IndexFunc(Config.Patreon.Grants, func(person PatreonGrant) bool {
+			return strings.EqualFold(person.Email, revokeEmail)
+		})
+		if idx < 0 {
+			pageVars.WarningMessage = "no grant found for " + revokeEmail
+		} else {
+			removed := Config.Patreon.Grants[idx]
+			newConfig := Config
+			newConfig.Patreon.Grants = slices.Delete(slices.Clone(Config.Patreon.Grants), idx, idx+1)
+
+			writer, err := simplecloud.InitWriter(r.Context(), ConfigBucket, Config.sourcePath)
+			if err != nil {
+				pageVars.WarningMessage = err.Error()
+			} else {
+				err = writeConfigFile(newConfig, writer)
+				writer.Close()
+				if err != nil {
+					log.Println(err)
+					pageVars.WarningMessage = err.Error()
+				} else {
+					Config = newConfig
+					pageVars.InfoMessage = fmt.Sprintf("Removed %s grant from %s", removed.Tier, removed.Email)
+					LogPages["Admin"].Printf("Grant removed: %+v", removed)
+				}
+			}
+		}
+	}
+
 	// -- People: Patreon Grants --
 	var userTable [][]string
 	for i, person := range Config.Patreon.Grants {

--- a/auth.go
+++ b/auth.go
@@ -38,16 +38,18 @@ var APIRateLimiter = ratelimit.NewLimiter(APIRequestsPerSec, 2)
 
 var UserRateLimiter = ratelimit.NewLimiter(UserRequestsPerSec, 1)
 
+type PatreonGrant struct {
+	Category string `json:"category"`
+	Email    string `json:"email"`
+	Name     string `json:"name"`
+	Tier     string `json:"tier"`
+}
+
 type PatreonConfig struct {
 	Source string            `json:"source"`
 	Client map[string]string `json:"client"`
 	Secret map[string]string `json:"secret"`
-	Grants []struct {
-		Category string `json:"category"`
-		Email    string `json:"email"`
-		Name     string `json:"name"`
-		Tier     string `json:"tier"`
-	} `json:"grants"`
+	Grants []PatreonGrant    `json:"grants"`
 }
 
 type PatreonUserData struct {

--- a/css/admin.css
+++ b/css/admin.css
@@ -121,6 +121,43 @@
     color: var(--text-dim);
 }
 
+/* Quick-add grant form: one compact row above the grants table */
+.admin-grant-form {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+.admin-grant-form input[type="email"],
+.admin-grant-form input[type="text"],
+.admin-grant-form select {
+    flex: 1;
+    min-width: 0;
+    box-sizing: border-box;
+    padding: 8px 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-moderate);
+    background: var(--surface-2);
+    color: var(--normal);
+    font-size: var(--text-md);
+    outline: none;
+    font-family: inherit;
+}
+.admin-grant-form select { cursor: pointer; }
+.admin-grant-form input:focus,
+.admin-grant-form select:focus { border-color: var(--ainfo); }
+.admin-grant-form input::placeholder { color: var(--text-dim); }
+.admin-grant-form input[type="submit"] {
+    flex: 0 0 auto;
+    padding: 8px 14px;
+    border-radius: var(--radius-sm);
+    border: none;
+    background: var(--dodgerblue);
+    color: #fff;
+    font-size: var(--text-md);
+    font-weight: 600;
+    cursor: pointer;
+}
+
 .admin-table-wrap {
     background: var(--surface-1);
     border: 1px solid var(--border-subtle);

--- a/css/admin.css
+++ b/css/admin.css
@@ -158,6 +158,24 @@
     cursor: pointer;
 }
 
+/* Per-row grant removal: a small ✕ at the right edge of the grants table */
+.admin-grant-remove-cell {
+    width: 1%;
+    text-align: center;
+}
+.admin-grant-remove {
+    border: none;
+    background: none;
+    padding: 0 4px;
+    color: var(--text-dim);
+    font-size: var(--text-md);
+    line-height: 1;
+    cursor: pointer;
+}
+.admin-grant-remove:hover {
+    color: var(--adanger);
+}
+
 .admin-table-wrap {
     background: var(--surface-1);
     border: 1px solid var(--border-subtle);

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -171,7 +171,7 @@
                 </form>
                 <div class="admin-table-wrap">
                 <table class="table-data admin-table">
-                    <thead><tr><th>#</th><th>Category</th><th>Email</th><th>Name</th><th>Tier</th></tr></thead>
+                    <thead><tr><th>#</th><th>Category</th><th>Email</th><th>Name</th><th>Tier</th><th></th></tr></thead>
                     <tbody>
                     {{range $row := index .Tables 3}}
                         <tr>
@@ -180,6 +180,12 @@
                             <td class="admin-mono">{{index $row 2}}</td>
                             <td>{{index $row 3}}</td>
                             <td>{{index $row 4}}</td>
+                            <td class="admin-grant-remove-cell">
+                                <form method="POST" action="admin?page=people">
+                                    <input type="hidden" name="revokeEmail" value="{{index $row 2}}">
+                                    <button type="submit" class="admin-grant-remove" title="Remove grant for {{index $row 2}}">✕</button>
+                                </form>
+                            </td>
                         </tr>
                     {{end}}
                     </tbody>

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -158,6 +158,17 @@
                     <h2>Patreon Grants</h2>
                     <span class="count">{{len (index .Tables 3)}} users</span>
                 </div>
+                <form method="POST" action="admin?page=people" class="admin-grant-form">
+                    <input type="email" name="grantEmail" placeholder="email" required>
+                    <input type="text" name="grantName" placeholder="name">
+                    <input type="text" name="grantCategory" placeholder="category">
+                    <select name="grantTier">
+                        {{range .Tiers}}
+                            <option value="{{.}}">{{.}}</option>
+                        {{end}}
+                    </select>
+                    <input type="submit" value="Add Grant">
+                </form>
                 <div class="admin-table-wrap">
                 <table class="table-data admin-table">
                     <thead><tr><th>#</th><th>Category</th><th>Email</th><th>Name</th><th>Tier</th></tr></thead>


### PR DESCRIPTION
## Problem

The quick-add form (f3e31a81) made **granting** a Patreon tier one step, but **revoking** still means hand-editing the whole config in the editor tab — there is no way to remove an entry from the grants table.

## Fix

Each row of the grants table ends in a small **✕** that posts the row's email back to the People page:

```html
<form method="POST" action="admin?page=people">
    <input type="hidden" name="revokeEmail" value="{{index $row 2}}">
    <button type="submit" class="admin-grant-remove" title="Remove grant for {{index $row 2}}">✕</button>
</form>
```

The handler mirrors the quick-add block right above it: finds the grant by email (`slices.IndexFunc` + `EqualFold`, same case-insensitivity as the duplicate check), deletes it from a cloned slice, persists through the same `InitWriter`/`writeConfigFile` path, and swaps the running config — so the re-rendered page no longer shows the row and the removal survives restarts. An unknown email surfaces in the warning banner; success reports "Removed \<tier\> grant from \<email\>" and logs to the admin log.

The ✕ is dim by default and `--adanger` red on hover, in a width-collapsed right-edge column.

## Verification

- `go build ./...` and `go vet` clean.
- `TestTemplatesParse` (parses every template with the production funcMap) passes with `-count=1`.
- Not click-tested live: the admin panel needs Patreon admin auth plus a config bucket.

## Note for review

The PR carries two commits: the quick-add form (`ac23fb99`, a rebase of local `f3e31a81` onto origin/master — same content and authorship) that this change builds on, and the ✕-removal itself (`6b85e6c3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
