### PR TITLE
Keep a failed image from ending the image sync, and stop the shell erroring on its own assets

### DIFF
--- a/js/offline/offline-images-ui.js
+++ b/js/offline/offline-images-ui.js
@@ -23,21 +23,22 @@
         var text = codes.length
             ? 'Selected: ' + codes.length + ' editions, ' + est.count + ' images, ' + fmt(est.bytes)
             : 'No editions selected: no images will be downloaded.';
-        if (est.missing.length) text += ' (' + est.missing.length + ' without bundles yet)';
+        if (est.missing.length) text += ' (' + est.missing.length + ' without images yet)';
         return text;
     }
     function buildStorageText(usage, quota) {
         return 'Storage: ' + fmt(usage || 0) + ' used of ' + fmt(quota || 0);
     }
-    function buildDoneMessage(paused, missingCount, selectedCount) {
+    function buildDoneMessage(paused, missingCount, selectedCount, failedCount) {
         if (paused) return 'Paused. Sync Images Now resumes where it left off.';
         if (selectedCount > 0 && missingCount === selectedCount) {
-            return '0 of ' + selectedCount + ' selected editions have bundles yet.';
+            return '0 of ' + selectedCount + ' selected editions have images yet.';
         }
-        if (missingCount > 0) {
-            return 'Image sync finished. (' + missingCount + ' editions have no bundles yet)';
-        }
-        return 'Image sync finished.';
+        var notes = [];
+        if (missingCount > 0) notes.push(missingCount + ' editions have no images yet');
+        if (failedCount > 0) notes.push(failedCount + ' images failed and retry on the next sync');
+        if (!notes.length) return 'Image sync finished.';
+        return 'Image sync finished. (' + notes.join('; ') + ')';
     }
 
     function selectedCodes() {
@@ -144,7 +145,7 @@
             pauseBtn.disabled = false;
             fillEl.style.width = '0%';
             labelEl.textContent = plan.work.length
-                ? 'Syncing ' + plan.work.length + ' bundles (' + fmt(plan.totalBytes) + ')...'
+                ? 'Syncing ' + plan.work.length + ' editions (' + fmt(plan.totalBytes) + ')...'
                 : 'Images already up to date.';
             window.OfflineMode.sync();
         }).catch(function (err) {
@@ -160,12 +161,12 @@
         if (msg.type === 'progress' && msg.stage === 'images') {
             var pct = progressPct(msg.done, msg.total);
             fillEl.style.width = pct + '%';
-            labelEl.textContent = msg.done + ' / ' + msg.total + ' bundles (' +
+            labelEl.textContent = msg.done + ' / ' + msg.total + ' editions (' +
                 fmt(msg.bytes || 0) + ') ' + (msg.code || '');
         } else if (msg.type === 'done' && syncing) {
             syncing = false;
             pauseBtn.hidden = true;
-            labelEl.textContent = buildDoneMessage(pauseRequested, (msg.imgMissing || []).length, syncSelectedCount);
+            labelEl.textContent = buildDoneMessage(pauseRequested, (msg.imgMissing || []).length, syncSelectedCount, msg.imgFailed || 0);
             pauseRequested = false;
             renderEstimates();
             renderStorage();
@@ -208,7 +209,7 @@
         pauseBtn.addEventListener('click', function () {
             pauseRequested = true;
             pauseBtn.disabled = true;
-            labelEl.textContent = 'Pausing after the current bundle...';
+            labelEl.textContent = 'Pausing after the current edition...';
             window.OfflineMode.cancelSync();
         });
         document.addEventListener('offline:sync-message', onSyncMessage);

--- a/js/offline/offline-images.js
+++ b/js/offline/offline-images.js
@@ -58,14 +58,45 @@
     // connection busy without burying a phone's network stack.
     var FETCH_CONCURRENCY = 6;
 
+    // A corpus this size meets transient 5xx and dropped connections as a
+    // matter of course, so each image gets its own retries before it counts
+    // as failed.
+    var MAX_ATTEMPTS = 3;
+    var RETRY_BASE_MS = 500;
+
+    function delay(ms) {
+        return new Promise(function (resolve) { self.setTimeout(resolve, ms); });
+    }
+
+    // Marks the errors that must end the whole run rather than cost one image.
+    function fatalError(message) {
+        var err = new Error(message);
+        err.fatal = true;
+        return err;
+    }
+
     // Fetches one image into the cache. Reports its size, or 0 when the source
     // never published it, which is expected and not an error.
     async function fetchImage(cache, key) {
         var url = imageURL(key);
-        var resp = await self.fetch(url, { credentials: 'same-origin' });
-        if (resp.status === 403) throw new Error('forbidden');
-        if (resp.status === 404) return 0;
-        if (!resp.ok) throw new Error('image ' + key + ': HTTP ' + resp.status);
+        var resp = null;
+        for (var attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            try {
+                resp = await self.fetch(url, { credentials: 'same-origin' });
+            } catch (err) {
+                if (attempt === MAX_ATTEMPTS) throw err;
+                await delay(RETRY_BASE_MS * attempt);
+                continue;
+            }
+            if (resp.status === 403) throw fatalError('forbidden');
+            if (resp.status === 404) return 0;
+            if (resp.ok) break;
+            // Only a server-side failure is worth a second attempt.
+            if (resp.status < 500 || attempt === MAX_ATTEMPTS) {
+                throw new Error('image ' + key + ': HTTP ' + resp.status);
+            }
+            await delay(RETRY_BASE_MS * attempt);
+        }
         var blob = await resp.blob();
         try {
             await cache.put(new Request(url), new Response(blob, {
@@ -73,7 +104,7 @@
             }));
         } catch (err) {
             if (err && err.name === 'QuotaExceededError') {
-                throw new Error('storage quota exceeded while caching ' + key);
+                throw fatalError('storage quota exceeded while caching ' + key);
             }
             throw err;
         }
@@ -86,8 +117,9 @@
         var total = plan.work.length;
         var done = 0;
         var bytes = 0;
-        if (total === 0) return { done: 0, total: 0, bytes: 0, paused: false, missing: plan.missing };
-        if (deps.cancelled()) return { done: 0, total: total, bytes: 0, paused: true, missing: plan.missing };
+        var failed = 0;
+        if (total === 0) return { done: 0, total: 0, bytes: 0, paused: false, missing: plan.missing, failed: 0 };
+        if (deps.cancelled()) return { done: 0, total: total, bytes: 0, paused: true, missing: plan.missing, failed: 0 };
 
         if (self.navigator && self.navigator.storage && self.navigator.storage.estimate) {
             var est = await self.navigator.storage.estimate();
@@ -100,7 +132,7 @@
 
         var cache = await self.caches.open(IMAGE_CACHE);
         for (var i = 0; i < plan.work.length; i++) {
-            if (deps.cancelled()) return { done: done, total: total, bytes: bytes, paused: true, missing: plan.missing };
+            if (deps.cancelled()) return { done: done, total: total, bytes: bytes, paused: true, missing: plan.missing, failed: failed };
             var item = plan.work[i];
             deps.post({ type: 'progress', stage: 'images', done: done, total: total, code: item.code, bytes: bytes });
 
@@ -111,29 +143,40 @@
             var stored = [];
             var next = 0;
             var cancelled = false;
+            var fatal = null;
+            var setFailures = 0;
             var workers = [];
             for (var w = 0; w < FETCH_CONCURRENCY; w++) {
                 workers.push((async function () {
                     while (true) {
+                        if (fatal) return;
                         if (deps.cancelled()) { cancelled = true; return; }
                         var idx = next++;
                         if (idx >= keys.length) return;
-                        var size = await fetchImage(cache, keys[idx]);
-                        if (size > 0) {
-                            bytes += size;
-                            stored.push(keys[idx]);
+                        try {
+                            var size = await fetchImage(cache, keys[idx]);
+                            if (size > 0) {
+                                bytes += size;
+                                stored.push(keys[idx]);
+                            }
+                        } catch (err) {
+                            if (err && err.fatal) { fatal = err; return; }
+                            setFailures++;
                         }
                     }
                 })());
             }
             await Promise.all(workers);
-            if (cancelled) return { done: done, total: total, bytes: bytes, paused: true, missing: plan.missing };
+            if (fatal) throw fatal;
+            failed += setFailures;
+            if (cancelled) return { done: done, total: total, bytes: bytes, paused: true, missing: plan.missing, failed: failed };
 
-            await deps.putImgState({ code: item.code, hash: item.hash, done: true, keys: stored.sort() });
+            // A set that lost images stays not-done, so the next sync retries it.
+            await deps.putImgState({ code: item.code, hash: item.hash, done: setFailures === 0, keys: stored.sort() });
             done++;
             deps.post({ type: 'progress', stage: 'images', done: done, total: total, code: item.code, bytes: bytes });
         }
-        return { done: done, total: total, bytes: bytes, paused: false, missing: plan.missing };
+        return { done: done, total: total, bytes: bytes, paused: false, missing: plan.missing, failed: failed };
     }
 
     // Removes cached images and state rows for editions no longer selected.

--- a/js/offline/offline-sync.js
+++ b/js/offline/offline-sync.js
@@ -47,7 +47,7 @@ async function runImagesStage(manifest, imgEditions, isCancelled) {
     });
     if (sel.length === 0) {
         await OfflineDB.setMeta('imgCount', 0);
-        return { bytes: 0, missing: [] };
+        return { bytes: 0, missing: [], failed: 0 };
     }
     var rows = await OfflineDB.getAllRows('imgstate');
     var states = {};
@@ -71,7 +71,7 @@ async function runImagesStage(manifest, imgEditions, isCancelled) {
         return sum + (imgMap[r.code] ? imgMap[r.code].n : 1);
     }, 0);
     await OfflineDB.setMeta('imgCount', imgCount);
-    return { bytes: res.bytes, missing: res.missing || [] };
+    return { bytes: res.bytes, missing: res.missing || [], failed: res.failed || 0 };
 }
 
 async function runSync(msg) {
@@ -146,10 +146,12 @@ async function runSync(msg) {
             await self.OfflineDB.setMeta('authLapsed', false);
         }
         var imgMissing = [];
+        var imgFailed = 0;
         try {
             var imgResult = await runImagesStage(manifest, msg.imgEditions, function() { return cancelled; });
             state.bytes += imgResult.bytes;
             imgMissing = imgResult.missing;
+            imgFailed = imgResult.failed;
         } catch (err) {
             if (err && err.message === 'forbidden') {
                 try { await self.OfflineDB.setMeta('authLapsed', true); } catch (e) {}
@@ -157,7 +159,7 @@ async function runSync(msg) {
             post({ type: 'error', stage: 'images', message: err.message });
             return;
         }
-        post({ type: 'done', changedSets: state.done, bytes: state.bytes, imgMissing: imgMissing });
+        post({ type: 'done', changedSets: state.done, bytes: state.bytes, imgMissing: imgMissing, imgFailed: imgFailed });
     } catch (err) {
         if (err && err.message === 'forbidden') await self.OfflineDB.setMeta('authLapsed', true);
         post({ type: 'error', stage: (err && err.stage) || stage, message: (err && err.message) || String(err) });

--- a/sw.js
+++ b/sw.js
@@ -19,6 +19,7 @@ var SHELL_URLS = [
     '/js/fetchnames.js?hash=' + BUILD,
     '/js/autocomplete.js?hash=' + BUILD,
     '/js/navbar.js?hash=' + BUILD,
+    '/js/nightmode.js?hash=' + BUILD,
     '/js/palette-chips.js?hash=' + BUILD,
     '/js/palette-providers.js?hash=' + BUILD,
     '/js/guide-data.js?hash=' + BUILD,
@@ -30,6 +31,7 @@ var SHELL_URLS = [
     '/css/offline.css?hash=' + BUILD,
     '/js/offline/offline-db.js?hash=' + BUILD,
     '/js/offline/offline-mode.js?hash=' + BUILD,
+    '/js/offline/offline-prefer.js?hash=' + BUILD,
     '/js/offline/offline-format.js?hash=' + BUILD,
     '/js/offline/offline-util.js?hash=' + BUILD,
     '/js/offline/offline-query.js?hash=' + BUILD,
@@ -43,6 +45,8 @@ var SHELL_URLS = [
     '/js/offline/offline-banner.js?hash=' + BUILD,
     '/js/offline/offline-watch.js?hash=' + BUILD,
     '/img/logo/ban-stroop.png',
+    '/img/misc/patreon.png',
+    '/img/misc/discord.png',
     '/img/favicon/favicon-32x32.png',
     '/img/favicon/site.webmanifest'
 ];
@@ -51,8 +55,24 @@ var SHELL_URLS = [
 var KEYRUNE_PREFIX = 'https://cdn.jsdelivr.net/npm/keyrune@';
 var KEYRUNE_CSS = KEYRUNE_PREFIX + 'latest/css/keyrune.css';
 
+// Lucide draws the navbar and picker icons, and stays on @latest for the same
+// reason keyrune does.
+var LUCIDE_PREFIX = 'https://unpkg.com/lucide@';
+var LUCIDE_JS = LUCIDE_PREFIX + 'latest/dist/umd/lucide.js';
+
 function isKeyrune(url) {
     return url.href.indexOf(KEYRUNE_PREFIX) === 0;
+}
+
+function isCdnAsset(url) {
+    return isKeyrune(url) || url.href.indexOf(LUCIDE_PREFIX) === 0;
+}
+
+// Best effort, like the stylesheet: a CDN outage costs icons, not the install.
+function cacheCdnScript(c, url) {
+    return fetch(new Request(url, { cache: 'reload', mode: 'cors' })).then(function (res) {
+        if (res.ok) return c.put(url, res);
+    }).catch(function () {});
 }
 
 // Caches the stylesheet plus the font files it actually names. The font URLs
@@ -93,7 +113,7 @@ self.addEventListener('install', function (e) {
             // symbols, not fail the install and take offline mode down with it.
             // Fetched cors so the entry is a real response rather than an opaque
             // one, which would be unreadable and padded against the quota.
-            return cacheKeyrune(c);
+            return cacheKeyrune(c).then(function () { return cacheCdnScript(c, LUCIDE_JS); });
         });
     }).then(function () { return self.skipWaiting(); }));
 });
@@ -115,7 +135,7 @@ self.addEventListener('fetch', function (e) {
         // is only the offline fallback. ignoreVary because the CDN varies on
         // Accept-Encoding, which would otherwise stop the stylesheet's own font
         // request from matching what was cached.
-        if (isKeyrune(url)) {
+        if (isCdnAsset(url)) {
             e.respondWith(fetch(req).catch(function () {
                 return caches.match(req, { cacheName: SHELL_CACHE, ignoreVary: true }).then(function (hit) {
                     return hit || Response.error();
@@ -131,7 +151,9 @@ self.addEventListener('fetch', function (e) {
     // Card images: cache-first with network fallback (the image sync fills the cache).
     if (url.pathname.indexOf('/api/offline/images/') === 0) {
         e.respondWith(caches.open(IMAGE_CACHE).then(function (c) {
-            return c.match(req).then(function (hit) { return hit || fetch(req); });
+            return c.match(req).then(function (hit) {
+                return hit || fetch(req).catch(function () { return Response.error(); });
+            });
         }));
         return;
     }
@@ -150,7 +172,9 @@ self.addEventListener('fetch', function (e) {
     }
 
     // Shell assets: cache-first; hash-keyed URLs make cache and server agree.
+    // An uncached asset offline answers with an error rather than an unhandled
+    // rejection, which the page sees as a failed request either way.
     e.respondWith(caches.match(req, { cacheName: SHELL_CACHE }).then(function (hit) {
-        return hit || fetch(req);
+        return hit || fetch(req).catch(function () { return Response.error(); });
     }));
 });

--- a/sw_test.go
+++ b/sw_test.go
@@ -3,9 +3,32 @@ package main
 import (
 	"io"
 	"net/http/httptest"
+	"os"
+	"regexp"
 	"strings"
 	"testing"
 )
+
+// The offline shell renders base.html with the shared navbar, so every script
+// and stylesheet they pull has to be precached or the shell breaks offline.
+func TestServiceWorkerPrecachesShellAssets(t *testing.T) {
+	sw, err := os.ReadFile("sw.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assetRE := regexp.MustCompile(`(?:src|href)="(/(?:js|css)/[^"?]+)`)
+	for _, tmpl := range []string{"templates/base.html", "templates/partials/navbar.html"} {
+		body, err := os.ReadFile(tmpl)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, m := range assetRE.FindAllStringSubmatch(string(body), -1) {
+			if !strings.Contains(string(sw), "'"+m[1]+"?hash=") {
+				t.Errorf("%s: %s is missing from the service worker precache list", tmpl, m[1])
+			}
+		}
+	}
+}
 
 func TestServeServiceWorker(t *testing.T) {
 	r := httptest.NewRequest("GET", "/sw.js", nil)

--- a/tests/offline/images-ui.test.js
+++ b/tests/offline/images-ui.test.js
@@ -63,15 +63,15 @@ test('buildEstimateText with known editions', () => {
     expect(UI.buildEstimateText(images, ['NEO', 'MID'])).toBe('Selected: 2 editions, 702 images, 54.8 MB');
 });
 
-test('buildEstimateText appends missing count when some codes have no bundle', () => {
+test('buildEstimateText appends missing count when some codes have no images', () => {
     expect(UI.buildEstimateText(images, ['NEO', 'NOPE'])).toBe(
-        'Selected: 2 editions, 302 images, 24.8 MB (1 without bundles yet)'
+        'Selected: 2 editions, 302 images, 24.8 MB (1 without images yet)'
     );
 });
 
 test('buildEstimateText with all codes missing from manifest', () => {
     expect(UI.buildEstimateText(images, ['X', 'Y'])).toBe(
-        'Selected: 2 editions, 0 images, 0 B (2 without bundles yet)'
+        'Selected: 2 editions, 0 images, 0 B (2 without images yet)'
     );
 });
 
@@ -121,10 +121,22 @@ test('buildDoneMessage reports plain finish when nothing is missing', () => {
     expect(UI.buildDoneMessage(false, 0, 3)).toBe('Image sync finished.');
 });
 
-test('buildDoneMessage reports all-missing outcome when every selected edition lacks a bundle', () => {
-    expect(UI.buildDoneMessage(false, 3, 3)).toBe('0 of 3 selected editions have bundles yet.');
+test('buildDoneMessage reports all-missing outcome when every selected edition lacks images', () => {
+    expect(UI.buildDoneMessage(false, 3, 3)).toBe('0 of 3 selected editions have images yet.');
 });
 
-test('buildDoneMessage appends missing count when some but not all editions lack bundles', () => {
-    expect(UI.buildDoneMessage(false, 2, 5)).toBe('Image sync finished. (2 editions have no bundles yet)');
+test('buildDoneMessage appends missing count when some but not all editions lack images', () => {
+    expect(UI.buildDoneMessage(false, 2, 5)).toBe('Image sync finished. (2 editions have no images yet)');
+});
+
+test('buildDoneMessage reports images that failed and will be retried', () => {
+    expect(UI.buildDoneMessage(false, 0, 5, 7)).toBe(
+        'Image sync finished. (7 images failed and retry on the next sync)'
+    );
+});
+
+test('buildDoneMessage reports missing editions and failed images together', () => {
+    expect(UI.buildDoneMessage(false, 2, 5, 7)).toBe(
+        'Image sync finished. (2 editions have no images yet; 7 images failed and retry on the next sync)'
+    );
 });

--- a/tests/offline/images.test.js
+++ b/tests/offline/images.test.js
@@ -55,6 +55,49 @@ test('fetchImage treats an unpublished image as a skip, not a failure', async ()
     expect(cache.store).toHaveLength(0);
 });
 
+test('fetchImage retries a transient 5xx and succeeds', async () => {
+    const { cache, caches } = makeFakeCache();
+    let calls = 0;
+    const mod = loadWithExtras({
+        caches,
+        setTimeout: fn => fn(),
+        fetch: async () => {
+            calls++;
+            if (calls < 3) return new Response(null, { status: 504 });
+            return new Response(new Uint8Array([1, 2, 3]));
+        },
+    });
+    expect(await mod.fetchImage(cache, 'key-aaa')).toBe(3);
+    expect(calls).toBe(3);
+});
+
+test('fetchImage retries a network error before giving up', async () => {
+    const { cache, caches } = makeFakeCache();
+    let calls = 0;
+    const mod = loadWithExtras({
+        caches,
+        setTimeout: fn => fn(),
+        fetch: async () => {
+            calls++;
+            throw new TypeError('Failed to fetch');
+        },
+    });
+    await expect(mod.fetchImage(cache, 'key-aaa')).rejects.toThrow('Failed to fetch');
+    expect(calls).toBe(3);
+});
+
+test('fetchImage does not retry a 403, which means auth lapsed', async () => {
+    const { cache, caches } = makeFakeCache();
+    let calls = 0;
+    const mod = loadWithExtras({
+        caches,
+        setTimeout: fn => fn(),
+        fetch: async () => { calls++; return new Response(null, { status: 403 }); },
+    });
+    await expect(mod.fetchImage(cache, 'key-aaa')).rejects.toThrow('forbidden');
+    expect(calls).toBe(1);
+});
+
 test('computeWorkList selects missing, changed, and unfinished bundles', () => {
     const states = {
         NEO: { code: 'NEO', hash: 'aaaa', done: true },  // up to date: skip
@@ -139,7 +182,7 @@ test('syncImages returns immediately when no work is needed', async () => {
         cancelled: () => false,
         putImgState: async () => {},
     });
-    expect(result).toEqual({ done: 0, total: 0, bytes: 0, paused: false, missing: [] });
+    expect(result).toEqual({ done: 0, total: 0, bytes: 0, paused: false, missing: [], failed: 0 });
 });
 
 test('syncImages returns missing codes with zero total when selection has no images yet', async () => {
@@ -152,7 +195,7 @@ test('syncImages returns missing codes with zero total when selection has no ima
         cancelled: () => false,
         putImgState: async () => {},
     });
-    expect(result).toEqual({ done: 0, total: 0, bytes: 0, paused: false, missing: ['NOPE'] });
+    expect(result).toEqual({ done: 0, total: 0, bytes: 0, paused: false, missing: ['NOPE'], failed: 0 });
 });
 
 test('syncImages includes missing codes alongside completed work', async () => {
@@ -167,7 +210,7 @@ test('syncImages includes missing codes alongside completed work', async () => {
         putImgState: async () => {},
         getImgKeys: keysFrom({ TST: ['key-aaa'] }),
     });
-    expect(result).toEqual({ done: 1, total: 1, bytes: 3, paused: false, missing: ['NOPE'] });
+    expect(result).toEqual({ done: 1, total: 1, bytes: 3, paused: false, missing: ['NOPE'], failed: 0 });
 });
 
 test('syncImages downloads each image and marks done', async () => {
@@ -187,13 +230,60 @@ test('syncImages downloads each image and marks done', async () => {
         putImgState: async r => states.push({ ...r }),
         getImgKeys: keysFrom({ TST: ['key-aaa', 'key-bbb'] }),
     });
-    expect(result).toEqual({ done: 1, total: 1, bytes: 4, paused: false, missing: [] });
+    expect(result).toEqual({ done: 1, total: 1, bytes: 4, paused: false, missing: [], failed: 0 });
     expect(posts).toHaveLength(2);
     expect(cache.store).toHaveLength(2);
     expect(states).toEqual([
         { code: 'TST', hash: 'h1', done: false },
         { code: 'TST', hash: 'h1', done: true, keys: ['key-aaa', 'key-bbb'] },
     ]);
+});
+
+test('syncImages survives an image the server keeps failing on', async () => {
+    const { caches } = makeFakeCache();
+    const states = [];
+    const mod = loadWithExtras({
+        caches,
+        setTimeout: fn => fn(),
+        fetch: async url => String(url).includes('key-bad')
+            ? new Response(null, { status: 504 })
+            : new Response(new Uint8Array([1, 2])),
+    });
+    const result = await mod.syncImages({
+        images: { TST: { h: 'h1', n: 2, b: 4 } },
+        sel: ['TST'],
+        states: {},
+        post: () => {},
+        cancelled: () => false,
+        putImgState: async r => states.push({ ...r }),
+        getImgKeys: keysFrom({ TST: ['key-good', 'key-bad'] }),
+    });
+    expect(result).toEqual({ done: 1, total: 1, bytes: 2, paused: false, missing: [], failed: 1 });
+    // Left not-done on purpose: the next sync retries the image that failed.
+    expect(states[states.length - 1]).toEqual({
+        code: 'TST', hash: 'h1', done: false, keys: ['key-good'],
+    });
+});
+
+test('syncImages moves on to the next set after one set fails', async () => {
+    const { caches } = makeFakeCache();
+    const mod = loadWithExtras({
+        caches,
+        setTimeout: fn => fn(),
+        fetch: async url => String(url).includes('key-bad')
+            ? new Response(null, { status: 504 })
+            : new Response(new Uint8Array([1, 2])),
+    });
+    const result = await mod.syncImages({
+        images: { AAA: { h: 'h1', n: 1, b: 2 }, BBB: { h: 'h2', n: 1, b: 2 } },
+        sel: ['AAA', 'BBB'],
+        states: {},
+        post: () => {},
+        cancelled: () => false,
+        putImgState: async () => {},
+        getImgKeys: keysFrom({ AAA: ['key-bad'], BBB: ['key-good'] }),
+    });
+    expect(result).toEqual({ done: 2, total: 2, bytes: 2, paused: false, missing: [], failed: 1 });
 });
 
 test('syncImages records only the images the server actually had', async () => {


### PR DESCRIPTION
Three fixes found while syncing the full image corpus on this branch. Based on `offline-mode`, not master.

## One failed image no longer ends the whole sync

`fetchImage` threw on any non-ok status, a throw rejected the worker, one rejected worker failed the `Promise.all`, and the catch in `runSync` posted an error and returned. So a single transient 504 anywhere in a 106,000 image run aborted the run, and the next attempt hit another one. That is the reason a full sync never finished rather than merely being slow.

Each image now gets three attempts with linear backoff, and only on the failures worth retrying: a 5xx or a network error. A 403 still fails fast, because it means the entitlement lapsed and retrying cannot help, and `QuotaExceededError` still stops everything, because the next image cannot fit either. Both are marked with an `err.fatal` flag rather than matched on message text.

Anything that survives its retries costs one image instead of the run. The set it belongs to is left `done: false`, so `computeWorkList` picks it up on the next sync and the images already cached are skipped. `syncImages` returns a `failed` count, which the worker forwards and the picker reports, so a run that quietly lost images says so instead of claiming it finished.

## The picker counts editions, not bundles

The work list has been per-set since the bundles came out, but the UI kept the old noun, so a full selection read `0 / 692 bundles` for something that is neither bundles nor images. It now says editions, along with the estimate line, the pause label and the done message.

## The offline shell stops erroring on its own assets

Three separate problems, all visible as a wall of console errors on `/offline` with the network down:

**Unhandled rejections.** The shell-asset and card-image branches of the fetch handler both ended in `hit || fetch(req)` with nothing after it, so any asset that was not in the cache became an uncaught `TypeError: Failed to fetch` once the network was gone. The navigate and keyrune branches above them already handled this. Both now fall back to `Response.error()`, which the page sees as the same failed request without the noise.

**Assets the shell renders but never precached.** `offline-prefer.js` (loaded by `base.html`), `nightmode.js`, `patreon.png` and `discord.png` all come from `base.html` and the shared navbar, which the offline shell renders, but none were in `SHELL_URLS`.

Since this is the third time an asset has been missed this way, `sw_test.go` now checks every script and stylesheet in `base.html` and `partials/navbar.html` against the precache list, so the next omission fails a test rather than reaching a browser.

**Lucide was not cached.** It draws the navbar and editions-picker icons and loads from `unpkg@latest`, but the cross-origin branch only recognised keyrune, so it was never cached and every icon was missing offline. It is now cached at install and served network-first with a cache fallback, exactly like the stylesheet, and for the same reason: staying on `@latest` keeps new icons arriving without a deploy.

## Verification

`go build`, `go vet` and `go test ./...` pass. 222 client tests pass under `bun test tests/offline/`, including new coverage for the retry path, for a set left retryable after a failure, and for a sync continuing past a set that failed.

## Not addressed here, but worth a look

Sync is still slow after this, and the reason looks structural rather than incidental. `serveImage` sends every image through the origin with `Cache-Control: private`, so nothing shared can cache them and each entitled user pulls the whole corpus, roughly 6.3 GB, out of B2 through the app. Every request reads the object fully into memory to hash it, with no timeout on the read.

Unlike `servePrices`, `serveImage` takes no email: the bytes are identical for every user, and the same images are already public on Scryfall and TCGplayer, so `private` may be stricter than the content needs. Measured from the bucket, sealed images run 117 to 288 KB against 34 to 75 KB for singles, since sealed mirrors the full size TCGplayer jpg while singles are the grid webp. That roughly 3.3x is consistent with sealed being where the 504s show up first. Happy to open something separate if the direction sounds right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
