### PR TITLE
charts: stash non-Magic snapshots through the long form

### DIFF
--- a/chart.go
+++ b/chart.go
@@ -559,17 +559,25 @@ func stashInTimeseries() {
 		}
 	}
 
-	// Upsert all accumulated rows in batches
-	rows := make([]timeseries.PriceRow, 0, len(accumulated))
-	for _, row := range accumulated {
-		rows = append(rows, *row)
-	}
+	// Upsert all accumulated rows in batches. The wide table is out of reach
+	// for non-default games - its mtgjson_uuid column is Postgres type uuid,
+	// and their ids (Lorcana's "1459_f") are not uuids - so they persist
+	// exclusively through the long form below.
+	var upserted, errCount int
+	if Config.Game == DefaultGame {
+		rows := make([]timeseries.PriceRow, 0, len(accumulated))
+		for _, row := range accumulated {
+			rows = append(rows, *row)
+		}
 
-	upserted, err := PricesArchiveDB.UpsertRows(context.Background(), rows, 500)
-	var errCount int
-	if err != nil {
-		errCount = len(rows) - upserted
-		ServerNotify("timeseries", fmt.Sprintf("batch upsert error: %s", err))
+		var err error
+		upserted, err = PricesArchiveDB.UpsertRows(context.Background(), rows, 500)
+		if err != nil {
+			errCount = len(rows) - upserted
+			ServerNotify("timeseries", fmt.Sprintf("batch upsert error: %s", err))
+		}
+	} else if !Config.TimeseriesConfig.LongFormWrites {
+		ServerNotify("timeseries", "snapshot has nowhere to write: non-default games need long_form_writes enabled")
 	}
 
 	// Dual-write the same snapshot into the long form (variants + prices).
@@ -588,28 +596,72 @@ func stashInTimeseries() {
 	ServerNotify("timeseries", msg)
 }
 
-// stashLongForm mirrors the accumulated wide rows into the long prices table. It
-// warms the variant cache once, resolves each row's ban_id (minting new
-// printings on the fly), and emits one LongPrice per set provider column with a
-// positive price (zeros are omitted, matching the backfill). Returns the number
-// of price rows upserted.
-func stashLongForm(ctx context.Context, accumulated map[string]*timeseries.PriceRow) (int, error) {
-	if err := PricesArchiveDB.WarmVariantCache(ctx); err != nil {
-		return 0, fmt.Errorf("warm variant cache: %w", err)
-	}
-	longRows := make([]timeseries.LongPrice, 0, len(accumulated)*4)
-	for _, row := range accumulated {
+// stashRowBanID resolves an accumulated row to its long-form variant. The
+// default game is keyed by mtgjson uuid; any other game maps the card's
+// TCGplayer product plus its finish sub-type - the same identity the tcgcsv
+// ingest mints, so both writers converge on one ban_id per printing.
+func stashRowBanID(ctx context.Context, row *timeseries.PriceRow) (int64, error) {
+	if Config.Game == DefaultGame {
 		lang := ""
 		if row.Language != nil {
 			lang = *row.Language
 		}
-		banID, err := PricesArchiveDB.ResolveMagicBanID(ctx, timeseries.MagicVariant{
+		return PricesArchiveDB.ResolveMagicBanID(ctx, timeseries.MagicVariant{
 			MtgjsonUUID: row.MtgjsonUUID,
 			IsFoil:      row.IsFoil,
 			IsEtched:    row.IsEtched,
 			IsAlt:       row.IsAlt,
 			Language:    lang,
 		})
+	}
+
+	// row.MtgjsonUUID carries the game-native id on non-default instances
+	co, err := mtgmatcher.GetUUID(row.MtgjsonUUID)
+	if err != nil {
+		return 0, err
+	}
+	pid, ok := tcgProductID(co)
+	if !ok {
+		return 0, fmt.Errorf("no TCGplayer product id for %s", row.MtgjsonUUID)
+	}
+	category := GetTCGCategoryID()
+	if category <= 0 {
+		return 0, fmt.Errorf("no TCGplayer category for game %q: catalog not loaded", Config.Game)
+	}
+	// Must be the sub-type the tcgcsv ingest stores for the same printing, or
+	// the two writers mint different ban_ids for it. That holds for a game
+	// publishing a single "Foil" printing (Magic, Riftbound) and not for one
+	// naming them otherwise - Lorcana's are "Cold Foil" and "Holofoil", with a
+	// dozen products carrying both - which needs the per-product printings the
+	// catalog dump lists. Unresolved: this writes an identity no Lorcana
+	// ingest row shares.
+	subType := "Normal"
+	if row.IsFoil || row.IsEtched {
+		subType = "Foil"
+	}
+	return PricesArchiveDB.ResolveTCGBanID(ctx, timeseries.TCGVariant{
+		CategoryID: category, ProductID: pid, SubType: subType,
+	})
+}
+
+// stashLongForm mirrors the accumulated wide rows into the long prices table. It
+// warms the variant cache once, resolves each row's ban_id (minting new
+// printings on the fly), and emits one LongPrice per set provider column with a
+// positive price (zeros are omitted, matching the backfill). Returns the number
+// of price rows upserted.
+func stashLongForm(ctx context.Context, accumulated map[string]*timeseries.PriceRow) (int, error) {
+	// A game with no category has no variant identity for any of its rows, so
+	// say it once here: per-row resolution would log the same thing for every
+	// card in the snapshot.
+	if Config.Game != DefaultGame && GetTCGCategoryID() <= 0 {
+		return 0, fmt.Errorf("no TCGplayer category for game %q: catalog not loaded", Config.Game)
+	}
+	if err := PricesArchiveDB.WarmVariantCache(ctx); err != nil {
+		return 0, fmt.Errorf("warm variant cache: %w", err)
+	}
+	longRows := make([]timeseries.LongPrice, 0, len(accumulated)*4)
+	for _, row := range accumulated {
+		banID, err := stashRowBanID(ctx, row)
 		if err != nil {
 			log.Println("long-form: resolve ban_id:", err)
 			continue


### PR DESCRIPTION
## Problem

A Lorcana instance's twice-daily snapshot persisted nothing. Every 500-row batch failed:

```
batch upsert error: pq: invalid input syntax for type uuid: "1459" (22P02)
```

The stash is the only capture point for the per-scraper prices a game instance loads — Card Kingdom carries Lorcana, and no TCGplayer feed covers it — so losing it loses those sources entirely for that game.

## Cause

The stash was keyed by mtgjson uuid end to end. Non-Magic ids (`1459_f`) are not uuids, and the wide table's `mtgjson_uuid` column is Postgres type `uuid`, so the rows were structurally unwritable. Batches fail atomically, so nothing landed — `variants` holds zero non-uuid rows.

## Fix

- The wide upsert is now default-game only; other games persist exclusively through the long form.
- `stashRowBanID` makes the dual-write game-aware: the default game keeps its mtgjson-uuid variant identity, other games resolve the card's TCGplayer product plus finish sub-type — the identity the tcgcsv ingest mints.
- The category comes from the catalog dump the game already loads at startup (via `GetTCGCategoryID`), so nothing is configured per game.
- A non-default instance without `long_form_writes` is told the snapshot has nowhere to write, instead of failing batch by batch; a game with no catalog is reported once from `stashLongForm` rather than once per card.

## Known gap, deliberately left open

Converging with the ingest assumes a game whose foil printing is named `"Foil"`. That holds for Magic and Riftbound, and **not for Lorcana**, whose TCGplayer printings are `Cold Foil` and `Holofoil` — `"Foil"` appears nowhere in the category. Measured across all 20 Lorcana groups (3,577 products):

| printings on one product | products |
|---|---|
| Cold Foil + Normal | 2,604 |
| Normal only | 425 |
| Holofoil only | 412 |
| Cold Foil only | 107 |
| Holofoil + Normal | 17 |
| Cold Foil + Holofoil + Normal | 12 |

So on Lorcana this writes an identity no ingest row shares: the crash is fixed and the prices are captured, but they land on a ban_id disjoint from the TCG prices for the same printing. No single constant fixes it (2,604 products foil as `Cold Foil`, 412 as `Holofoil`); resolving it needs the per-product printings the catalog dump lists, which is a separate change.

**This is safe to merge for Magic and Riftbound. Lorcana needs the sub-type work first** unless a split identity for that game is acceptable in the interim.

## Verification

`go build ./...`, `go vet`, and the package tests pass. The stash path itself is not covered by tests and has not been run against a live Lorcana instance.