### PR TITLE
search: round the corners of oversized card scans

### DIFF
--- a/css/search.css
+++ b/css/search.css
@@ -221,6 +221,9 @@
 
 .sidebar-img-wrap {
     position: relative;
+    /* The image and its foil overlay both read this, so a set whose scans are
+       cut rounder only has to set it once. */
+    --card-radius: var(--radius-lg);
     /* A fixed flex child of the sidebar column now, above the scrolling body.
        Shrink-wrapped so the foil ::after overlay hugs the image exactly even
        when the height cap makes it narrower than the column. */
@@ -229,9 +232,39 @@
     max-width: 100%;
     margin: 0 auto 14px;
 }
+/* Alpha's scans are cut rounder than the modern crop. */
+.sidebar-img-wrap[data-set="LEA"] {
+    --card-radius: 22px;
+}
+/* Oversized printings are scanned with a much rounder corner than the modern
+   crop. Every card in these sets is oversized, so the set alone selects them;
+   adding a set is one more entry here. */
+.sidebar-img-wrap:is(
+    [data-set="OARC"], [data-set="PSSC"], [data-set="OC20"],
+    [data-set="OC19"], [data-set="OC18"], [data-set="OC17"],
+    [data-set="OE01"], [data-set="OPCA"], [data-set="OC16"],
+    [data-set="OC15"], [data-set="OC14"], [data-set="PPC1"],
+    [data-set="OC13"], [data-set="OCM1"], [data-set="OPC2"],
+    [data-set="PHOP"], [data-set="PCMD"], [data-set="OCMD"],
+    [data-set="OHOP"]
+) {
+    --card-radius: 22px;
+}
+/* PHEL is the exception: five oversized angels plus one normal-size
+   double-faced token, and nothing else tells them apart - they share the set,
+   and the whole set has no release date of its own. */
+.sidebar-img-wrap[data-set="PHEL"]:not([data-name="Angel // Demon"]) {
+    --card-radius: 22px;
+}
+/* DCI mixes ten oversized promos into eighty normal ones, and only those two
+   print runs (Planechase planes, Archenemy schemes) are cut this way. No other
+   DCI promo shares either date. */
+.sidebar-img-wrap[data-set="DCI"]:is([data-date="2009-09-30"], [data-date="2010-09-30"]) {
+    --card-radius: 22px;
+}
 .sidebar-img-wrap.foil-wrap[data-foil="true"]::after,
 .sidebar-img-wrap.foil-wrap[data-etched="true"]::after {
-    border-radius: var(--radius-lg);
+    border-radius: var(--card-radius);
 }
 
 .sidebar-card-img {
@@ -242,19 +275,11 @@
     width: auto;
     max-width: 100%;
     max-height: 52vh;
-    border-radius: var(--radius-lg);
+    border-radius: var(--card-radius);
     border: 1px solid var(--border-subtle, rgba(255,255,255,0.06));
     display: block;
     background: var(--search-surface-2);
 }
-.sidebar-img-wrap[data-set="LEA"] .sidebar-card-img {
-    border-radius: 22px;
-}
-.sidebar-img-wrap[data-set="LEA"].foil-wrap[data-foil="true"]::after,
-.sidebar-img-wrap[data-set="LEA"].foil-wrap[data-etched="true"]::after {
-    border-radius: 22px;
-}
-
 .sidebar-printings {
     font-size: var(--text-base);
     color: var(--activetext);

--- a/css/sleepers.css
+++ b/css/sleepers.css
@@ -485,10 +485,39 @@
 }
 
 /* Card image rounding */
-.sleep-card-wrap img {
-    border-radius: 12px;
-    display: block;
+.sleep-card-wrap {
+    --card-radius: 12px;
 }
-.sleep-card-wrap[data-set="LEA"] img {
-    border-radius: 22px;
+.sleep-card-wrap[data-set="LEA"] {
+    --card-radius: 22px;
+}
+/* Oversized printings are scanned with a much rounder corner than the modern
+   crop. Every card in these sets is oversized, so the set alone selects them;
+   adding a set is one more entry here. */
+.sleep-card-wrap:is(
+    [data-set="OARC"], [data-set="PSSC"], [data-set="OC20"],
+    [data-set="OC19"], [data-set="OC18"], [data-set="OC17"],
+    [data-set="OE01"], [data-set="OPCA"], [data-set="OC16"],
+    [data-set="OC15"], [data-set="OC14"], [data-set="PPC1"],
+    [data-set="OC13"], [data-set="OCM1"], [data-set="OPC2"],
+    [data-set="PHOP"], [data-set="PCMD"], [data-set="OCMD"],
+    [data-set="OHOP"]
+) {
+    --card-radius: 22px;
+}
+/* PHEL is the exception: five oversized angels plus one normal-size
+   double-faced token, and nothing else tells them apart - they share the set,
+   and the whole set has no release date of its own. */
+.sleep-card-wrap[data-set="PHEL"]:not([data-name="Angel // Demon"]) {
+    --card-radius: 22px;
+}
+/* DCI mixes ten oversized promos into eighty normal ones, and only those two
+   print runs (Planechase planes, Archenemy schemes) are cut this way. No other
+   DCI promo shares either date. */
+.sleep-card-wrap[data-set="DCI"]:is([data-date="2009-09-30"], [data-date="2010-09-30"]) {
+    --card-radius: 22px;
+}
+.sleep-card-wrap img {
+    border-radius: var(--card-radius);
+    display: block;
 }

--- a/templates/search.html
+++ b/templates/search.html
@@ -329,7 +329,7 @@
                     }
                 }
 
-                function updateSidebar(src, printings, products, isFoil, isEtched, setCode, hasWarning, productsCount) {
+                function updateSidebar(src, printings, products, isFoil, isEtched, setCode, hasWarning, productsCount, releaseDate, cardName) {
                     var img = document.getElementById('cardImage');
                     img.src = src;
                     // The image height feeds the space measurement but only
@@ -344,6 +344,8 @@
                         wrapper.setAttribute('data-foil', isFoil ? 'true' : 'false');
                         wrapper.setAttribute('data-etched', isEtched ? 'true' : 'false');
                         wrapper.setAttribute('data-set', setCode);
+                        wrapper.setAttribute('data-date', releaseDate || '');
+                        wrapper.setAttribute('data-name', cardName || '');
                         if (hasWarning) {
                             wrapper.classList.add('content-warning');
                         } else {
@@ -1017,7 +1019,7 @@
                                  data-treatments="{{range $i, $t := $card.Treatments}}{{if $i}},{{end}}{{$t}}{{end}}"
                                  data-has-warning="{{$card.HasContentWarning}}"
                                  data-crop-url="{{$card.CropURL}}"
-                                 onmouseover="hoverSidebar({{$card.ImageURL}}, {{$card.Printings}}, {{$card.Products}}, {{$card.Foil}}, {{$card.Etched}}, {{$card.SetCode}}, {{$card.HasContentWarning}}, {{$card.NumProducts}});">
+                                 onmouseover="hoverSidebar({{$card.ImageURL}}, {{$card.Printings}}, {{$card.Products}}, {{$card.Foil}}, {{$card.Etched}}, {{$card.SetCode}}, {{$card.HasContentWarning}}, {{$card.NumProducts}}, {{$card.Date}}, {{$card.Name}});">
                                 <a class="result-set-link" href="?q=s:{{$card.SetCode}}">
                                     {{if $card.Keyrune}}
                                         <i class="ss {{$card.Keyrune}} ss-2x ss-fw result-set-icon"></i>
@@ -1113,7 +1115,7 @@
                                 {{end}}
                             </div>
                             {{end}}
-                            <div class="result-body{{if eq $i (dec (len $.AllKeys) 1)}} result-last-body{{end}}" onmouseover="hoverSidebar({{$card.ImageURL}}, {{$card.Printings}}, {{$card.Products}}, {{$card.Foil}}, {{$card.Etched}}, {{$card.SetCode}}, {{$card.HasContentWarning}}, {{$card.NumProducts}});">
+                            <div class="result-body{{if eq $i (dec (len $.AllKeys) 1)}} result-last-body{{end}}" onmouseover="hoverSidebar({{$card.ImageURL}}, {{$card.Printings}}, {{$card.Products}}, {{$card.Foil}}, {{$card.Etched}}, {{$card.SetCode}}, {{$card.HasContentWarning}}, {{$card.NumProducts}}, {{$card.Date}}, {{$card.Name}});">
                                 <!-- Sellers column -->
                                 <div class="result-col">
                                     <div class="result-col-header">Sellers</div>

--- a/templates/sleep.html
+++ b/templates/sleep.html
@@ -192,7 +192,7 @@ function checkSleepersCompare() {
                             <a href="{{$card.SearchURL}}">
                                 <nobr>
                                     <span class="small-hidden-text" aria-hidden="true">{{$card.Name}}</span>
-                                    <div class="foil-wrap sleep-card-wrap{{if $card.HasContentWarning}} content-warning{{end}}" data-foil="{{$card.Foil}}" data-etched="{{$card.Etched}}" data-set="{{$card.SetCode}}" style="margin: 5px;"{{if $card.HasContentWarning}} onclick="this.classList.add('cw-revealed');event.preventDefault()"{{end}}>
+                                    <div class="foil-wrap sleep-card-wrap{{if $card.HasContentWarning}} content-warning{{end}}" data-foil="{{$card.Foil}}" data-etched="{{$card.Etched}}" data-set="{{$card.SetCode}}" data-date="{{$card.Date}}" data-name="{{$card.Name}}" style="margin: 5px;"{{if $card.HasContentWarning}} onclick="this.classList.add('cw-revealed');event.preventDefault()"{{end}}>
                                         <img loading="lazy" src="{{$card.ImageURL}}" width=146 height=204 title="{{$card.Name}} [{{$card.Title}}]">
                                     </div>
                                 </nobr>


### PR DESCRIPTION
## Problem

Oversized printings are photographed with a much rounder corner than the modern crop, so the card image rendered square-ish against the art and showed a sliver of background in the corners. `LEA` already had a rule for exactly this; the ~20 oversized sets that share the shape had none.

## Fix

The radius moves onto a `--card-radius` custom property. The sidebar image, its foil overlay and the sleepers grid all read it, so a set can no longer round the art without also rounding the sheen drawn over it — previously three separate declarations that had to be kept in step by hand.

The rule then lives entirely in CSS:

- **19 sets qualify on the set code alone** — every card in them is oversized, so no further test is needed. Adding a set is one more entry in the `:is()` list.
- **DCI** mixes ten oversized promos into eighty normal ones. They are exactly the two print runs `2009-09-30` (Planechase planes) and `2010-09-30` (Archenemy schemes); no other DCI promo shares either date.
- **PHEL** is five oversized angels plus one normal-size double-faced token. They share the set and the set has no per-card release date, so the token is excluded by name.

No Go changes: the two attributes the CSS matches on (`data-date`, `data-name`) are passthroughs of `$card.Date` and `$card.Name`, fields the card struct already carried.

## Verification

Set membership was checked against the datastore before writing the rules: all 19 listed sets are 100% oversized, PHEL is 5 of 6, and DCI is 10 of 80 split across those two dates. Deliberately **not** matched are the other sets carrying the oversize rarity — `OC21`, `MOC`, `WHO`, `DSC`, `PVAN`, `P09`, `P10`, `P11`, `CLB`, `PMIC` — whose scans are cropped normally.

`go build ./...` and the template parse tests pass. **Not visually verified**: rendering the real pages needs a full datastore and DB boot, so the 22px should get an eyeball on a few of these sets before merge.

## Note

An alternative shape needs one attribute instead of two and no exceptions at all: expose `co.Card.Rarity` and match `[data-rarity="oversize"]` together with the set list, which makes both the DCI dates and the PHEL name unnecessary (they are only proxies for oversized-ness). It costs a one-line passthrough field on `GenericCard`. Happy to swap if that trade reads better.