### PR TITLE
charts: take the checkpoint timeline from the upstream ban list

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -359,10 +359,10 @@ func Admin(w http.ResponseWriter, r *http.Request) {
 	// -- Checkpoints: handle POST if submitted --
 	newCheckpoints := r.FormValue("checkpointsTextArea")
 	if newCheckpoints != "" {
-		var parsed checkpointsFile
+		var parsed banlistFile
 		if err := json.Unmarshal([]byte(newCheckpoints), &parsed); err != nil {
 			pageVars.WarningMessage = "Checkpoints JSON invalid: " + err.Error()
-		} else if err := saveCheckpoints(r.Context(), parsed.Events); err != nil {
+		} else if err := saveCheckpoints(r.Context(), parsed); err != nil {
 			pageVars.WarningMessage = "Checkpoints save failed: " + err.Error()
 		} else {
 			pageVars.InfoMessage = "Checkpoints updated"

--- a/checkpoints.go
+++ b/checkpoints.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"regexp"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/mtgban/go-mtgban/mtgmatcher"
@@ -16,45 +18,107 @@ import (
 	"github.com/mtgban/mtgban-website/internal/bucketstore"
 )
 
-// CheckpointEvent is one record as authored in checkpoints.json. A single event
-// can fan out into multiple ChartCheckpoint annotations (e.g. a ban announcement
-// affecting several cards or carrying both banned and unbanned lists).
-//
-// AllCards skips the per-card filter so the event lands on every chart — used
-// for game-wide news like a format launch ("Pioneer announced") where the
-// banned/unbanned card lists don't apply. Type "format" is implicitly AllCards.
-type CheckpointEvent struct {
-	ID            string   `json:"id"`
-	Type          string   `json:"type"` // "ban" | "format"
-	Date          string   `json:"date"` // YYYY-MM-DD
-	Format        string   `json:"format,omitempty"`
-	Title         string   `json:"title"`
-	URL           string   `json:"url,omitempty"`
-	SetCode       string   `json:"set_code,omitempty"`
-	AllCards      bool     `json:"all_cards,omitempty"`
-	CardsBanned   []string `json:"cards_banned,omitempty"`
-	CardsUnbanned []string `json:"cards_unbanned,omitempty"`
-	// Vintage restricts rather than bans; the announcement is the same event,
-	// so restrictions ride the same "ban" type and share its toggle.
-	CardsRestricted   []string `json:"cards_restricted,omitempty"`
-	CardsUnrestricted []string `json:"cards_unrestricted,omitempty"`
+// banlistFile is the upstream ban list: one chronological list of changes per
+// format, keyed by the format's own lowercase name. It carries no titles or
+// ids - the frontend composes a title from the format - and no notion of a
+// format launch, which lives in the config instead.
+type banlistFile map[string][]banlistEntry
+
+// banlistEntry is one announcement for one format. A null date decodes to the
+// empty string; those entries are the format's standing ban list rather than
+// an event, and are only usable when the announcement url names a date.
+type banlistEntry struct {
+	Date string `json:"date"`
+	URL  string `json:"url"`
+	// Changes maps a card name to what the announcement did to it:
+	// "banned", "restricted" or "legal" (no longer either).
+	Changes map[string]string `json:"changes"`
 }
 
-type checkpointsFile struct {
-	Events []CheckpointEvent `json:"events"`
+// checkpointFormats are the formats whose announcements move prices enough to
+// be worth a marker, mapped to the spelling shown on the chart. The upstream
+// list also covers Alchemy and a long tail of retired or niche formats (block
+// formats, unsets, two-headed giant); charting a card's Tempest-block ban is
+// noise, so anything absent here is dropped at load.
+var checkpointFormats = map[string]string{
+	"standard":  "Standard",
+	"pioneer":   "Pioneer",
+	"modern":    "Modern",
+	"legacy":    "Legacy",
+	"vintage":   "Vintage",
+	"pauper":    "Pauper",
+	"commander": "Commander",
+	"brawl":     "Brawl",
 }
 
-// ChartCheckpoint is the per-chart annotation shape sent to the frontend.
-// One record == one vertical line on the chart.
-//
-// Bans/unbans/restrictions carry an IconURL pointing to a local white-stroked SVG.
-// Releases/reprints carry a KeyruneCode so the frontend can render the set
-// glyph from the Keyrune font (already loaded for the search page) — that
-// avoids fetching and recoloring external SVGs at render time.
-// Format events carry an IconText (the format name, e.g. "Pioneer") which
-// the frontend draws directly as the label content.
+// banlistAction describes one card's fate in one announcement, already
+// resolved to the marker the chart draws.
+type banlistAction struct {
+	Type    string // "ban" | "restrict" | "legal"
+	Detail  string // "Banned in Legacy"
+	IconURL string
+}
+
+var banlistActions = map[string]banlistAction{
+	"banned":     {Type: "ban", Detail: "Banned", IconURL: "/img/checkpoints/hammer.svg"},
+	"restricted": {Type: "restrict", Detail: "Restricted", IconURL: "/img/checkpoints/restricted.svg"},
+	// The upstream list says only that a card is legal again, without
+	// distinguishing an unban from an unrestriction - and both are true of
+	// "legal" in the formats that restrict. Say what it says.
+	"legal": {Type: "legal", Detail: "Legal", IconURL: "/img/checkpoints/unlock.svg"},
+}
+
+// banlistDateFromURL recovers the date of an entry that carries none from its
+// announcement url, which ends in one ("...announcing-pioneer-format-2019-10-21").
+// The dateless entries are format launches and standing lists; the launches
+// have such a url, the standing lists have none and are skipped.
+var banlistURLDate = regexp.MustCompile(`(\d{4}-\d{2}-\d{2})$`)
+
+// banlistVariantSuffix matches the per-variant letter the list appends to the
+// Unfinity attractions ("Scavenger Hunt (a)" through "(f)"). Those are six
+// printings of one card, named once in our datastore, so the suffix is dropped
+// and the six identical markers collapse to one.
+var banlistVariantSuffix = regexp.MustCompile(`\s+\([a-z]\)$`)
+
+// banlistYears bounds how far back the timeline is worth building. The list
+// reaches 1994; a chart cannot show a marker older than its own data, and the
+// index would otherwise carry three decades nobody looks at.
+const banlistYears = 10
+
+func banlistDateFromURL(link string) string {
+	return banlistURLDate.FindString(strings.TrimRight(link, "/"))
+}
+
+// banlistNames are the few cards the list spells differently from our
+// datastore. Normalization closes most gaps on its own, but not this one: it
+// drops every "s", so "Name Sticker" Goblin folds to nametickergoblin and can
+// never meet the card it means.
+var banlistNames = map[string]string{
+	`"Name Sticker" Goblin`: "_____ Goblin",
+}
+
+func banlistCardName(name string) string {
+	name = banlistVariantSuffix.ReplaceAllString(name, "")
+	if known, found := banlistNames[name]; found {
+		return known
+	}
+	return name
+}
+
+// FormatEvent is a curated, game-wide marker configured by hand: a format
+// launch or similar, which no ban list reports. Every chart shows it.
+type FormatEvent struct {
+	Date   string `json:"date"`
+	Format string `json:"format"`
+	Title  string `json:"title,omitempty"`
+	URL    string `json:"url,omitempty"`
+}
+
 type ChartCheckpoint struct {
-	Type        string `json:"type"`   // "ban" | "unban" | "restrict" | "unrestrict" | "release" | "reprint" | "format"
+	Type string `json:"type"` // "ban" | "restrict" | "legal" | "release" | "reprint" | "format"
+	// Format names the format an announcement applies to, so the frontend can
+	// compose the title the upstream ban list does not carry.
+	Format      string `json:"format,omitempty"`
 	Date        string `json:"date"`   // YYYY-MM-DD
 	Title       string `json:"title"`  // headline, e.g. set name or ban announcement title
 	Detail      string `json:"detail"` // sub-line, e.g. "Banned in Modern"
@@ -69,7 +133,7 @@ type ChartCheckpoint struct {
 // credentials, since the document lives on the same bucket as the datastore —
 // reload/save are infrequent enough that the extra B2 auth round-trip is not
 // worth a long-lived client.
-var checkpointsStore = &bucketstore.Store[checkpointsFile]{
+var checkpointsStore = &bucketstore.Store[banlistFile]{
 	Bucket: func(ctx context.Context) (simplecloud.ReadWriter, string, error) {
 		cpPath := Config.Datastore.CheckpointsPath
 		if cpPath == "" {
@@ -95,24 +159,90 @@ func reloadCheckpoints() error {
 	if err := checkpointsStore.Load(context.Background()); err != nil {
 		return err
 	}
+	events := indexBanlist(checkpointsStore.Get())
+	banlistIndex.Store(&events)
+
 	cpPath := Config.Datastore.CheckpointsPath
 	source := "disk"
 	if strings.HasPrefix(cpPath, "b2://") {
 		source = "B2"
 	}
-	log.Printf("checkpoints: loaded %d events from %s (%s)", len(checkpointsStore.Get().Events), cpPath, source)
+	var markers int
+	for _, list := range events {
+		markers += len(list)
+	}
+	log.Printf("checkpoints: loaded %d cards, %d markers from %s (%s)", len(events), markers, cpPath, source)
 	return nil
 }
 
-// saveCheckpoints pushes events to the bucket and, on success, atomically
-// swaps the in-memory cache.
-func saveCheckpoints(ctx context.Context, events []CheckpointEvent) error {
-	return checkpointsStore.Save(ctx, checkpointsFile{Events: events})
+// banlistIndex is the loaded ban list turned inside out: one entry per card,
+// since every chart asks about a single card and walking 350-odd
+// announcements (some listing eighty cards) per render is wasted work. Keyed
+// by normalized name so lookups need no case folding.
+var banlistIndex atomic.Pointer[map[string][]ChartCheckpoint]
+
+// indexBanlist flattens the document into per-card markers, dropping formats
+// that are not charted and entries that cannot be placed on a timeline.
+func indexBanlist(doc banlistFile) map[string][]ChartCheckpoint {
+	cutoff := time.Now().AddDate(-banlistYears, 0, 0).Format("2006-01-02")
+
+	out := map[string][]ChartCheckpoint{}
+	// One announcement can name the same card several times once the variant
+	// suffixes are stripped, and that is one marker, not six.
+	type marker struct{ card, date, format, kind string }
+	seen := map[marker]bool{}
+
+	for rawFormat, entries := range doc {
+		format, charted := checkpointFormats[strings.ToLower(rawFormat)]
+		if !charted {
+			continue
+		}
+		for _, entry := range entries {
+			date := entry.Date
+			if date == "" {
+				date = banlistDateFromURL(entry.URL)
+			}
+			if date == "" || date < cutoff {
+				continue
+			}
+			for card, rawAction := range entry.Changes {
+				action, known := banlistActions[strings.ToLower(rawAction)]
+				if !known {
+					continue
+				}
+				key := mtgmatcher.Normalize(banlistCardName(card))
+				m := marker{key, date, format, action.Type}
+				if seen[m] {
+					continue
+				}
+				seen[m] = true
+				out[key] = append(out[key], ChartCheckpoint{
+					Type:    action.Type,
+					Date:    date,
+					Format:  format,
+					Detail:  action.Detail + " in " + format,
+					URL:     entry.URL,
+					IconURL: action.IconURL,
+				})
+			}
+		}
+	}
+	return out
+}
+
+// saveCheckpoints pushes the document to the bucket and, on success, atomically
+// swaps the in-memory cache and its index.
+func saveCheckpoints(ctx context.Context, doc banlistFile) error {
+	if err := checkpointsStore.Save(ctx, doc); err != nil {
+		return err
+	}
+	events := indexBanlist(doc)
+	banlistIndex.Store(&events)
+	return nil
 }
 
 // currentCheckpointsJSON returns the in-memory document serialized as JSON,
-// for display in the admin editor. An empty store still produces a valid
-// `{"events": []}` document.
+// for display in the admin editor.
 func currentCheckpointsJSON() (string, error) {
 	return checkpointsStore.JSON()
 }
@@ -188,73 +318,45 @@ func multiCardCheckpoints(cardNames []string, earliest time.Time) []ChartCheckpo
 }
 
 func curatedCheckpoints(cardName string, earliest time.Time) []ChartCheckpoint {
-	events := checkpointsStore.Get().Events
-
 	earliestStr := earliest.Format("2006-01-02")
 	var out []ChartCheckpoint
 
-	for _, ev := range events {
+	if idx := banlistIndex.Load(); idx != nil {
+		// A ban list names the face it means - "Reflection of Kiki-Jiki" -
+		// while the chart asks with the whole card, so look up each face too.
+		// An announcement naming more than one face of the same card is still
+		// one marker, hence the dedupe.
+		names := []string{cardName}
+		if strings.Contains(cardName, " // ") {
+			names = append(names, strings.Split(cardName, " // ")...)
+		}
+		seen := map[ChartCheckpoint]bool{}
+		for _, name := range names {
+			for _, cp := range (*idx)[mtgmatcher.Normalize(name)] {
+				if cp.Date < earliestStr || seen[cp] {
+					continue
+				}
+				seen[cp] = true
+				out = append(out, cp)
+			}
+		}
+	}
+
+	// Format launches are game-wide: every chart should see "Pioneer
+	// announced" regardless of which card the user is viewing.
+	for _, ev := range Config.FormatEvents {
 		if ev.Date < earliestStr {
 			continue
 		}
-		switch ev.Type {
-		case "ban":
-			if ev.AllCards || containsFold(ev.CardsBanned, cardName) {
-				out = append(out, ChartCheckpoint{
-					Type:    "ban",
-					Date:    ev.Date,
-					Title:   ev.Title,
-					Detail:  banDetail("Banned", ev.Format),
-					URL:     ev.URL,
-					IconURL: "/img/checkpoints/hammer.svg",
-				})
-			}
-			if ev.AllCards || containsFold(ev.CardsUnbanned, cardName) {
-				out = append(out, ChartCheckpoint{
-					Type:    "unban",
-					Date:    ev.Date,
-					Title:   ev.Title,
-					Detail:  banDetail("Unbanned", ev.Format),
-					URL:     ev.URL,
-					IconURL: "/img/checkpoints/unlock.svg",
-				})
-			}
-			// AllCards is deliberately not honoured here: an announcement that
-			// applies to every card is a ban-style event, and claiming every
-			// card was restricted would be wrong.
-			if containsFold(ev.CardsRestricted, cardName) {
-				out = append(out, ChartCheckpoint{
-					Type:    "restrict",
-					Date:    ev.Date,
-					Title:   ev.Title,
-					Detail:  banDetail("Restricted", ev.Format),
-					URL:     ev.URL,
-					IconURL: "/img/checkpoints/restricted.svg",
-				})
-			}
-			if containsFold(ev.CardsUnrestricted, cardName) {
-				out = append(out, ChartCheckpoint{
-					Type:    "unrestrict",
-					Date:    ev.Date,
-					Title:   ev.Title,
-					Detail:  banDetail("Unrestricted", ev.Format),
-					URL:     ev.URL,
-					IconURL: "/img/checkpoints/unlock.svg",
-				})
-			}
-		case "format":
-			// Format-launch events are inherently all-cards: every chart
-			// should see "Pioneer announced" regardless of which card the
-			// user is viewing.
-			out = append(out, ChartCheckpoint{
-				Type:     "format",
-				Date:     ev.Date,
-				Title:    ev.Title,
-				Detail:   formatDetail(ev.Format),
-				URL:      ev.URL,
-				IconText: ev.Format,
-			})
-		}
+		out = append(out, ChartCheckpoint{
+			Type:     "format",
+			Date:     ev.Date,
+			Format:   ev.Format,
+			Title:    ev.Title,
+			Detail:   formatDetail(ev.Format),
+			URL:      ev.URL,
+			IconText: ev.Format,
+		})
 	}
 	return out
 }
@@ -399,25 +501,9 @@ func perCardSetCheckpoints(cardName string, e EditionEntry, earliest, now time.T
 	return out
 }
 
-func banDetail(action, format string) string {
-	if format == "" {
-		return action
-	}
-	return action + " in " + format
-}
-
 func formatDetail(format string) string {
 	if format == "" {
 		return "Format announced"
 	}
 	return format + " format announced"
-}
-
-func containsFold(list []string, target string) bool {
-	for _, item := range list {
-		if strings.EqualFold(item, target) {
-			return true
-		}
-	}
-	return false
 }

--- a/js/chartopts.js
+++ b/js/chartopts.js
@@ -110,7 +110,7 @@ function externalTooltipHandler(context) {
                 // a CSS custom property so per-row styling stays in CSS.
                 html += '<div class="chart-tooltip-row chart-tooltip-cp" style="--cp-color:' + dotColor + '">' +
                     '<span class="chart-tooltip-swatch" style="background:' + dotColor + '"></span>' +
-                    '<span><strong>' + escapeHtml(cp.title) + '</strong>' +
+                    '<span><strong>' + escapeHtml(checkpointTitle(cp)) + '</strong>' +
                     (cp.detail ? '<br><span style="opacity:.75">' + escapeHtml(cp.detail) + '</span>' : '') +
                     '</span>' +
                     '</div>';
@@ -363,31 +363,32 @@ function saveLegendState(chart, storageKey) {
 // otherwise render black-on-grey, which disappears).
 const checkpointColors = {
     ban:        { line: 'rgba(217, 83, 79, 0.9)',  label: 'rgba(217, 83, 79, 0.9)'  },
-    unban:      { line: 'rgba(92, 184, 92, 0.9)',  label: 'rgba(92, 184, 92, 0.9)'  },
     // Vintage restrictions are their own action, not a softer ban, so they get
     // their own hue rather than a shade of the ban red.
     restrict:   { line: 'rgba(13, 110, 253, 0.9)', label: 'rgba(13, 110, 253, 0.9)' },
-    unrestrict: { line: 'rgba(92, 184, 92, 0.9)',  label: 'rgba(92, 184, 92, 0.9)'  },
+    // The ban list reports only that a card is legal again, without saying
+    // whether it was unbanned or unrestricted, so one marker covers both.
+    legal:      { line: 'rgba(92, 184, 92, 0.9)',  label: 'rgba(92, 184, 92, 0.9)'  },
     release: { line: 'rgba(108, 117, 125, 0.9)', label: 'rgba(0, 0, 0, 0.9)'    },
     reprint: { line: 'rgba(240, 173, 78, 0.9)', label: 'rgba(240, 173, 78, 0.9)' },
     format:  { line: 'rgba(102, 16, 242, 0.9)', label: 'rgba(102, 16, 242, 0.9)' },
 };
 
 // Line z-order priority for same-date overlaps. Higher z draws later, so
-// the more important line wins the pixel: red ban > green unban > orange
+// the more important line wins the pixel: red ban > blue restrict > green
 // reprint > black release. Format isn't called out in the priority but
 // sits below release as a soft default.
 const checkpointZ = {
     ban: 6,
     restrict: 5,
-    unban: 4,
-    unrestrict: 3,
+    legal: 3,
     reprint: 2,
     release: 1,
     format: 0,
 };
 
-// Bans + unbans share the "Bans" checkbox; releases + formats share the
+// Bans, restrictions and returns to legal share the "Bans" checkbox;
+// releases + formats share the
 // "Releases" checkbox (both are set/format-launch context).
 // Checkpoint dates are calendar days ("2026-08-10"). new Date() reads that
 // form as UTC midnight, while the time scale parses the same string as local
@@ -395,6 +396,15 @@ const checkpointZ = {
 // East of UTC that pushes a checkpoint on the last axis day past scale.max and
 // the annotation is dropped as out of range - a ban announced today would not
 // draw at all. Parse into the scale's own frame instead.
+// The ban list carries no titles, so a checkpoint from it arrives with a
+// format and no title; announcements are named after their format everywhere
+// else, so compose the same thing here rather than storing it 350 times.
+function checkpointTitle(cp) {
+    if (cp.title) return cp.title;
+    if (cp.format) return cp.format + ' B&R Announcement';
+    return cp.detail || '';
+}
+
 function checkpointTime(dateStr) {
     if (typeof dateStr !== 'string') return NaN;
     var parts = dateStr.split('-');
@@ -408,7 +418,7 @@ function checkpointTime(dateStr) {
 function checkpointToggleKey(type) {
     // Restrictions come from the same B&R announcement as bans, so they ride
     // the same toggle rather than adding a checkbox for a Vintage-only action.
-    if (type === 'unban' || type === 'restrict' || type === 'unrestrict') return 'ban';
+    if (type === 'restrict' || type === 'legal') return 'ban';
     if (type === 'format') return 'release';
     return type;
 }
@@ -892,7 +902,7 @@ function buildCheckpointAnnotations(checkpoints, chartRef, opts) {
         // load triggers redraw above) pick up the real glyph character.
         //
         // The glyph itself carries the type's color (release = monochrome
-        // theme-text, reprint = orange, ban = red, unban = green). Release
+        // theme-text, reprint = orange, ban = red, legal = green). Release
         // is the only monochrome type, so it flips between black and white
         // to stay legible against the chart background.
         var glyphColorFn = function () {
@@ -912,7 +922,7 @@ function buildCheckpointAnnotations(checkpoints, chartRef, opts) {
             // renders strings inline using the label font, so the badge sizes
             // to fit the text rather than to the uniform icon canvas.
             if (cp.iconText) return cp.iconText;
-            return cp.title;
+            return checkpointTitle(cp);
         };
         // Font only affects the text-fallback path now — canvas content is
         // pre-rendered and the plugin ignores the font option for it.
@@ -932,7 +942,7 @@ function buildCheckpointAnnotations(checkpoints, chartRef, opts) {
             borderColor: palette.line,
             // Release lines get noisy at multi-year zooms — drop the dashed
             // line once the visible range exceeds 2 years (i.e. 5y/10y),
-            // keeping only the keyrune icon at the top. Bans/unbans/
+            // keeping only the keyrune icon at the top. Bans/restrictions/
             // reprints/formats stay dashed regardless.
             borderWidth: function (ctx) {
                 if (cp.type !== 'release') return 1.5;

--- a/main.go
+++ b/main.go
@@ -514,7 +514,11 @@ type ConfigType struct {
 		BucketSecretKey string `json:"bucket_access_secret"`
 		CheckpointsPath string `json:"checkpoints_path"`
 	} `json:"datastore"`
-	Game                   string             `json:"game"`
+	Game string `json:"game"`
+	// FormatEvents are the game-wide chart markers no ban list reports - a
+	// format launching, say. Everything else on the checkpoint timeline comes
+	// from the ban list document or the set registry.
+	FormatEvents           []FormatEvent      `json:"format_events,omitempty"`
 	ScraperConfig          ScraperConfig      `json:"scraper_config"`
 	TimeseriesConfig       TimeseriesConfig   `json:"timeseries_config"`
 	NewNewspaperConfigLine string             `json:"new_newspaper_config_line"`


### PR DESCRIPTION
## Problem

The checkpoints document is written by hand, one event per announcement, so it holds only what someone remembered to add. Today's Vintage restriction of The Fantasticar was missing — it had nowhere to go until `cards_restricted` was added yesterday, and nobody had filled it in — and so are years of older announcements.

## Fix

Read the published ban list instead: a chronological list of changes per format, reaching back to 1994. Measured against the real file, the timeline goes from ~100 hand-curated events to **325 cards / 640 markers** after filtering, spanning `2016-11-16..2026-08-10`.

It arrives shaped differently and says less, so the adapter has to make some calls:

| upstream | here |
|---|---|
| formats key the document | 8 charted by name; Alchemy, block formats, unsets and the rest dropped at load |
| history back to 1994 | 10-year cutoff — a chart cannot reach further |
| no titles | frontend composes one from the `format` the payload now carries |
| no ids | nothing needed them |
| `date: null` on standing ban lists | the 3 that are format launches name a date in the announcement url; the other 9 are skipped |
| `banned` / `restricted` / `legal` | same three markers; `legal` says "Legal in X" rather than guessing unban vs unrestrict |

**Name matching needed three adjustments**, each found by checking all 763 names against the datastore:

- Unfinity attractions carry a per-variant letter (`Scavenger Hunt (a)`…`(f)`) that our datastore does not. Stripped — and the six identical entries dedupe to one marker.
- A ban list names the *face* it means (`Reflection of Kiki-Jiki`) where a chart asks about the whole card (`Fable of the Mirror-Breaker // Reflection of Kiki-Jiki`). Faces are looked up too, deduped, since the list names both.
- `"Name Sticker" Goblin` needs an outright alias: normalization drops every "s", so it folds to `nametickergoblin` and can never meet `_____ Goblin`.

Format launches are the one thing no ban list reports, so they move to the config as `format_events`. Lookups are indexed by card at load rather than scanning 367 announcements per chart.

## Verification

Against the real `banlist.json`:

```
The Fantasticar   2026-08-10 Restricted in Vintage, 2026-08-10 Banned in Legacy
Fable // Reflection of Kiki-Jiki   2023-05-29 Banned in Standard   (one marker, not two)
Scavenger Hunt    2024-05-13 Banned in Vintage, Banned in Legacy   (not six each)
_____ Goblin      2024-05-13 Banned in Vintage, Pauper, Legacy
Island            (none)
```

Full suite passes.

## Before this works in production

1. Upload `banlist.json` to the `checkpoints_path` (or repoint it).
2. Add the launches to config.json — they are no longer in the document:
   ```json
   "format_events": [
     {"date": "2018-05-01", "format": "Brawl",   "title": "Brawl format introduced"},
     {"date": "2019-06-15", "format": "Pauper",  "title": "Pauper officially sanctioned"},
     {"date": "2019-10-21", "format": "Pioneer", "title": "Pioneer format introduced"}
   ]
   ```
3. Reload checkpoints. Note nothing refreshes that document automatically — startup and the admin button only — and the admin editor now edits upstream data, so hand edits there are clobbered on the next refresh.

## Note on the commit list

Only the top commit is this change. The four beneath it are your existing unpushed local commits (the corner-radius pair, the checkpoint timezone fix, and the restriction markers this builds on); pushing master will collapse this PR to a single commit.