### PR TITLE
Serve Riftbound alongside Magic and Lorcana

### DIFF
--- a/.github/workflows/riftbound-deploy.yml
+++ b/.github/workflows/riftbound-deploy.yml
@@ -1,0 +1,23 @@
+name: riftbound-deploy
+
+on:
+  push:
+    tags:
+      - 'v*'
+      - 'riftbound-*'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2.5.2
+        with:
+          token: ${{ secrets.DO_API_TOKEN }}
+
+      - name: Create deployment
+        run: doctl apps create-deployment ${{ secrets.DO_RIFTBOUND_APP_ID }} --wait
+

--- a/templates/home.html
+++ b/templates/home.html
@@ -125,6 +125,8 @@ body.modal-embed .landing-brand { margin-bottom: 18px; }
             <a href="https://mtgban.com">Magic: the Gathering</a>
             <span>|</span>
             <a href="https://lorcana.mtgban.com">Disney Lorcana</a>
+            <span>|</span>
+            <a href="https://riftbound.mtgban.com">Riftbound</a>
         </div>
 
         <div class="landing-login-row">

--- a/templates/mobile/home.html
+++ b/templates/mobile/home.html
@@ -52,6 +52,8 @@
             <a href="https://mtgban.com">Magic: the Gathering</a>
             <span>|</span>
             <a href="https://lorcana.mtgban.com">Disney Lorcana</a>
+            <span>|</span>
+            <a href="https://riftbound.mtgban.com">Riftbound</a>
         </div>
 
         <div class="m-home-login-row">

--- a/utils.go
+++ b/utils.go
@@ -36,6 +36,18 @@ var colorRarityMap = map[string]map[string]string{
 		"special":   "#652978",
 		"enchanted": "#03A9FC",
 	},
+	// The four printed tiers climb the same metals Lorcana uses, and the two
+	// treatments that cut across them take the two remaining colors. Riftbound
+	// also has a "none" rarity, held by four cards, which is left out so it
+	// renders uncolored like any rarity a game does not describe.
+	"riftbound": {
+		"common":   "var(--normal)",
+		"uncommon": "#707883",
+		"rare":     "#CD7F32",
+		"epic":     "#FFD700",
+		"showcase": "#03A9FC",
+		"promo":    "#652978",
+	},
 }
 
 type GenericCard struct {


### PR DESCRIPTION
The site is built once per game and reads `Config.Game`, so most of it works
for a new game already. Sweeping every place that branches on the game turned
up three that did not.

**Deploy workflow** — each game is its own app and its own workflow, and
Riftbound had none. Needs `DO_RIFTBOUND_APP_ID`.

**Landing pages** — the footer lists the deployments and is the only way to
reach one from another; it stopped at Lorcana.

**Rarity colors** — `colorRarityMap` described only Lorcana, so every Riftbound
card rendered uncolored. The rarities are taken from the datastore rather than
guessed (common 604, uncommon 530, rare 658, epic 386, showcase 240, promo
402). The four printed tiers climb the same metals Lorcana's do; showcase and
promo are treatments cutting across those tiers rather than sitting above them,
so they take the two colors Lorcana spends on its own out-of-band printings.
The `none` rarity, held by four cards, is left out so it renders uncolored like
any rarity a game does not describe.

`tcgcsv`, the `timeseries` partition for category 89, and `news.go`'s game map
already covered Riftbound, and the card back is in already.

**Deliberately not included:** `collectr` has no Riftbound entry. Its category
id would be 89, the same as TCGplayer's, but the `catalog_category_name` it
filters listings by is only observable in a showcase that actually holds those
cards. Guessing is worse than omitting: `parseProducts` drops every item whose
category name differs, so a wrong value reports the page as unparseable,
whereas an absent game is refused cleanly by name.

Also still needed outside this repo: the Riftbound deployment's config needs
its `tcgcsv_config.games` entry for category 89.

Build, vet, gofmt and the test suite pass against go-mtgban v0.7.0.
