### PR TITLE
read the SYP quantity rule off the scraper, not its name

### DIFF
--- a/api_banprice.go
+++ b/api_banprice.go
@@ -558,7 +558,7 @@ func banPricesFromRows(cardIds []string, found map[string]map[string][]SearchEnt
 
 				shouldQty := qty && !row.NoQuantity
 				if vendorSide {
-					shouldQty = qty && (!indexStores[row.Shorthand] || row.Shorthand == "SYP")
+					shouldQty = qty && (!indexStores[row.Shorthand] || row.QuantityPriority)
 				}
 				if shouldQty {
 					if co.Sealed {
@@ -860,7 +860,7 @@ func getVendorPrices(mode string, enabledStores []string, filterByEdition string
 		}
 
 		// Loop through cards
-		shouldQty := qty && (!vendor.Info().MetadataOnly || vendor.Info().Shorthand == "SYP")
+		shouldQty := qty && (!vendor.Info().MetadataOnly || vendor.Info().QuantityPriority)
 		shouldBaseCond := !vendor.Info().MetadataOnly && !vendor.Info().SealedMode
 
 		rule := EntryRule{

--- a/search.go
+++ b/search.go
@@ -54,6 +54,12 @@ type SearchEntry struct {
 	NoQuantity   bool
 	BundleIcon   string
 
+	// QuantityPriority marks a store whose rows are read as a count of
+	// copies wanted rather than as an offer, so the quantity is shown
+	// where the price would be and the price is not ranked against the
+	// others. The scraper declares it; nothing here names the store.
+	QuantityPriority bool
+
 	// Badge renders this entry as the official "Available at Amazon"
 	// search-link badge rather than a normal store row. BundleIcon is a
 	// generic per-store icon, so it cannot be used to single this out.
@@ -1151,15 +1157,16 @@ func searchSellersNG(cardIds []string, config SearchConfig) (foundSellers map[st
 
 				// Prepare all the deets
 				res := SearchEntry{
-					ScraperName: name,
-					Shorthand:   info.Shorthand,
-					Price:       entry.Price,
-					Quantity:    entry.Quantity,
-					URL:         entry.URL,
-					NoQuantity:  info.NoQuantityInventory || info.MetadataOnly,
-					BundleIcon:  icon,
-					Country:     Country2flag[info.CountryFlag],
-					ExtraValues: entry.ExtraValues,
+					ScraperName:      name,
+					Shorthand:        info.Shorthand,
+					Price:            entry.Price,
+					Quantity:         entry.Quantity,
+					URL:              entry.URL,
+					NoQuantity:       info.NoQuantityInventory || info.MetadataOnly,
+					BundleIcon:       icon,
+					QuantityPriority: info.QuantityPriority,
+					Country:          Country2flag[info.CountryFlag],
+					ExtraValues:      entry.ExtraValues,
 				}
 				if info.CreditMultiplier > 0 {
 					res.Credit = entry.Price / info.CreditMultiplier

--- a/templates/mobile/search.html
+++ b/templates/mobile/search.html
@@ -456,7 +456,7 @@
                                         {{if $entry.URL}}<a class="m-vendor-link" href="{{$entry.URL}}" target="_blank" rel="nofollow">{{$entry.ScraperName}}</a>{{else}}{{$entry.ScraperName}}{{end}}
                                     </span>
                                     <span class="m-vendor-right">
-                                        <span class="m-vendor-price">{{if eq $entry.Shorthand "SYP"}}# {{$entry.Quantity}}{{else if $entry.Price}}$ {{printf "%.2f" $entry.Price}}{{else}}n/a{{end}}</span>
+                                        <span class="m-vendor-price">{{if $entry.QuantityPriority}}# {{$entry.Quantity}}{{else if $entry.Price}}$ {{printf "%.2f" $entry.Price}}{{else}}n/a{{end}}</span>
                                         <span class="m-vendor-qty"></span>
                                     </span>
                                 </div>
@@ -485,7 +485,7 @@
                                             {{if eq $ei 0}}<span class="m-best-badge">Best</span>{{end}}
                                         </span>
                                         <span class="m-vendor-right">
-                                            <span class="m-vendor-price{{if and (ne $entry.Shorthand "SYP") (gt $card.GoodBuylist 0.0) (ge $entry.Price $card.GoodBuylist)}} m-price-best{{end}}">$ {{printf "%.2f" $entry.Price}}</span>
+                                            <span class="m-vendor-price{{if and (not $entry.QuantityPriority) (gt $card.GoodBuylist 0.0) (ge $entry.Price $card.GoodBuylist)}} m-price-best{{end}}">$ {{printf "%.2f" $entry.Price}}</span>
                                             <span class="m-vendor-qty">{{if and $entry.Quantity (eq $conditions "NM")}}{{$entry.Quantity}}{{end}}</span>
                                             <i class="m-vendor-chevron" data-lucide="chevron-down"></i>
                                         </span>
@@ -519,7 +519,7 @@
                                         {{if eq $ei 0}}<span class="m-best-badge">Best</span>{{end}}
                                     </span>
                                     <span class="m-vendor-right">
-                                        <span class="m-vendor-price{{if and (ne $entry.Shorthand "SYP") (gt $card.GoodBuylist 0.0) (ge $entry.Price $card.GoodBuylist)}} m-price-best{{end}}">$ {{printf "%.2f" $entry.Price}}</span>
+                                        <span class="m-vendor-price{{if and (not $entry.QuantityPriority) (gt $card.GoodBuylist 0.0) (ge $entry.Price $card.GoodBuylist)}} m-price-best{{end}}">$ {{printf "%.2f" $entry.Price}}</span>
                                         <span class="m-vendor-qty">{{if and $entry.Quantity (eq $conditions "NM")}}{{$entry.Quantity}}{{end}}</span>
                                     </span>
                                 </div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -1292,10 +1292,10 @@
                                                     {{$blPriceWarn = invalid_direct $cardId .Price}}
                                                 {{end}}
                                                 {{$aboveP90 := false}}
-                                                {{if and (ne .Shorthand "SYP") (gt $card.GoodBuylist 0.0) (ge .Price $card.GoodBuylist)}}{{$aboveP90 = true}}{{end}}
+                                                {{if and (not .QuantityPriority) (gt $card.GoodBuylist 0.0) (ge .Price $card.GoodBuylist)}}{{$aboveP90 = true}}{{end}}
                                                 <span class="price-right has-buylist-extra">
                                                 <span class="price{{if $blPriceWarn}} price-warn{{end}}{{if $aboveP90}} price-best{{end}}" {{if $blPriceWarn}}data-tooltip="Price looks off — TCG Market is {{$marketPrice := tcg_market_price $cardId}}{{if $marketPrice}}$ {{printf "%.2f" $marketPrice}}{{else}}missing{{end}}"{{else if gt $card.GoodBuylist 0.0}}title="Card Kingdom P90 $ {{printf "%.2f" $card.GoodBuylist}}{{if gt $card.HighestBuylist 0.0}}; 90-day high $ {{printf "%.2f" $card.HighestBuylist}}{{end}}"{{end}}>
-                                                    {{if ne .Shorthand "SYP"}}<span class="cur">$</span><span class="amt">{{printf "%.2f" .Price}}</span>
+                                                    {{if not .QuantityPriority}}<span class="cur">$</span><span class="amt">{{printf "%.2f" .Price}}</span>
                                                     {{else}}<span class="cur">#</span><span class="amt">{{.Quantity}}</span>
                                                     {{end}}
                                                 </span>


### PR DESCRIPTION
Follows go-mtgban's `QuantityPriority`, which v0.6.13 sets but nothing read yet.

## Problem

The SYP list reports how many copies TCGplayer still wants at a given market price, so its rows are a count rather than an offer. Three places act on that, and each asked for the store by name:

| | did | now |
|---|---|---|
| `api_banprice.go` ×2 | `row.Shorthand == "SYP"` / `vendor.Info().Shorthand == "SYP"` | `row.QuantityPriority` / `vendor.Info().QuantityPriority` |
| `templates/search.html` ×2 | `ne .Shorthand "SYP"` | `not .QuantityPriority` |
| `templates/mobile/search.html` ×3 | `eq $entry.Shorthand "SYP"` | `$entry.QuantityPriority` |

That spread one scraper's identity across the price API and both search views — exactly what the flag was added to stop.

## Fix

Read the flag the scraper declares. `SearchEntry` carries it to the templates, sitting beside the `NoQuantity` it already carried for the same kind of reason; `api_banprice` reads it off the same entry and off `ScraperInfo` directly on the vendor side.

Nothing changes behaviourally today — SYP is the only scraper setting the flag — but a second such list now works without touching the website, and the price API picks it up from the dumps once regenerated.

## What is deliberately left

The remaining `"SYP"` references name the list because they *are* about that list, not about how a row is read: the newspaper page and its CSV download, the `nosyp` arbitrage filter, the `syp` search keyword, the badge on a card, and the nav entry that hides itself when the list is unavailable. `templates/arbit.html`'s three checks are page identity — routing to `?page=syp` and placing that page's download link — not scraper metadata.

## Verification

Full main-package suite passes with the card datastore loaded, `TestTemplatesParse` included, so both rewritten templates still parse; `gofmt`/`vet`/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
