### PR TITLE
recents: keep the search art off the sync wire

### DIFF
--- a/js/user-state.js
+++ b/js/user-state.js
@@ -95,8 +95,32 @@
 
     function payloadForSection(section) {
         if (section === 'favorites') return JSON.parse(readLocal(FAVORITES_KEY, '[]')).map(trimFavorite);
-        if (section === 'recents') return JSON.parse(readLocal(RECENTS_KEY, '[]'));
+        if (section === 'recents') return JSON.parse(readLocal(RECENTS_KEY, '[]')).map(trimRecent);
         return buildPreferences();
+    }
+
+    // Card art on a recent search is owned by the device: captureFirstResultImage
+    // in recent-searches.js reads it off the results page on every visit. It never
+    // travels over the wire, so drop whatever a server copy carries (older clients
+    // did push it) and re-apply what this device already has - otherwise a hydrate
+    // blanks the thumbnails of any entry whose art had not been pushed yet.
+    var RECENT_ART_KEYS = ['img', 'crop', 'foil', 'cw'];
+    function recentId(s) { return ('' + ((s && s.q) || '')).toLowerCase(); }
+    function keepRecentArt(recents) {
+        var localBy = {};
+        localRecents().forEach(function(s) { if (s && s.q != null) localBy[recentId(s)] = s; });
+        return (recents || []).map(function(s) {
+            if (!s) return s;
+            var prev = s.q != null ? localBy[recentId(s)] : null;
+            // Read prev before clearing s: a caller may hand us the local list.
+            var art = {};
+            if (prev && !s.del) {
+                RECENT_ART_KEYS.forEach(function(k) { if (prev[k] != null) art[k] = prev[k]; });
+            }
+            RECENT_ART_KEYS.forEach(function(k) { delete s[k]; });
+            Object.keys(art).forEach(function(k) { s[k] = art[k]; });
+            return s;
+        });
     }
 
     // Apply server state into localStorage.
@@ -120,8 +144,9 @@
                 writeFP('favorites', JSON.stringify(favs.map(trimFavorite)));
             }
             if (state.recents) {
-                rawSetItem(RECENTS_KEY, JSON.stringify(state.recents));
-                writeFP('recents', JSON.stringify(state.recents));
+                var recents = keepRecentArt(state.recents);
+                rawSetItem(RECENTS_KEY, JSON.stringify(recents));
+                writeFP('recents', JSON.stringify(recents.map(trimRecent)));
             }
             if (state.preferences) {
                 Object.keys(state.preferences).forEach(function(k) {
@@ -208,8 +233,10 @@
         attempt = attempt || 0;
         if (!serverState) return Promise.resolve(false);
         var mergedFavs = mergeList(localFavorites(), serverState.favorites || [], function(f) { return f.id; }, 50);
-        var mergedRecents = mergeList(localRecents(), serverState.recents || [], function(s) { return (s.q || '').toLowerCase(); }, 15);
+        var mergedRecents = mergeList(localRecents(), serverState.recents || [], recentId, 15);
         var mergedPrefs = mergePrefs(buildPreferences(), serverState.preferences || {});
+        // Must run before the write below: it reads the pre-merge local copies.
+        mergedRecents = keepRecentArt(mergedRecents);
 
         try {
             rawSetItem(FAVORITES_KEY, JSON.stringify(mergedFavs));
@@ -224,16 +251,30 @@
 
         // Nothing new to push: adopt version, skip the write.
         if (!localHasNew(mergedFavs, mergedRecents, mergedPrefs, serverState)) {
-            writeFP('favorites', JSON.stringify(mergedFavs.map(trimFavorite)));
-            writeFP('recents', JSON.stringify(mergedRecents));
-            writeFP('preferences', JSON.stringify(mergedPrefs));
-            markClean();
+            // Record a fingerprint only for a section the server verifiably
+            // holds. Claiming one for a payload that was never sent makes the
+            // next flush skip its PATCH, stranding the local copy for good.
+            // Merging can still reorder or cap a list the server agrees on, so
+            // re-queue whatever came out different instead of going clean.
+            var trimmedFavs = mergedFavs.map(trimFavorite);
+            var trimmedRecents = mergedRecents.map(trimRecent);
+            var synced = true;
+            if (sameList(trimmedFavs, (serverState.favorites || []).map(trimFavorite), function(f) { return f.id; })) {
+                writeFP('favorites', JSON.stringify(trimmedFavs));
+            } else { schedule('favorites'); synced = false; }
+            if (sameList(trimmedRecents, (serverState.recents || []).map(trimRecent), recentId)) {
+                writeFP('recents', JSON.stringify(trimmedRecents));
+            } else { schedule('recents'); synced = false; }
+            if (canonJSON(mergedPrefs) === canonJSON(serverState.preferences || {})) {
+                writeFP('preferences', JSON.stringify(mergedPrefs));
+            } else { schedule('preferences'); synced = false; }
+            if (synced) markClean();
             writeMarker(version);
             return Promise.resolve(true);
         }
 
         var body = JSON.stringify({
-            favorites: mergedFavs.map(trimFavorite), recents: mergedRecents,
+            favorites: mergedFavs.map(trimFavorite), recents: mergedRecents.map(trimRecent),
             preferences: mergedPrefs, version: version
         });
         return fetch(BASE, {
@@ -254,7 +295,7 @@
                 if (res && typeof res.version === 'number') version = res.version;
                 writeMarker(version);
                 writeFP('favorites', JSON.stringify(mergedFavs.map(trimFavorite)));
-                writeFP('recents', JSON.stringify(mergedRecents));
+                writeFP('recents', JSON.stringify(mergedRecents.map(trimRecent)));
                 writeFP('preferences', JSON.stringify(mergedPrefs));
                 markClean();
                 return true;
@@ -322,6 +363,31 @@
         return live.concat(tombs);
     }
 
+    // A payload and the server's copy of it agree on content but not on shape:
+    // JSONB does not preserve key order, and mergeList re-sorts and caps lists.
+    // Compare on a canonical form - keys sorted, entries ordered by id.
+    function canonJSON(x) {
+        return JSON.stringify(canonValue(x));
+    }
+    function canonValue(x) {
+        if (x === null || typeof x !== 'object') return x === undefined ? null : x;
+        if (Array.isArray(x)) return x.map(canonValue);
+        var out = {};
+        Object.keys(x).sort().forEach(function(k) {
+            if (x[k] !== undefined) out[k] = canonValue(x[k]);
+        });
+        return out;
+    }
+    function sameList(a, b, idOf) {
+        function canon(list) {
+            return canonJSON((list || []).slice().sort(function(x, y) {
+                var xi = String(idOf(x)), yi = String(idOf(y));
+                return xi < yi ? -1 : xi > yi ? 1 : 0;
+            }));
+        }
+        return canon(a) === canon(b);
+    }
+
     // Preferences: last-write-wins per key (local wins on first merge).
     function mergePrefs(localPrefs, serverPrefs) {
         var out = {};
@@ -342,6 +408,15 @@
             foil: f.foil, etched: f.etched,
             finishTag: f.finishTag, finishClass: f.finishClass,
             treatments: f.treatments, img: f.img, cw: f.cw
+        };
+    }
+
+    // Recents sync identity and intent only; the card art (img, crop, foil, cw)
+    // is re-derived on each device from the search results page.
+    function trimRecent(s) {
+        return {
+            q: s.q, t: s.t, m: s.m, del: s.del, pinned: s.pinned,
+            set: s.set, keyrune: s.keyrune
         };
     }
 


### PR DESCRIPTION
## Problem

Recent-searches rows lose their card art. On `/search`, the newest entries
render the magnifier placeholder while older ones keep their background
(reported for `price>1000` and `Rugged Prairie`, the two most recent entries).

Not a server-side gap — production serves good art for both of the queries
that came up blank:

```
/search?q=Rugged+Prairie   → data-crop-url=".../art_crop/front/6/b/6bd21c9e….jpg"
/search?q=price%3E1000     → data-crop-url=".../art_crop/front/c/7/c74e5574….jpg"
```

## Cause

A race between the art capture and the cross-device sync layer.

1. On form submit, `addSearch` stores the entry art-less, and the `pagehide`
   keepalive PATCH pushes that copy to the server.
2. On the results page, `captureFirstResultImage` fills in `img`/`crop` but
   does **not** bump `m`. The setItem shim marks dirty and schedules a PATCH
   1.5s out.
3. `hydrate` (user-state.js loads before recent-searches.js) sees dirty, GETs,
   and reaches `reconcile` well inside that 1.5s.
4. `mergeList` keeps the local copy on an `m` tie, so the art survives locally.
   But `localHasNew` compares mtimes only → `false` → reconcile takes the
   "nothing new to push" branch, which writes a fingerprint **for a payload it
   never sent**, and marks clean.
5. The queued flush hits `fpMatches` in `patchSection` and resolves without a
   request. The art never reaches the server.
6. A later clean hydrate takes the `applyState` path, which does a wholesale
   `rawSetItem(RECENTS_KEY, JSON.stringify(state.recents))` — unlike the
   favorites branch right above it, which preserves local-only fields. The art
   is wiped.

Whether an entry keeps its art comes down to which side of the 1.5s the GET
lands on, which is why the newest entries are the ones that look broken.

## Fix

Make the art device-owned rather than synced.

- `trimRecent` keeps `img`/`crop`/`foil`/`cw` out of every payload, mirroring
  how `trimFavorite` already holds back favorite prices.
- `keepRecentArt` drops whatever a server copy carries (older clients did push
  it, so legacy rows can't shadow local values) and re-applies this device's
  art on both inbound paths — `applyState` and post-`mergeList` in `reconcile`.
- `captureFirstResultImage` re-derives the art on every results-page visit, so
  there is nothing left to race over.

Plus the fingerprint hole: `reconcile` now compares the merged list against the
server's on a canonical form (JSONB preserves neither key nor list order) and
only records a fingerprint for a section the server verifiably holds. Anything
that came out different is re-queued instead of marked clean, so a reorder or
an expired tombstone converges on the next flush rather than being stranded.

## Verification

No JS test runner in the repo, so I drove the real `js/user-state.js` in a fake
browser (fake `Storage`, `fetch`, timers) reproducing the exact race — local
entry enriched with a crop, server holding the art-less copy at the same `m`,
then a clean re-hydrate:

```
===== BEFORE (HEAD) =====
local entry keeps crop:      true
art sent over the wire:      false
after a clean re-hydrate:   crop=LOST img=LOST

===== AFTER (patched) =====
local entry keeps crop:      true
art sent over the wire:      false
after a clean re-hydrate:   crop=kept img=kept
```

And six scenarios over the paths this touches:

```
1. already in sync, nothing local-only: no write, goes clean
  ok   no write issued
  ok   marked clean
2. local pin is newer: pushed, art stays home
  ok   a write happened
  ok   pin reached server
  ok   no art on the wire
  ok   art still local
3. server entry is newer (other device): adopted, local art survives
  ok   adopted server pin
  ok   kept local art
4. server tombstone wins: entry hidden, art dropped
  ok   tombstone applied
  ok   art cleared on tombstone
5. local tombstone wins: delete propagates to server
  ok   delete reached server
6. entry only on the server: pulled down
  ok   entry pulled

12 passed, 0 failed
```

Note: existing server rows keep their legacy `img`/`crop` fields until the first
push from an updated client rewrites them; `keepRecentArt` deletes them on read
in the meantime. The `?hash=` cache-buster is the VCS revision, so deploying
busts it on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
