### PR TITLE
Make the cold boot cheap and quiet

### DIFF
--- a/api.go
+++ b/api.go
@@ -855,14 +855,26 @@ func LoadFromCloud(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var failed []string
 	for kind, list := range scrapersConfig {
 		for _, shorthand := range list {
 			err := loadScraper(DataBucket, config.BucketPath, Config.Game, name, kind, shorthand, config.BucketFileFormat)
 			if err != nil {
 				log.Println(err)
+				failed = append(failed, fmt.Sprintf("%s/%s: %s", kind, shorthand, err))
 				continue
 			}
 		}
+	}
+
+	// A scraper that just finished producing and still will not load is the
+	// case worth waking someone for, unlike the same absence at startup.
+	if len(failed) > 0 {
+		slices.Sort(failed)
+		msg := fmt.Sprintf("Server reloaded %s, %d did not load: %s", name, len(failed), strings.Join(failed, "; "))
+		ServerNotify("reload", msg, true)
+		w.Write([]byte(`{"status": "ok"}`))
+		return
 	}
 
 	ServerNotify("reload", "Server reloaded "+name)

--- a/load.go
+++ b/load.go
@@ -97,23 +97,41 @@ func loadScrapersNG(config ScraperConfig) error {
 		return fmt.Errorf("unsupported path scheme %s", u.Scheme)
 	}
 
+	var loaded int
+	var failed []string
+
 	for name, scrapersConfig := range config.Config {
 		for kind, list := range scrapersConfig {
 			for _, shorthand := range list {
 				err := loadScraperWithRetry(DataBucket, config.BucketPath, Config.Game, name, kind, shorthand, config.BucketFileFormat)
 				if err != nil {
-					msg := fmt.Sprintf("failed to load %s/%s/%s after %d attempts: %s",
-						name, kind, shorthand, scraperLoadRetries, err)
-					ServerNotify("reload", msg, true)
+					failed = append(failed, fmt.Sprintf("%s/%s/%s: %s", name, kind, shorthand, err))
 					continue
 				}
+				loaded++
 			}
 		}
 	}
 
-	ServerNotify("reload", "Server loaded")
+	// No @here: at startup nothing has loaded yet, so an absent scraper is
+	// the ordinary state rather than news. Breakage worth waking someone for
+	// is a scraper that was serving and stopped, which is the reload path.
+	ServerNotify("reload", loadSummary(loaded, failed))
 
 	return nil
+}
+
+func loadSummary(loaded int, failed []string) string {
+	var b strings.Builder
+
+	slices.Sort(failed)
+
+	fmt.Fprintf(&b, "Server loaded %d/%d scrapers", loaded, loaded+len(failed))
+	if len(failed) > 0 {
+		fmt.Fprintf(&b, "\nnot loaded (%d): %s", len(failed), strings.Join(failed, "; "))
+	}
+
+	return b.String()
 }
 
 // isTimeout reports whether err is the hung-connection case scraperLoadTimeout

--- a/load.go
+++ b/load.go
@@ -27,6 +27,15 @@ const (
 
 	// Number of retry attempts for a failed/timed-out scraper load.
 	scraperLoadRetries = 3
+
+	// How many scrapers are fetched at once during a full load. Each one in
+	// flight holds a decoded inventory, so the ceiling here is memory rather
+	// than anything the bucket imposes.
+	scraperLoadConcurrency = 6
+
+	// blazer's range parallelism within a single object. It multiplies with
+	// the fan-out above, hence lower than what a serial loader could afford.
+	bucketConcurrentDownloads = 4
 )
 
 var DataBucket simplecloud.Reader
@@ -90,28 +99,58 @@ func loadScrapersNG(config ScraperConfig) error {
 		if err != nil {
 			return err
 		}
-		b2Bucket.ConcurrentDownloads = 20
+		b2Bucket.ConcurrentDownloads = bucketConcurrentDownloads
 
 		DataBucket = b2Bucket
 	default:
 		return fmt.Errorf("unsupported path scheme %s", u.Scheme)
 	}
 
-	var loaded int
-	var failed []string
+	type scraperLoad struct {
+		name      string
+		kind      string
+		shorthand string
+	}
 
+	var loads []scraperLoad
 	for name, scrapersConfig := range config.Config {
 		for kind, list := range scrapersConfig {
 			for _, shorthand := range list {
-				err := loadScraperWithRetry(DataBucket, config.BucketPath, Config.Game, name, kind, shorthand, config.BucketFileFormat)
-				if err != nil {
-					failed = append(failed, fmt.Sprintf("%s/%s/%s: %s", name, kind, shorthand, err))
-					continue
-				}
-				loaded++
+				loads = append(loads, scraperLoad{name, kind, shorthand})
 			}
 		}
 	}
+
+	type loadResult struct {
+		entry string
+		err   error
+	}
+
+	var loaded int
+	var failed []string
+
+	// The tally needs no lock: WorkerPool runs consume on this goroutine, and
+	// publishing is already serialized by updateSellers/updateVendors. A load
+	// that fails travels as a result rather than as the worker's error, since
+	// the summary reports it and loadScraperWithRetry has already logged it.
+	mtgban.WorkerPool(context.Background(), scraperLoadConcurrency, loads,
+		func(ctx context.Context, load scraperLoad, results chan<- loadResult) error {
+			err := loadScraperWithRetry(DataBucket, config.BucketPath, Config.Game, load.name, load.kind, load.shorthand, config.BucketFileFormat)
+			results <- loadResult{
+				entry: fmt.Sprintf("%s/%s/%s", load.name, load.kind, load.shorthand),
+				err:   err,
+			}
+			return nil
+		},
+		func(result loadResult) {
+			if result.err != nil {
+				failed = append(failed, fmt.Sprintf("%s: %s", result.entry, result.err))
+				return
+			}
+			loaded++
+		},
+		nil,
+	)
 
 	// No @here: at startup nothing has loaded yet, so an absent scraper is
 	// the ordinary state rather than news. Breakage worth waking someone for

--- a/load.go
+++ b/load.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/url"
 	"path"
 	"slices"
@@ -115,6 +116,19 @@ func loadScrapersNG(config ScraperConfig) error {
 	return nil
 }
 
+// isTimeout reports whether err is the hung-connection case scraperLoadTimeout
+// exists to catch, which is the only thing worth a second attempt here: the B2
+// client already retries what it considers transient before returning, and
+// everything else, an unpublished dump most of all, is permanent.
+func isTimeout(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
 func loadScraperWithRetry(bucket simplecloud.Reader, base, game, name, kind, shorthand, format string) error {
 	var lastErr error
 	for attempt := range scraperLoadRetries {
@@ -129,8 +143,11 @@ func loadScraperWithRetry(bucket simplecloud.Reader, base, game, name, kind, sho
 		if lastErr == nil {
 			return nil
 		}
+		if !isTimeout(lastErr) {
+			return lastErr
+		}
 
-		log.Printf("load %s/%s/%s failed: %v", name, kind, shorthand, lastErr)
+		log.Printf("load %s/%s/%s timed out: %v", name, kind, shorthand, lastErr)
 	}
 	return lastErr
 }

--- a/load_test.go
+++ b/load_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestLoadSummary(t *testing.T) {
+	tests := []struct {
+		name   string
+		loaded int
+		failed []string
+		want   string
+	}{
+		{
+			name:   "all loaded",
+			loaded: 3,
+			want:   "Server loaded 3/3 scrapers",
+		},
+		{
+			name:   "unloaded scrapers still count towards the total",
+			loaded: 1,
+			failed: []string{"a/retail/A: no such object"},
+			want: "Server loaded 1/2 scrapers\n" +
+				"not loaded (1): a/retail/A: no such object",
+		},
+		{
+			name:   "listed in a stable order whatever order they finished in",
+			loaded: 0,
+			failed: []string{"c/retail/C: timeout", "a/retail/A: timeout"},
+			want: "Server loaded 0/2 scrapers\n" +
+				"not loaded (2): a/retail/A: timeout; c/retail/C: timeout",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := loadSummary(test.loaded, test.failed)
+			if got != test.want {
+				t.Errorf("got:\n%s\nwant:\n%s", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Three defects in the startup load path, plus the alerting fix that falls out of
them. No new dependencies — `go.mod` is untouched.

### 1. Every error was retried, including the permanent ones

`loadScraperWithRetry` gave all errors 3 attempts with 0/5/10s backoff. A dump
that hasn't been published yet is the common case while a game is being wired
up, so each absent entry burned ~15s per boot rediscovering something already
known. The 2-minute `scraperLoadTimeout` × 3 also meant **one wedged connection
could block the whole serial loop for six minutes**.

Inverted: retry only what's known-transient, which here means the timeout. That
needs nothing but stdlib (`context.DeadlineExceeded`, `net.Error.Timeout()`),
and it's closer to why the loop exists — its stated job is the hung connection.
It's also non-redundant now: blazer's `withBackoff` already retries everything
`base.Action(err) == base.Retry` (5xx, 429) *before* returning, so an outer
retry on anything but a timeout just repeats a settled answer.

### 2. One `@here` per failed shorthand, every boot

`ServerNotify(..., true)` prefixes `@here` and fired once per failure. Now the
outcome is one line:

```
Server loaded 24/27 scrapers
not loaded (3): coolstuffinc_sealed_lorcana/retail/CSISealed: ...
```

**Sent without `@here`** — at startup nothing has loaded yet, so an absent
scraper is the ordinary state, not news.

### 3. The loads were serial

27 shorthand loads on the magic instance, each "<2s" per the existing comment —
about a minute of boot spent waiting on the network. Fanning out is safe as the
code already stands: `updateSellers`/`updateVendors` take `scrapersWriteMu` and
publish through an `atomic.Pointer`, so the only new shared state is the tally.
Bounded at 6 by memory (each in-flight load holds a decoded inventory), not by
what B2 tolerates. `ConcurrentDownloads` drops 20 → 4 since blazer's range
parallelism is intra-object and now multiplies with the fan-out.

### 4. …so the `@here` moves to the reload path

Reload failures were logged and swallowed. That's where paging belongs: the ping
arrives *because* a scraper just finished producing, so a dump that still won't
load means something broke. The response stays `ok` so a partial failure doesn't
fail the workflow that pinged.

### Why this shape

An earlier draft distinguished "absent" from "broken" by classifying the error,
which meant importing `blazer` into the website for one boolean — B2 is the only
backend that defers its 404 to the first `Read`, so nothing else could answer it.
Moving the alert to the reload path removes the question entirely: at boot the
distinction doesn't matter, because neither case is worth paging for.

Consequence worth naming: a scraper that is genuinely broken at boot no longer
pages — it appears in the summary line, and pages on its next reload ping.

### Verification

`go build`, `go vet`, `gofmt` clean; suite passes. `TestLoadSummary` covers the
counting and the stable ordering, which matters now that completion order is
nondeterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)