### PR TITLE
admin: fetch the workflow status after the page renders

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -54,6 +54,14 @@ var BuildCommit = func() string {
 }()
 
 func Admin(w http.ResponseWriter, r *http.Request) {
+	// The dashboard asks for the workflow status once it has rendered, so a
+	// round trip to GitHub never delays the page. Answered from here rather
+	// than a route of its own, to stay behind the same signing middleware.
+	if r.FormValue("workflows") != "" {
+		serveRunningWorkflows(w)
+		return
+	}
+
 	sig := getSignatureFromCookies(r)
 
 	page := r.FormValue("page")
@@ -66,15 +74,6 @@ func Admin(w http.ResponseWriter, r *http.Request) {
 	pageVars.LastUpdate = GetLastDatastoreUpdate()
 	pageVars.LastNews = GetLastNewspaperUpdate()
 	pageVars.LastStash = GetLastStashUpdate()
-
-	var gaScrapers []string
-	for _, state := range []string{"in_progress", "queued"} {
-		scrapers, err := snapshotGithubAction(state)
-		if err != nil {
-			log.Println(err)
-		}
-		gaScrapers = append(gaScrapers, scrapers...)
-	}
 
 	msg := r.FormValue("msg")
 	if msg != "" {
@@ -466,10 +465,9 @@ func Admin(w http.ResponseWriter, r *http.Request) {
 		}
 		inv := seller.Inventory()
 
+		// A running workflow overrides this to 🔶 once the poll answers.
 		status := "✅"
-		if slices.Contains(gaScrapers, key) {
-			status = "🔶"
-		} else if len(inv) == 0 {
+		if len(inv) == 0 {
 			status = "🔴"
 		}
 
@@ -520,10 +518,9 @@ func Admin(w http.ResponseWriter, r *http.Request) {
 		}
 		bl := vendor.Buylist()
 
+		// A running workflow overrides this to 🔶 once the poll answers.
 		status := "✅"
-		if slices.Contains(gaScrapers, key) {
-			status = "🔶"
-		} else if len(bl) == 0 {
+		if len(bl) == 0 {
 			status = "🔴"
 		}
 
@@ -804,6 +801,55 @@ func sendGithubAction(key string) error {
 
 	return nil
 }
+
+// serveRunningWorkflows answers the dashboard's status poll.
+func serveRunningWorkflows(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	err := json.NewEncoder(w).Encode(struct {
+		Running []string `json:"running"`
+	}{runningWorkflows()})
+	if err != nil {
+		log.Println("workflow status:", err)
+	}
+}
+
+// runningWorkflows lists the workflows queued or in progress. The two states
+// are queried at once: they are independent, and serialized they doubled the
+// wait. Empty without a token to ask with, and on failure - the dashboard
+// simply leaves its rows as rendered.
+func runningWorkflows() []string {
+	if Config.Api["github_action_token"] == "" {
+		return nil
+	}
+
+	states := []string{"in_progress", "queued"}
+	results := make([][]string, len(states))
+
+	var wg sync.WaitGroup
+	for i, state := range states {
+		wg.Add(1)
+		go func(i int, state string) {
+			defer wg.Done()
+			names, err := gaFetch(state)
+			if err != nil {
+				log.Println(err)
+				return
+			}
+			results[i] = names
+		}(i, state)
+	}
+	wg.Wait()
+
+	var names []string
+	for _, result := range results {
+		names = append(names, result...)
+	}
+	return names
+}
+
+// overridable in tests
+var gaFetch = snapshotGithubAction
 
 func snapshotGithubAction(state string) ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/admin_ajax_test.go
+++ b/admin_ajax_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func stubGAFetch(t *testing.T, fetch func(string) ([]string, error)) {
+	t.Helper()
+	prevFetch, prevAPI := gaFetch, Config.Api
+	t.Cleanup(func() { gaFetch, Config.Api = prevFetch, prevAPI })
+	gaFetch = fetch
+	Config.Api = map[string]string{"github_action_token": "test-token"}
+}
+
+// The poll answers with both states, and asks for them at the same time: run
+// back to back these were the two round trips that used to precede the page.
+func TestRunningWorkflowsQueriesStatesConcurrently(t *testing.T) {
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	stubGAFetch(t, func(state string) ([]string, error) {
+		started <- struct{}{}
+		<-release // no call may finish before both have begun
+		return []string{state}, nil
+	})
+
+	done := make(chan []string, 1)
+	go func() { done <- runningWorkflows() }()
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+			t.Fatal("the two states are still queried one after the other")
+		}
+	}
+	close(release)
+
+	got := <-done
+	if len(got) != 2 {
+		t.Errorf("running = %v, want one entry per state", got)
+	}
+}
+
+// A failing state is logged and skipped: the dashboard keeps the rows it has.
+func TestRunningWorkflowsToleratesFailure(t *testing.T) {
+	stubGAFetch(t, func(state string) ([]string, error) {
+		if state == "queued" {
+			return nil, errors.New("github unreachable")
+		}
+		return []string{state}, nil
+	})
+
+	got := runningWorkflows()
+	if len(got) != 1 || got[0] != "in_progress" {
+		t.Errorf("running = %v, want just the state that answered", got)
+	}
+}
+
+func TestRunningWorkflowsSkipsWithoutToken(t *testing.T) {
+	var calls int32
+	stubGAFetch(t, func(state string) ([]string, error) {
+		atomic.AddInt32(&calls, 1)
+		return []string{state}, nil
+	})
+	Config.Api = map[string]string{}
+
+	if got := runningWorkflows(); got != nil {
+		t.Errorf("running = %v, want nil", got)
+	}
+	if n := atomic.LoadInt32(&calls); n != 0 {
+		t.Errorf("made %d calls without a token, want none", n)
+	}
+}
+
+// The endpoint the page polls: json, uncached, and shaped as the script reads it.
+func TestServeRunningWorkflows(t *testing.T) {
+	stubGAFetch(t, func(state string) ([]string, error) {
+		return []string{state + "-scraper"}, nil
+	})
+
+	w := httptest.NewRecorder()
+	serveRunningWorkflows(w)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("content-type = %q", ct)
+	}
+	if cc := w.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Errorf("cache-control = %q, want no-store", cc)
+	}
+	var payload struct {
+		Running []string `json:"running"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(payload.Running) != 2 {
+		t.Errorf("running = %v, want both states", payload.Running)
+	}
+}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -69,14 +69,14 @@
                 </tr></thead>
                 <tbody>
                 {{range $row := index .Tables 0}}
-                    <tr>
+                    <tr data-tag="{{index $row 2}}">
                         <td><a href="?refresh={{index $row 2}}" onclick="return confirm('Are you sure you want to refresh {{index $row 0}}?')">{{index $row 0}}</a></td>
                         <td class="admin-mono">{{index $row 1}}</td>
                         <td class="admin-mono"><a href="?logs={{index $row 2}}">{{index $row 2}}</a></td>
                         <td class="admin-mono"><time class="admin-localtime" datetime="{{index $row 3}}">{{index $row 3}}</time></td>
                         <td class="admin-mono">{{index $row 4}}</td>
                         <td class="c">{{index $row 5}}</td>
-                        <td class="c">{{index $row 6}}</td>
+                        <td class="c admin-status">{{index $row 6}}</td>
                     </tr>
                 {{end}}
                 </tbody>
@@ -100,14 +100,14 @@
                 </tr></thead>
                 <tbody>
                 {{range $row := index .Tables 1}}
-                    <tr>
+                    <tr data-tag="{{index $row 2}}">
                         <td><a href="?refresh={{index $row 2}}" onclick="return confirm('Are you sure you want to refresh {{index $row 0}}?')">{{index $row 0}}</a></td>
                         <td class="admin-mono">{{index $row 1}}</td>
                         <td class="admin-mono"><a href="?logs={{index $row 2}}">{{index $row 2}}</a></td>
                         <td class="admin-mono"><time class="admin-localtime" datetime="{{index $row 3}}">{{index $row 3}}</time></td>
                         <td class="admin-mono">{{index $row 4}}</td>
                         <td class="c">{{index $row 5}}</td>
-                        <td class="c">{{index $row 6}}</td>
+                        <td class="c admin-status">{{index $row 6}}</td>
                     </tr>
                 {{end}}
                 </tbody>
@@ -438,6 +438,43 @@
 {{end}}
 
 {{define "extra-scripts"}}
+<script>
+// The scraper rows render with the status the server can answer for free
+// (has data / has none). Whether a refresh is running lives at GitHub, so it
+// is fetched after paint and folded in here rather than holding the page.
+(function () {
+    var rows = document.querySelectorAll('tr[data-tag]');
+    if (!rows.length) {
+        return;
+    }
+    fetch('?workflows=1', {credentials: 'same-origin'})
+        .then(function (resp) {
+            return resp.ok ? resp.json() : null;
+        })
+        .then(function (data) {
+            if (!data || !data.running) {
+                return;
+            }
+            var running = {};
+            data.running.forEach(function (name) {
+                running[name] = true;
+            });
+            rows.forEach(function (row) {
+                if (!running[row.getAttribute('data-tag')]) {
+                    return;
+                }
+                var cell = row.querySelector('.admin-status');
+                if (cell) {
+                    cell.textContent = '🔶';
+                    cell.title = 'refresh running';
+                }
+            });
+        })
+        .catch(function () {
+            // Status stays as rendered; the dashboard is still usable.
+        });
+})();
+</script>
 <script>
 window.__jsonEditors = window.__jsonEditors || {};
 


### PR DESCRIPTION
## Problem

The admin page blocked on GitHub before rendering. `Admin` opened with two **sequential** calls to `api.github.com` — `in_progress` then `queued` — purely to put a 🔶 busy marker on scraper rows. Measured against that endpoint:

```
in_progress: 0.322s / 0.094s / 0.096s   (http 200)
queued:      0.400s / 0.138s / 0.122s   (http 200, 14.9 KB)
```

**0.2–0.8s before a byte is written**, and up to the pair of 2s timeouts when GitHub is slow — which is exactly when an admin is reloading.

## Fix

The page no longer waits on GitHub at all. It renders with the status the server already knows for free (has data / has none), and asks for the rest once it is up:

- `?workflows=1` on the **same handler** returns `{"running":[…]}` as JSON. Answering from `Admin` rather than a route of its own keeps it behind the existing admin signing middleware — no new auth wiring.
- The two states are queried **concurrently**; serialized, they doubled the wait.
- Rows carry `data-tag`, the status cell is `.admin-status`, and the script folds 🔶 in after paint.
- A failed or empty poll leaves the rows exactly as rendered, so the dashboard degrades to "can't tell you what's running" rather than breaking.
- No token configured means no calls.

This replaces the earlier server-side cache on this branch (the branch name is now vestigial). The cache still made the *first* load after boot wait and kept a TTL's worth of staleness; polling after paint removes the dependency from the render path outright, and there is no cache to be stale.

## Verification

Four unit tests, no network — `gaFetch` is stubbed:

```
--- PASS: TestRunningWorkflowsQueriesStatesConcurrently
--- PASS: TestRunningWorkflowsToleratesFailure
--- PASS: TestRunningWorkflowsSkipsWithoutToken
--- PASS: TestServeRunningWorkflows
```

The concurrency test holds both calls open until each has started, so it fails if they ever go back to sequential. The endpoint test pins the JSON shape, `application/json`, and `Cache-Control: no-store`. Package tests and template parsing pass; the poll script passes `node --check`.

**Not verified in a browser**: rendering the real dashboard needs a running server with admin auth, so the fetch-and-patch path has not been exercised end to end. Worth one look at the Status column after merge — it should show ✅/🔴 immediately, with 🔶 appearing a moment later for anything refreshing.

## Scope

This was the only remote call in the handler; everything else is in-memory (uptime/mem/disk are syscalls, key overrides read an in-memory store, the tables walk loaded snapshots). The end-to-end page time was not measured — if it still drags, that wants a real profile.