### PR TITLE
search: name the game in the Cardmarket fallback link

### DIFF
--- a/search.go
+++ b/search.go
@@ -726,15 +726,17 @@ func Search(w http.ResponseWriter, r *http.Request) {
 			if err == nil {
 				var link string
 
+				game := cardmarket.GameIdMagic
+				if Config.Game == "lorcana" {
+					game = cardmarket.GameIdLorcana
+				}
 				id, err := strconv.Atoi(co.Identifiers["mcmId"])
 				if err != nil || id == 0 {
-					link = "https://www.cardmarket.com/en/Products/Search?searchString=" + url.QueryEscape(pageVars.Metadata[cardId].Name)
+					// Cardmarket names the game in every product path, so the
+					// name-only fallback has to carry it too.
+					link = cardmarket.SearchURL(pageVars.Metadata[cardId].Name, game, Config.Affiliate["MKM"])
 				} else {
-					game := cardmarket.GameIdMagic
-					if Config.Game == "lorcana" {
-						game = cardmarket.GameIdLorcana
-					}
-					link = cardmarket.BuildURL(id, game, "", co.Foil || co.Etched)
+					link = cardmarket.BuildURL(id, game, Config.Affiliate["MKM"], co.Foil || co.Etched)
 				}
 				tmp = append(tmp, SearchEntry{
 					ScraperName: "CardMarket",


### PR DESCRIPTION
## Problem

Cardmarket spells the game out in every product path and has no game-agnostic one, so the link built for a card with no `mcmId` — `/en/Products/Search?searchString=…` — 404s instead of landing on a search.

It also dropped the affiliate: `BuildURL` was called with `""` and the fallback appended nothing, so **neither** Cardmarket link carried attribution, even though `affiliate.MKM` is set in the config. `grep 'Affiliate\["MKM"\]'` across the repo returned no hits at all before this.

## Fix

Resolve the game id once for both branches and hand it to `cardmarket.SearchURL`, which knows the spelling, along with the configured affiliate. Needs go-mtgban ≥ v0.7.0 (mtgban/go-mtgban#82), which is what master now pins.

## Verification

Links produced against v0.7.0:

```
lorcana fallback   https://www.cardmarket.com/en/Lorcana/Products/Search?searchString=Ariel+-+Singing+Mermaid&utm_campaign=card_prices&utm_medium=text&utm_source=mtgban
magic fallback     https://www.cardmarket.com/en/Magic/Products/Search?searchString=Black+Lotus&utm_campaign=card_prices&utm_medium=text&utm_source=mtgban
magic product      https://www.cardmarket.com/en/Magic/Products?idProduct=12345&isFoil=Y&language=1&utm_campaign=card_prices&utm_medium=text&utm_source=mtgban
```

Game segment present on the fallback, attribution now on both paths. `go build ./...`, `go vet`, and the package tests pass.

**Not clicked through**: the URLs are asserted by shape, not by loading them at Cardmarket. Worth one click on a card with no `mcmId` after merge.