### PR TITLE
strip the templates' indentation once at parse time

### DIFF
--- a/internal/tmplparse/tmplparse.go
+++ b/internal/tmplparse/tmplparse.go
@@ -1,0 +1,62 @@
+// Package tmplparse parses HTML template files with the indentation they
+// are written with stripped out. Nesting a loop of rows inside a page
+// inside a base layout leaves every rendered row carrying its accumulated
+// indent, which on a large page is most of what the browser has to parse.
+package tmplparse
+
+import (
+	"fmt"
+	"html/template"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Runs of whitespace that span a line break, outside the elements whose
+// content is whitespace-significant. Go's regexp has no backreferences,
+// so each protected element is spelled out rather than matched by name.
+var indent = regexp.MustCompile(`(?is)(<pre\b[^>]*>.*?</pre>|<textarea\b[^>]*>.*?</textarea>|<script\b[^>]*>.*?</script>|<style\b[^>]*>.*?</style>)|[ \t]*\n[ \t\n]*`)
+
+// CollapseIndent reduces each run of whitespace containing a newline to a
+// single newline, never to nothing: HTML draws a word space between inline
+// elements separated by whitespace, so removing it outright would run them
+// together. What is left is one separator where the source had some, which
+// renders identically.
+//
+// Elements whose content renders verbatim - pre, textarea, script, style -
+// are handed back untouched.
+func CollapseIndent(src string) string {
+	return indent.ReplaceAllStringFunc(src, func(match string) string {
+		// A protected element came through whole; hand it back as it was
+		if strings.HasPrefix(match, "<") {
+			return match
+		}
+		return "\n"
+	})
+}
+
+// ParseFiles is html/template's ParseFiles with the sources collapsed on
+// the way in, and so with the same naming rules: each file becomes a
+// template named after its base, and the one matching the root's name is
+// parsed into the root itself. Only the template text is rewritten, never
+// the data later rendered through it.
+func ParseFiles(baseName string, files []string, funcs template.FuncMap) (*template.Template, error) {
+	root := template.New(baseName).Funcs(funcs)
+	for _, file := range files {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", file, err)
+		}
+		name := filepath.Base(file)
+		target := root
+		if name != baseName {
+			target = root.New(name)
+		}
+		_, err = target.Parse(CollapseIndent(string(src)))
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", file, err)
+		}
+	}
+	return root, nil
+}

--- a/internal/tmplparse/tmplparse_test.go
+++ b/internal/tmplparse/tmplparse_test.go
@@ -1,0 +1,94 @@
+package tmplparse
+
+import (
+	"html/template"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCollapseIndentKeepsOneSeparator(t *testing.T) {
+	// Inline elements separated by a line break draw a word space between
+	// them; collapsing to nothing would run the words together.
+	got := CollapseIndent("<span>one</span>\n        <span>two</span>")
+	want := "<span>one</span>\n<span>two</span>"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestCollapseIndentDropsBlankLines(t *testing.T) {
+	got := CollapseIndent("<div>\n\n    \n        <p>x</p>\n</div>")
+	want := "<div>\n<p>x</p>\n</div>"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// The elements whose content renders verbatim have to survive byte for
+// byte; the site's admin and upload templates both use them.
+func TestCollapseIndentLeavesVerbatimElements(t *testing.T) {
+	for _, tag := range []string{"pre", "textarea", "script", "style"} {
+		body := "\n    keep\n        this\n"
+		src := "<div>\n    <" + tag + " class=\"x\">" + body + "</" + tag + ">\n</div>"
+		got := CollapseIndent(src)
+		if !strings.Contains(got, body) {
+			t.Errorf("<%s> content was altered: %q", tag, got)
+		}
+	}
+}
+
+func TestCollapseIndentIsIdempotent(t *testing.T) {
+	src := "<div>\n    <p>a</p>\n\n        <p>b</p>\n</div>\n<pre>\n  x\n</pre>"
+	once := CollapseIndent(src)
+	if twice := CollapseIndent(once); twice != once {
+		t.Errorf("second pass changed the result:\n once: %q\ntwice: %q", once, twice)
+	}
+}
+
+// Template actions keep working across a collapse, including ones the
+// author already trimmed by hand.
+func TestCollapseIndentKeepsActions(t *testing.T) {
+	src := "{{ range .Items }}\n    <li>{{ .Name }}</li>\n{{ end }}\n{{- if .X }}y{{ end }}"
+	got := CollapseIndent(src)
+	for _, want := range []string{"{{ range .Items }}", "{{ .Name }}", "{{ end }}", "{{- if .X }}"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("action %q lost: %q", want, got)
+		}
+	}
+}
+
+// ParseFiles keeps html/template's naming rules, and renders the data it
+// is given untouched even where the template around it was collapsed.
+func TestParseFilesNamesAndRenders(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "base.html")
+	page := filepath.Join(dir, "page.html")
+	os.WriteFile(base, []byte("{{ define \"base.html\" }}\n    <main>\n        {{ template \"page.html\" . }}\n    </main>\n{{ end }}"), 0o600)
+	os.WriteFile(page, []byte("{{ define \"page.html\" }}\n    <span>{{ upper .Name }}</span>\n    <span>tail</span>\n{{ end }}"), 0o600)
+
+	funcs := template.FuncMap{"upper": strings.ToUpper}
+	tmpl, err := ParseFiles("base.html", []string{base, page}, funcs)
+	if err != nil {
+		t.Fatalf("ParseFiles: %v", err)
+	}
+
+	var out strings.Builder
+	err = tmpl.ExecuteTemplate(&out, "base.html", struct{ Name string }{"a b  c"})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	got := out.String()
+	if strings.Contains(got, "\n    ") {
+		t.Errorf("indentation survived: %q", got)
+	}
+	// Data passes through as given, spacing included
+	if !strings.Contains(got, "A B  C") {
+		t.Errorf("rendered value was altered: %q", got)
+	}
+	// The separator between the two inline elements is still there
+	if strings.Contains(got, "</span><span>") {
+		t.Errorf("inline elements were run together: %q", got)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/mtgban/mtgban-website/internal/palette"
 	"github.com/mtgban/mtgban-website/internal/suggest"
+	"github.com/mtgban/mtgban-website/internal/tmplparse"
 	"github.com/mtgban/mtgban-website/observability"
 	"github.com/mtgban/mtgban-website/tcgcsv"
 	"github.com/mtgban/mtgban-website/timeseries"
@@ -1436,7 +1437,7 @@ func buildTemplateCache() (map[string]*template.Template, error) {
 				key = "mobile/" + name
 			}
 			baseName, files := renderTemplateFiles(name, mobile)
-			t, err := template.New(baseName).Funcs(funcMap).ParseFiles(files...)
+			t, err := tmplparse.ParseFiles(baseName, files, funcMap)
 			if err != nil {
 				return nil, fmt.Errorf("parsing %s (mobile=%v): %w", name, mobile, err)
 			}
@@ -1452,7 +1453,7 @@ func render(w http.ResponseWriter, tmpl string, pageVars PageVars) {
 	if DevMode {
 		// Hot-reload: re-parse from disk every request
 		baseName, files := renderTemplateFiles(tmpl, pageVars.IsMobile)
-		t, err := template.New(baseName).Funcs(funcMap).ParseFiles(files...)
+		t, err := tmplparse.ParseFiles(baseName, files, funcMap)
 		if err != nil {
 			log.Print("template parsing error: ", err)
 			return


### PR DESCRIPTION
## Problem

A loop of rows nested inside a page nested inside a base layout leaves every rendered row carrying its accumulated indent. On a real search that is most of the document:

```
/search?q=Lightning+Bolt   7,436,198 bytes
  leading whitespace       4,176,996 bytes   (56% of the page)
  of which blank lines     2,319,857 bytes
```

Brotli hides this on the wire — the page ships in 77 KB — but the browser still decodes it back to **7.2 MB and tokenizes every byte**, which measured at ~1.37 s of parse time. Compression cannot help with that; only sending fewer bytes can.

## Fix

New package **`internal/tmplparse`** reads template files with their indentation collapsed. That happens once at start up rather than per request, and leaves how the templates are written alone — no `{{-` markers sprinkled through hundreds of lines, no per-request post-processing of rendered output.

The rule is the important part: **each run of whitespace containing a newline becomes a single newline, never nothing.** HTML draws a word space between inline elements separated by whitespace, so collapsing to nothing would run `<span>one</span>` and `<span>two</span>` together. Elements whose content renders verbatim — `pre`, `textarea`, `script`, `style` — pass through untouched; `templates/admin.html` and `templates/upload.html` both use them.

Only template text is rewritten, never the data rendered through it, so no card name or other value can be disturbed.

`html/template`'s `ParseFiles` offers nowhere to preprocess, so the package reimplements it — same naming rules, with the func map passed in as an argument. Both the production cache and the dev-mode hot-reload path go through it, so dev and prod render the same bytes.

Cost at start up: 29 template files, 539,950 bytes of source, **~18 ms** for the whole collapse pass, against a process that already spends ~25 s loading the datastore.

## Before / after

Same query, same local datastore, uncompressed HTML:

```
/search?q=Bolt   1,115,963 -> 412,375 bytes   (-63%)
remaining indentation           22,899 bytes
```

Better than the 56% the whitespace census predicted, because blank lines collapse away entirely rather than becoming a single newline each.

The page renders identically — inline spacing intact throughout (`TCG (Low / Market)`, `Condition: NM`, card rules text), no console errors. An earlier check of the same transformation applied to production's rendered output produced a byte-identical DOM, 24,339 nodes either way, and parsed 18% faster.

## Verification

Tests in `internal/tmplparse` cover the failure modes: one separator survives between inline elements, blank lines go, each verbatim element keeps its content byte-for-byte, the collapse is idempotent, template actions (including hand-trimmed `{{-`) survive, and `ParseFiles` keeps the stdlib's naming rules while rendering its data untouched — spacing included — without running inline elements together. In the main package, `buildTemplateCache` is exercised so every real template still parses. Full suite passes with the card datastore loaded; `gofmt`/`vet`/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
