### PR TITLE
perf: the rest of the small-batch fixes

### DIFF
--- a/api_banprice.go
+++ b/api_banprice.go
@@ -887,29 +887,33 @@ func BanPrice2CSV(httpWriter http.ResponseWriter, pm map[string]map[string]*BanP
 // When uploadedData is nil, rows are derived from the price map keys (using
 // sorted for ordering if non-nil).
 func SimplePrice2CSV(w *csv.Writer, pm map[string]map[string]*BanPrice, uploadedData []UploadEntry, sorted []string, preferFlavor bool) error {
+	// One pass over the registered scrapers for the index set, and a
+	// membership map for the seen scrapers: the loop below visits every
+	// (row, store) pair and slices.Contains made it quadratic.
+	metaOnly := map[string]bool{}
+	for _, scraper := range GetSellers() {
+		if scraper.Info().MetadataOnly {
+			metaOnly[scraper.Info().Shorthand] = true
+		}
+	}
+	for _, scraper := range GetVendors() {
+		if scraper.Info().MetadataOnly {
+			metaOnly[scraper.Info().Shorthand] = true
+		}
+	}
+
 	var allScrapers []string
-	var allIndexes []string
+	seen := map[string]bool{}
+	allIndexes := map[string]bool{}
 	for id := range pm {
 		for scraperKey := range pm[id] {
-			if slices.Contains(allScrapers, scraperKey) {
+			if seen[scraperKey] {
 				continue
 			}
-
-			for _, scraper := range GetSellers() {
-				if scraper.Info().Shorthand == scraperKey && scraper.Info().MetadataOnly {
-					if !slices.Contains(allIndexes, scraperKey) {
-						allIndexes = append(allIndexes, scraperKey)
-					}
-				}
+			seen[scraperKey] = true
+			if metaOnly[scraperKey] {
+				allIndexes[scraperKey] = true
 			}
-			for _, scraper := range GetVendors() {
-				if scraper.Info().Shorthand == scraperKey && scraper.Info().MetadataOnly {
-					if !slices.Contains(allIndexes, scraperKey) {
-						allIndexes = append(allIndexes, scraperKey)
-					}
-				}
-			}
-
 			allScrapers = append(allScrapers, scraperKey)
 		}
 	}
@@ -999,7 +1003,7 @@ func SimplePrice2CSV(w *csv.Writer, pm map[string]map[string]*BanPrice, uploaded
 	return w.Error()
 }
 
-func priceRowToCSV(pm map[string]map[string]*BanPrice, id string, allScrapers, allIndexes []string, condition string, preferFlavor, withSKU bool) ([]string, error) {
+func priceRowToCSV(pm map[string]map[string]*BanPrice, id string, allScrapers []string, allIndexes map[string]bool, condition string, preferFlavor, withSKU bool) ([]string, error) {
 	co, err := mtgmatcher.GetUUID(id)
 	if err != nil {
 		uuid := mtgmatcher.ExternalUUID(id)
@@ -1023,11 +1027,11 @@ func priceRowToCSV(pm map[string]map[string]*BanPrice, id string, allScrapers, a
 			continue
 		}
 		cond := condition
-		if slices.Contains(allIndexes, scraper) {
+		if allIndexes[scraper] {
 			cond = ""
 		}
 		price := getPrice(entry, cond)
-		prices[i] = fmt.Sprintf("%0.2f", price)
+		prices[i] = strconv.FormatFloat(price, 'f', 2, 64)
 	}
 
 	scryfallID, found := co.Identifiers["scryfallId"]

--- a/news.go
+++ b/news.go
@@ -1271,12 +1271,22 @@ func Newspaper(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if skipEditionsOpt != "" || rarity != "" || filter != "" || bucket != "" || finish != "" {
+		// Editions repeat across rows, so resolve each distinct one once
+		// rather than per row, and split the filter list once as well.
+		skipEditions := strings.Split(skipEditionsOpt, ",")
+		setCodeByEdition := map[string]string{}
 		var output []NewspaperResult
 		for _, result := range results {
 			if skipEditionsOpt != "" {
-				filters := strings.Split(skipEditionsOpt, ",")
-				set, err := mtgmatcher.GetSetByName(result.Edition)
-				if err == nil && slices.Contains(filters, set.Code) {
+				code, found := setCodeByEdition[result.Edition]
+				if !found {
+					set, err := mtgmatcher.GetSetByName(result.Edition)
+					if err == nil {
+						code = set.Code
+					}
+					setCodeByEdition[result.Edition] = code
+				}
+				if code != "" && slices.Contains(skipEditions, code) {
 					continue
 				}
 			}
@@ -1312,24 +1322,35 @@ func Newspaper(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 
-			sort.SliceStable(results, func(i, j int) bool {
-				a := results[i].FieldValue(sorting)
-				b := results[j].FieldValue(sorting)
-				var af, bf float64
-				af, _ = strconv.ParseFloat(a, 64)
-				bf, _ = strconv.ParseFloat(b, 64)
-				numberSort := af != 0 || bf != 0
+			// FieldValue formats the field per call; resolve each row's
+			// sort key once instead of twice per comparison.
+			type decorated struct {
+				row NewspaperResult
+				str string
+				num float64
+			}
+			dec := make([]decorated, len(results))
+			for i := range results {
+				s := results[i].FieldValue(sorting)
+				f, _ := strconv.ParseFloat(s, 64)
+				dec[i] = decorated{row: results[i], str: s, num: f}
+			}
+			sort.SliceStable(dec, func(i, j int) bool {
+				numberSort := dec[i].num != 0 || dec[j].num != 0
 				if dir == "asc" {
 					if numberSort {
-						return af < bf
+						return dec[i].num < dec[j].num
 					}
-					return a < b
+					return dec[i].str < dec[j].str
 				}
 				if numberSort {
-					return af > bf
+					return dec[i].num > dec[j].num
 				}
-				return a > b
+				return dec[i].str > dec[j].str
 			})
+			for i := range dec {
+				results[i] = dec[i].row
+			}
 			break
 		}
 	}

--- a/screener.go
+++ b/screener.go
@@ -175,14 +175,25 @@ func sortScreenerRows(rows []ScreenerResult, field, dir string) {
 	if field == "" {
 		field = "pct"
 	}
-	sort.SliceStable(rows, func(i, j int) bool {
-		a, _ := strconv.ParseFloat(rows[i].FieldValue(field), 64)
-		b, _ := strconv.ParseFloat(rows[j].FieldValue(field), 64)
+	// FieldValue formats the field per call; resolve each row's key once.
+	type decorated struct {
+		row ScreenerResult
+		num float64
+	}
+	dec := make([]decorated, len(rows))
+	for i := range rows {
+		num, _ := strconv.ParseFloat(rows[i].FieldValue(field), 64)
+		dec[i] = decorated{row: rows[i], num: num}
+	}
+	sort.SliceStable(dec, func(i, j int) bool {
 		if dir == "asc" {
-			return a < b
+			return dec[i].num < dec[j].num
 		}
-		return a > b
+		return dec[i].num > dec[j].num
 	})
+	for i := range dec {
+		rows[i] = dec[i].row
+	}
 }
 
 type EditionFacet struct {

--- a/upload.go
+++ b/upload.go
@@ -1000,8 +1000,11 @@ func Upload(w http.ResponseWriter, r *http.Request) {
 
 		cardId := uploadedData[i].CardId
 
-		// Pick the right store list for this entry
-		isSealed := slices.Contains(sealedProductIds, cardId)
+		// Pick the right store list for this entry. The sealed id list was
+		// built from this same lookup, so ask the datastore directly instead
+		// of scanning the list per row.
+		co, err := mtgmatcher.GetUUID(cardId)
+		isSealed := err == nil && co.Sealed
 		entryStores := enabledStores
 		if isSealed {
 			entryStores = enabledSealedStores


### PR DESCRIPTION
The three fixes from #293 that were left behind when it was trimmed to two, rebased onto current master and adjusted for what has landed since.

1. **Upload sealed flag** (`upload.go`) — the per-entry loop tested each row against the sealed product id list with `slices.Contains`: rows × sealed ids string comparisons, thousands per upload, and worse since the extended row cap went to 15000. That list is built from `GetUUID`'s `Sealed` flag in the first place, so the loop asks the datastore directly — one map lookup per row.

2. **CSV dump membership** (`api_banprice.go`) — column discovery tested each scraper key against a growing slice and rescanned every registered seller and vendor on each new key, quadratic in stores over dumps of thousands of rows; every rendered cell then paid another `Contains`. Membership goes through maps built from one metadata-only pass, and cells render with `strconv.FormatFloat` instead of `Sprintf`. *The single-flush change this commit originally carried is already on master, so only the rest is here.*

3. **Newspaper and screener sorts** (`news.go`, `screener.go`) — the edition filter split the cookie and resolved the set of every row, though editions repeat across a table; both comparators then called `FieldValue` on each side of every comparison, formatting the field to a string and parsing it back, N log N times. Distinct editions resolve once, the list splits once, and rows are decorated with their sort key before ordering.

## Note on what changed since

The third commit's original justification leaned partly on `GetSetByName` being a scan over every set. go-mtgban#61 has since made it an index lookup, so that half is worth much less than it was — its comment has been rewritten not to claim otherwise. The `FieldValue`-per-comparison half is untouched by that and still stands on its own.

## Verification

Full main-package suite passes with the card datastore loaded; `gofmt`/`vet`/build clean; each commit builds and vets independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
