### PR TITLE
fix: stop at the notice when a subpage hides itself

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -457,6 +457,26 @@ func enforceAPISigning(next http.Handler) http.Handler {
 	})
 }
 
+// targetsSubPage reports whether r asks for the given subpage. Some
+// subpages have a path of their own, others are a query parameter on the
+// parent's path (the newspaper's pages all live under /newspaper and pick
+// themselves with page=), so the path has to match and so does every
+// parameter the link pins down. Matching the path alone would let the
+// parent stand in for its own subpage.
+func targetsSubPage(r *http.Request, link string) bool {
+	target, err := url.Parse(link)
+	if err != nil || target.Path != r.URL.Path {
+		return false
+	}
+	query := r.URL.Query()
+	for key, values := range target.Query() {
+		if len(values) > 0 && query.Get(key) != values[0] {
+			return false
+		}
+	}
+	return true
+}
+
 func enforceSigning(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer recoverPanic(r, w)
@@ -609,12 +629,12 @@ func enforceSigning(next http.Handler) http.Handler {
 
 				// Check if link is a subpage, and validate if viewing conditions are met
 				for _, subPage := range nav.SubPages {
-					if strings.HasPrefix(subPage.Link, r.URL.Path) &&
+					if targetsSubPage(r, subPage.Link) &&
 						subPage.ShouldHide != nil && subPage.ShouldHide() {
 						pageVars := genPageNav("Error", sig)
 						pageVars.Title = "Unauthorized"
 						render(w, "home.html", pageVars)
-						break
+						return
 					}
 				}
 

--- a/auth_subpage_test.go
+++ b/auth_subpage_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mtgban/mtgban-website/ratelimit"
+)
+
+// navWithHiddenSubPage installs a nav whose subpage hides itself, and
+// returns a handler whose body carries the marker, so a test can tell
+// whether the gated page was rendered.
+func navWithHiddenSubPage(t *testing.T, parentLink, subLink, marker string) http.Handler {
+	t.Helper()
+
+	savedNavs, savedOrder := ExtraNavs, OrderNav
+	savedDev, savedSig := DevMode, SigCheck
+	savedLimiter := UserRateLimiter
+	t.Cleanup(func() {
+		ExtraNavs, OrderNav = savedNavs, savedOrder
+		DevMode, SigCheck = savedDev, savedSig
+		UserRateLimiter = savedLimiter
+	})
+
+	// Unsigned requests all share the one empty-email bucket, so without a
+	// limiter of its own a test gets the rate limit notice instead of the page
+	UserRateLimiter = ratelimit.NewLimiter(UserRequestsPerSec, 1)
+	DevMode, SigCheck = true, false
+	ExtraNavs = map[string]*NavElem{
+		"Testing": {
+			Name: "Testing",
+			Link: parentLink,
+			Page: "home.html",
+			SubPages: []NavElem{
+				{
+					Name:       "Hidden",
+					Link:       subLink,
+					ShouldHide: func() bool { return true },
+				},
+			},
+		},
+	}
+	OrderNav = []string{"Testing"}
+
+	return enforceSigning(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(marker))
+	}))
+}
+
+// A hidden subpage answers with the notice and nothing else: rendering it
+// and carrying on into the gated handler used to glue both documents into
+// one response, serving the very page the subpage was hiding.
+func TestEnforceSigningHiddenSubPageStopsAtNotice(t *testing.T) {
+	const marker = "PAGE-BODY-MARKER"
+	handler := navWithHiddenSubPage(t, "/newspaper", "/newspaper?page=syp", marker)
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest("GET", "/newspaper?page=syp", nil))
+
+	body := recorder.Body.String()
+	if strings.Contains(body, marker) {
+		t.Error("gated handler ran after the notice was rendered")
+	}
+	if count := strings.Count(body, "</html>"); count != 1 {
+		t.Errorf("response holds %d documents, want exactly 1", count)
+	}
+}
+
+// Hiding a subpage must not hide the page it hangs off. The subpage is
+// picked by a query parameter, so matching on the path alone made every
+// plain request to the parent look like a request for the subpage.
+func TestEnforceSigningHiddenSubPageLeavesParentAlone(t *testing.T) {
+	const marker = "PAGE-BODY-MARKER"
+	handler := navWithHiddenSubPage(t, "/newspaper", "/newspaper?page=syp", marker)
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest("GET", "/newspaper", nil))
+
+	if !strings.Contains(recorder.Body.String(), marker) {
+		t.Error("parent page was withheld because one of its subpages is hidden")
+	}
+}
+
+// A subpage on a path of its own keeps working the same way.
+func TestEnforceSigningHiddenSubPageOwnPath(t *testing.T) {
+	const marker = "PAGE-BODY-MARKER"
+	handler := navWithHiddenSubPage(t, "/search", "/sealed", marker)
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest("GET", "/search", nil))
+
+	if !strings.Contains(recorder.Body.String(), marker) {
+		t.Error("parent page was withheld because a sibling subpage is hidden")
+	}
+}


### PR DESCRIPTION
## Problem

`enforceSigning` hides a subpage whose `ShouldHide` says so by rendering the unauthorized notice — then `break`s, which lands on the call into the gated handler a few lines below. Every other render in that function returns; this one doesn't. The response ends up carrying **both documents**, so the page the subpage was hiding is served anyway, appended to the notice saying it can't be.

It also matches the wrong request. A subpage link may pin a query parameter instead of having a path of its own, and the check compared that whole link against the request *path* by prefix:

```go
strings.HasPrefix(subPage.Link, r.URL.Path)   // "/newspaper?page=syp" vs "/newspaper"
```

Since the surrounding loop only runs when `r.URL.Path == nav.Link`, the parent always matches its own subpage. With the SYP buylist unavailable, **every plain request for `/newspaper`** takes the branch meant for `/newspaper?page=syp`.

The two faults hide each other: the guard fires on the wrong page, and the missing `return` means the right page gets rendered anyway, so nothing looks broken beyond a doubled document.

## Fix

`targetsSubPage` matches a subpage by its path *and* by every query parameter its link pins down, so the parent no longer stands in for its own subpage; and the branch returns once the notice is rendered.

## Verification

Three tests, each pinned to a distinct failure:

| test | fails on |
|---|---|
| `…StopsAtNotice` | today's code — the gated body is served after the notice |
| `…LeavesParentAlone` | a naive `break`→`return` — `/newspaper` withheld whenever SYP is missing |
| `…OwnPath` | a subpage with a path of its own regressing |

Each was confirmed to fail against the code it targets and pass with the fix. They install their own `UserRateLimiter`, since unsigned requests share the one empty-email bucket and would otherwise get the rate-limit notice instead of the page.

Full main-package suite passes with the card datastore loaded; `gofmt`/`vet`/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
