### PR TITLE
stop compressing responses in the app

### DIFF
--- a/api_suggest.go
+++ b/api_suggest.go
@@ -81,7 +81,14 @@ func SuggestAPI(w http.ResponseWriter, r *http.Request) {
 		// no cache holds on to the degraded answer
 		if len(AllNames) == 0 {
 			w.Header().Set("Cache-Control", "no-store")
+		} else {
+			// The full name list is the heaviest thing the front end
+			// asks for, and it only changes when the datastore reloads,
+			// so let the browser keep it instead of pulling it down on
+			// every page view
+			w.Header().Set("Cache-Control", "public, max-age=3600")
 		}
+		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(&AllNames)
 		return
 	}

--- a/auth.go
+++ b/auth.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/NYTimes/gziphandler"
 	"github.com/mtgban/mtgban-website/patreon"
 	"github.com/mtgban/mtgban-website/ratelimit"
 )
@@ -390,7 +389,7 @@ func enforceAPISigning(next http.Handler) http.Handler {
 
 		// If signature is empty let it pass through
 		if sig == "" && !strings.HasPrefix(r.URL.Path, "/api/load") {
-			gziphandler.GzipHandler(next).ServeHTTP(w, r)
+			next.ServeHTTP(w, r)
 			return
 		}
 
@@ -453,7 +452,7 @@ func enforceAPISigning(next http.Handler) http.Handler {
 			return
 		}
 
-		gziphandler.GzipHandler(next).ServeHTTP(w, r)
+		next.ServeHTTP(w, r)
 	})
 }
 
@@ -643,7 +642,7 @@ func enforceSigning(next http.Handler) http.Handler {
 		}
 
 		recordPageHit(r)
-		gziphandler.GzipHandler(next).ServeHTTP(w, r)
+		next.ServeHTTP(w, r)
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.25.0
 
 require (
 	github.com/BlueMonday/go-scryfall v0.9.0
-	github.com/NYTimes/gziphandler v1.1.1
 	github.com/PuerkitoBio/goquery v1.10.3
 	github.com/bwmarrin/discordgo v0.27.1
 	github.com/danielgtaylor/unistyle v0.0.0-20190218054314-fff153823f5f

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,6 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.56.0/go.mod h1:rqP9UEhOXv9WhQ7Gjz+G5y/pf8+BJZW5/Ts0AhE0PwE=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.56.0 h1:0YP0+/ixwu+Uqeu/FGiBZNQ19huiUxxiPXIc9WsLKuQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.56.0/go.mod h1:6ZZMQhZKDvUvkJw2rc+oDP90tMMzuU/J+5HG1ZmPOmE=
-github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
-github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/PuerkitoBio/goquery v1.10.3 h1:pFYcNSqHxBD06Fpj/KsbStFRsgRATgnf3LeXiUkhzPo=
 github.com/PuerkitoBio/goquery v1.10.3/go.mod h1:tMUX0zDMHXYlAQk6p35XxQMqMweEKB7iK7iLNd4RH4Y=
 github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9orim59UnfUTLRjMpd09C5uEVQ6RPGeCaVI=

--- a/main.go
+++ b/main.go
@@ -23,7 +23,6 @@ import (
 
 	"database/sql"
 
-	"github.com/NYTimes/gziphandler"
 	"github.com/hashicorp/go-cleanhttp"
 	_ "github.com/lib/pq"
 	"github.com/mtgban/mtgban-website/internal/palette"
@@ -1276,7 +1275,7 @@ func main() {
 	http.Handle("/api/suggest", noSigning(http.HandlerFunc(SuggestAPI)))
 	http.Handle("/api/chart/", noSigning(http.HandlerFunc(ChartDataAPI)))
 	http.Handle("/api/prices/", enforceSigning(http.HandlerFunc(BatchPricesAPI)))
-	http.Handle("/api/userstate/", noSigning(gziphandler.GzipHandler(http.HandlerFunc(UserStateAPI))))
+	http.Handle("/api/userstate/", noSigning(http.HandlerFunc(UserStateAPI)))
 	http.Handle("/api/opensearch.xml", noSigning(http.HandlerFunc(OpenSearchDesc)))
 	http.Handle("/api/load/datastore", noSigning(http.HandlerFunc(LoadDatastoreFromCloud)))
 	http.Handle("/api/load/", enforceAPISigning(http.HandlerFunc(LoadFromCloud)))


### PR DESCRIPTION
## Problem

The app compressed the pages behind its signing middleware, and nothing else — every other route already leaned on whatever sits in front. Both deployments now have something in front that compresses, and it gets the better result:

| | proxy | what reaches the reader |
|---|---|---|
| mtgban.com | nginx, `gzip_types` set | gzip |
| lorcana.mtgban.com | Cloudflare → DO App Platform | **brotli**, on html, css, js and `text/plain` alike |

A signed page on lorcana.mtgban.com comes back `content-encoding: br`, not the gzip the app produced — so the app's work there is not merely duplicated, it is discarded and redone better.

## Fix

Drop the compression from the app, and the `NYTimes/gziphandler` dependency with it. Also set the `Cache-Control` the card-name list never had: the front end refetches that list on every page view, and the edge currently answers `cf-cache-status: BYPASS` on it, while `/css/main.css` — where the app *does* set a header — is a `HIT`. So the app's `Cache-Control` reaches the edge intact and is what decides this.

## ⚠️ Needs an nginx change before merging

`text/csv` is **not** in the `gzip_types` list, and the price dumps under `/api/mtgban` are served as `text/csv`. They are compressed today *by the app*, so this PR would leave them raw:

```
$ curl -s -o /dev/null -D - -H "Accept-Encoding: gzip" https://mtgban.com/api/mtgban/sets.csv
Content-Type: text/csv
Content-Encoding: gzip        <- from the app, not nginx

sets.csv: identity 3154 -> gzip 1701
```

Adding `text/csv` to `gzip_types` covers it. The full price dumps are far larger than this sets listing, so it is worth doing first.

Worth knowing separately: on lorcana.mtgban.com the same endpoint already answers **with no `Content-Encoding` at all** — Cloudflare does not compress `text/csv` and does not pass the app's gzip through either, so those dumps go out raw today. That is a pre-existing gap this PR doesn't change, fixable with a Cloudflare compression rule.

## Verification

Every content type the app sets (`application/json`, `text/plain`, `text/csv`) and every type it serves through `http.ServeFile` was checked against what each proxy compresses; `text/csv` on nginx is the one gap, called out above. No `gziphandler` reference remains in the tree. Full main-package suite passes with the card datastore loaded; `gofmt`/`vet`/build clean; each commit builds and vets independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
