### PR TITLE
auth: gate the pprof endpoints behind the Admin grant

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -328,6 +328,22 @@ func putSignatureInCookies(w http.ResponseWriter, sig string) {
 	setCookie(w, "MTGBAN", sig, oneMonth, true)
 }
 
+// adminOnly hides the wrapped handler from signatures that do not carry
+// the Admin grant. It performs no validation of its own: it must sit
+// behind enforceSigning, which authenticates the signature before any of
+// its parameters can be trusted. Non-admins get a plain 404 so the
+// endpoint's existence is not advertised.
+func adminOnly(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		canDo, _ := strconv.ParseBool(GetParamFromSig(getSignatureFromCookies(r), "Admin"))
+		if !canDo && !(DevMode && !SigCheck) {
+			http.NotFound(w, r)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // This function is mostly here only for initializing the host
 // and the signature from invite links
 func noSigning(next http.Handler) http.Handler {

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -1302,8 +1303,20 @@ func main() {
 		w.Write([]byte("ok"))
 	})
 
+	// pprof registered itself on the default mux at import time, so its
+	// routes cannot be wrapped individually like the other pages; steer
+	// them through the standard signing middleware (plus the Admin grant)
+	// here instead, and everything else straight to the mux
+	debugHandler := enforceSigning(adminOnly(http.DefaultServeMux))
 	srv := &http.Server{
 		Addr: ":" + Config.Port,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasPrefix(r.URL.Path, "/debug") {
+				debugHandler.ServeHTTP(w, r)
+				return
+			}
+			http.DefaultServeMux.ServeHTTP(w, r)
+		}),
 	}
 
 	done := make(chan os.Signal, 1)


### PR DESCRIPTION
## Problem

`https://mtgban.com/debug/pprof/` is reachable by anyone — an anonymous request returns 200 and every profile with it: 30-second CPU captures, heap dumps, goroutine stacks with full source paths. That's both an internals leak and a free DoS lever (profiling is not cheap). Cause: `net/http/pprof` registers itself on the default mux at import time, and the server runs the default mux unwrapped.

## Fix

The pprof `init` already owns the `/debug/pprof/` mux patterns, so its routes can't be wrapped individually like the other pages — but the auth doesn't need reimplementing either. The server handler steers `/debug` requests through the **standard middleware chain**:

```go
debugHandler := enforceSigning(adminOnly(http.DefaultServeMux))
```

`enforceSigning` authenticates exactly like every gated page — cookie or `sig` query parameter, HMAC, expiry, rate limiting — and the new `adminOnly` middleware (~10 lines, no validation of its own) then requires the **Admin** grant, answering 404 so the endpoint stays unadvertised to non-admins. Everything outside `/debug` goes straight to the mux; dev mode without `-sig` stays open like the rest of the site.

The `sig` query parameter support comes from the existing plumbing for free, so command-line tools work without cookie juggling:

```
go tool pprof "https://mtgban.com/debug/pprof/profile?seconds=30&sig=<admin sig>"
```

Known minor limitation: `POST /debug/pprof/symbol` (legacy symbolization, unused by Go-native profiles) now answers 405 like any non-nav POST.

## Before / after

Before (production, anonymous request):

```
$ curl -s -o /dev/null -w "%{http_code}" https://mtgban.com/debug/pprof/
200   <- full pprof index
```

After (local build, `-sig` enabled, signatures minted against the dev secret):

```
anonymous:            standard unauthorized page
forged Admin=true:    standard unauthorized page   <- rejected by enforceSigning's HMAC check
valid non-admin sig:  404                          <- rejected by adminOnly
admin sig (cookie):   pprof index served
admin sig (?sig=):    pprof index served
```

Profiles also inherit the site's request rate limiting, which blunts the DoS angle further.

## Verification

`go build ./...`, `go vet`, and the test suite pass; the matrix above was taken against the running server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
