### PR TITLE
Close the five code-scanning findings that were real

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -263,24 +263,48 @@ func redirectAfterAuth(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, redir, http.StatusFound)
 }
 
-// isServerOrigin reports whether target is an absolute URL on this very site,
-// naming both the scheme and the host that ServerURL does.
+// isServerOrigin reports whether target is an absolute URL on this site: the
+// scheme ServerURL names, on a hostname the session cookie already covers.
 //
-// Comparing the parsed host is what refuses the spellings that only look like
-// ours: "https://www.mtgban.com@evil.com" parses with evil.com as the host,
-// and the schemeless, backslash and scheme-only forms parse with no host at
-// all. An unset ServerURL matches nothing, since without it there is no origin
-// to be part of.
+// ServerURL is latched once per process from whichever trusted host arrived
+// first, while the state is the page's own window.location.href, so the two
+// legitimately name sibling hosts - mtgban.com, www, beta. The session spans
+// them because the cookie is written on the parent domain, so the redirect has
+// to span exactly the same set: globalCookieDomain is asked for it rather than
+// spelling out a second, drifting notion of ours. Comparing hostnames instead
+// of hosts keeps an explicit default port, which a proxy may put in
+// X-Forwarded-Host but a browser never writes, from failing every match.
+//
+// Comparing the parsed hostname is what refuses the spellings that only look
+// like ours: "https://www.mtgban.com@evil.com" parses with evil.com as the
+// host, "mtgban.com.evil.com" is under evil.com and not under ours, and the
+// schemeless, backslash and scheme-only forms parse with no host at all. An
+// unset ServerURL matches nothing, since without it there is no origin to be
+// part of.
 func isServerOrigin(target string) bool {
 	server, err := url.Parse(ServerURL)
-	if err != nil || server.Host == "" {
+	if err != nil || server.Hostname() == "" {
 		return false
 	}
 	u, err := url.Parse(target)
-	if err != nil {
+	if err != nil || u.Hostname() == "" || u.Scheme != server.Scheme {
 		return false
 	}
-	return u.Scheme == server.Scheme && u.Host == server.Host
+
+	// Hostnames are case insensitive, but url.Parse preserves whatever case
+	// the target was written in
+	host := strings.ToLower(u.Hostname())
+	name := strings.ToLower(server.Hostname())
+	if host == name {
+		return true
+	}
+
+	// An empty domain is a host-only cookie, which no sibling ever receives
+	domain := globalCookieDomain(name)
+	if domain == "" {
+		return false
+	}
+	return host == domain || strings.HasSuffix(host, "."+domain)
 }
 
 func signHMACSHA1Base64(key []byte, data []byte) string {

--- a/auth.go
+++ b/auth.go
@@ -239,16 +239,48 @@ func Auth(w http.ResponseWriter, r *http.Request) {
 	// Keep it secret. Keep it safe.
 	putSignatureInCookies(w, sig)
 
-	// Redirect to the URL indicated in this query param, or go to homepage
+	// Redirect, we're done here
+	redirectAfterAuth(w, r)
+}
+
+// redirectAfterAuth returns the visitor to the page indicated in the state
+// query param, or to the homepage.
+//
+// State rides through Patreon untouched and comes back as whatever the link
+// that opened the flow put there, so a crafted authorize URL names any site it
+// likes - and by the time we read it the session cookie is already set.
+// isLocalRedirect is no help here: templates build state out of
+// window.location.href, so a legitimate one is absolute.
+func redirectAfterAuth(w http.ResponseWriter, r *http.Request) {
 	redir := strings.Split(r.FormValue("state"), ";")[0]
 
-	// Go back home if empty or if coming back from a logout
-	if redir == "" || strings.Contains(redir, "errmsg=logout") {
+	// Go back home when coming back from a logout, and whenever the target is
+	// not ours - which is also how the empty state lands there
+	if strings.Contains(redir, "errmsg=logout") || !isServerOrigin(redir) {
 		redir = ServerURL
 	}
 
-	// Redirect, we're done here
 	http.Redirect(w, r, redir, http.StatusFound)
+}
+
+// isServerOrigin reports whether target is an absolute URL on this very site,
+// naming both the scheme and the host that ServerURL does.
+//
+// Comparing the parsed host is what refuses the spellings that only look like
+// ours: "https://www.mtgban.com@evil.com" parses with evil.com as the host,
+// and the schemeless, backslash and scheme-only forms parse with no host at
+// all. An unset ServerURL matches nothing, since without it there is no origin
+// to be part of.
+func isServerOrigin(target string) bool {
+	server, err := url.Parse(ServerURL)
+	if err != nil || server.Host == "" {
+		return false
+	}
+	u, err := url.Parse(target)
+	if err != nil {
+		return false
+	}
+	return u.Scheme == server.Scheme && u.Host == server.Host
 }
 
 func signHMACSHA1Base64(key []byte, data []byte) string {

--- a/auth_redirect_test.go
+++ b/auth_redirect_test.go
@@ -26,10 +26,16 @@ func TestRedirectAfterAuth(t *testing.T) {
 	}{
 		{"same page", "https://www.mtgban.com/search?q=lotus", "https://www.mtgban.com/search?q=lotus"},
 		{"same host root", home, home},
+		{"bare domain", "https://mtgban.com/search?q=lotus", "https://mtgban.com/search?q=lotus"},
+		{"sibling subdomain", "https://beta.mtgban.com/arbit", "https://beta.mtgban.com/arbit"},
+		{"explicit default port", "https://www.mtgban.com:443/search?q=lotus", "https://www.mtgban.com:443/search?q=lotus"},
+		{"uppercase sibling", "https://BETA.MTGBAN.COM/arbit", "https://BETA.MTGBAN.COM/arbit"},
 		{"empty", "", home},
 		{"logout", "https://www.mtgban.com/?errmsg=logout", home},
 		{"other host", "https://evil.com/", home},
 		{"host suffix", "https://www.mtgban.com.evil.com/", home},
+		{"domain suffix", "https://mtgban.com.evil.com/", home},
+		{"domain prefix", "https://notmtgban.com/", home},
 		{"scheme downgrade", "http://www.mtgban.com/", home},
 		{"userinfo", "https://www.mtgban.com@evil.com/", home},
 		{"protocol relative", "//evil.com/", home},
@@ -44,6 +50,61 @@ func TestRedirectAfterAuth(t *testing.T) {
 		w := httptest.NewRecorder()
 		// The client id rides along after a semicolon, the way the login links
 		// in the templates spell it
+		r := httptest.NewRequest(http.MethodGet, "/auth?code=code&state="+url.QueryEscape(tt.state+";web"), nil)
+		redirectAfterAuth(w, r)
+
+		got := w.Header().Get("Location")
+		if got != tt.want {
+			t.Errorf("%s: state %q redirected to %q, want %q", tt.name, tt.state, got, tt.want)
+		}
+	}
+}
+
+// A proxy is free to name the default port in X-Forwarded-Host, which latches
+// it into ServerURL, but no browser writes it in window.location.href. The
+// visitor still has to get back to the page they logged in from.
+func TestRedirectAfterAuthWithDefaultPort(t *testing.T) {
+	saved := ServerURL
+	t.Cleanup(func() { ServerURL = saved })
+	ServerURL = "https://www.mtgban.com:443"
+
+	for _, tt := range []struct {
+		name  string
+		state string
+		want  string
+	}{
+		{"portless same host", "https://www.mtgban.com/search?q=lotus", "https://www.mtgban.com/search?q=lotus"},
+		{"portless sibling", "https://beta.mtgban.com/arbit", "https://beta.mtgban.com/arbit"},
+		{"other host", "https://evil.com/", ServerURL},
+	} {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/auth?code=code&state="+url.QueryEscape(tt.state+";web"), nil)
+		redirectAfterAuth(w, r)
+
+		got := w.Header().Get("Location")
+		if got != tt.want {
+			t.Errorf("%s: state %q redirected to %q, want %q", tt.name, tt.state, got, tt.want)
+		}
+	}
+}
+
+// A dev session lives on a host-only cookie, so nothing but that host is ours,
+// and the port the dev server happens to run on is no part of the answer.
+func TestRedirectAfterAuthLocalhost(t *testing.T) {
+	saved := ServerURL
+	t.Cleanup(func() { ServerURL = saved })
+	ServerURL = "http://localhost:8080"
+
+	for _, tt := range []struct {
+		name  string
+		state string
+		want  string
+	}{
+		{"same host", "http://localhost:8080/search?q=lotus", "http://localhost:8080/search?q=lotus"},
+		{"other host", "http://evil.com/", ServerURL},
+		{"production host", "https://www.mtgban.com/", ServerURL},
+	} {
+		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodGet, "/auth?code=code&state="+url.QueryEscape(tt.state+";web"), nil)
 		redirectAfterAuth(w, r)
 

--- a/auth_redirect_test.go
+++ b/auth_redirect_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// The state parameter is whatever the link that opened the login wrote, and the
+// session cookie is set before it is read, so a redirect anywhere but this very
+// site has to land on the homepage instead. The state also arrives percent
+// decoded, which is where "%5C" turns back into the backslash a browser reads
+// as a slash.
+func TestRedirectAfterAuth(t *testing.T) {
+	saved := ServerURL
+	t.Cleanup(func() { ServerURL = saved })
+	ServerURL = "https://www.mtgban.com"
+
+	const home = "https://www.mtgban.com"
+
+	for _, tt := range []struct {
+		name  string
+		state string
+		want  string
+	}{
+		{"same page", "https://www.mtgban.com/search?q=lotus", "https://www.mtgban.com/search?q=lotus"},
+		{"same host root", home, home},
+		{"empty", "", home},
+		{"logout", "https://www.mtgban.com/?errmsg=logout", home},
+		{"other host", "https://evil.com/", home},
+		{"host suffix", "https://www.mtgban.com.evil.com/", home},
+		{"scheme downgrade", "http://www.mtgban.com/", home},
+		{"userinfo", "https://www.mtgban.com@evil.com/", home},
+		{"protocol relative", "//evil.com/", home},
+		{"backslash", `/\evil.com`, home},
+		{"double backslash", `\\evil.com`, home},
+		{"scheme and backslashes", `https:\\evil.com`, home},
+		{"javascript", "javascript:alert(document.cookie)", home},
+		{"data", "data:text/html,<script>alert(1)</script>", home},
+		{"control character", "/\t//evil.com", home},
+		{"relative path", "/search", home},
+	} {
+		w := httptest.NewRecorder()
+		// The client id rides along after a semicolon, the way the login links
+		// in the templates spell it
+		r := httptest.NewRequest(http.MethodGet, "/auth?code=code&state="+url.QueryEscape(tt.state+";web"), nil)
+		redirectAfterAuth(w, r)
+
+		got := w.Header().Get("Location")
+		if got != tt.want {
+			t.Errorf("%s: state %q redirected to %q, want %q", tt.name, tt.state, got, tt.want)
+		}
+	}
+}
+
+// Without a ServerURL there is no origin to be part of, and a relative target
+// would otherwise match the empty scheme and host an unset one parses to. The
+// empty fallback reaches the browser as the site root, which is where
+// http.Redirect resolves it against the request.
+func TestRedirectAfterAuthWithoutServerURL(t *testing.T) {
+	saved := ServerURL
+	t.Cleanup(func() { ServerURL = saved })
+	ServerURL = ""
+
+	for _, state := range []string{`/\evil.com`, "//evil.com/", "https://evil.com/"} {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/auth?code=code&state="+url.QueryEscape(state), nil)
+		redirectAfterAuth(w, r)
+
+		got := w.Header().Get("Location")
+		if got != "/" {
+			t.Errorf("state %q redirected to %q, want the site root", state, got)
+		}
+	}
+}

--- a/js/store-picker.js
+++ b/js/store-picker.js
@@ -36,3 +36,30 @@ document.addEventListener('click', function (event) {
 
     select.focus();
 });
+
+// Picking a store navigates to the option's value, so the value decides where
+// the visitor lands. Resolving it against the current page and comparing the
+// origin is what the browser itself would do, so nothing can look local and
+// resolve elsewhere: a browser strips a tab, newline or carriage return before
+// it parses, which is how "/\t/evil.com" reads as "//evil.com" and leaves.
+//
+// The store that is already active carries an empty value, and an empty value
+// resolves to this very page, so it needs saying that it goes nowhere.
+function goToStore(value) {
+    if (!value) {
+        return;
+    }
+
+    var url;
+    try {
+        url = new URL(value, window.location.href);
+    } catch (err) {
+        return;
+    }
+
+    if (url.origin !== window.location.origin) {
+        return;
+    }
+
+    window.location.href = url.href;
+}

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
+	"io/fs"
 	"log"
 	"net/http"
 	"net/url"
@@ -654,10 +655,52 @@ const (
 	DefaultSignatureDuration = 11 * 24 * time.Hour
 )
 
-// Cache for a week as these assets either never change or have a snapshot key in the URL
-func ServeFile(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=86400")
-	http.ServeFile(w, r, r.URL.Path[1:])
+// staticRoots are the directories the server hands out off disk. Each is
+// served through an http.Dir rooted at itself, so a request can only name a
+// file inside the tree it routed to and the requested path never reaches an
+// open call here: the constraint is the root, not a check that a later route
+// could widen past.
+var staticRoots = []string{"css", "img", "js"}
+
+// filesOnly is an http.FileSystem that serves files and refuses directories.
+// http.FileServer otherwise renders an index for a directory requested bare,
+// and none of these trees carries an index.html to cover one.
+type filesOnly struct{ fs http.FileSystem }
+
+func (only filesOnly) Open(name string) (http.File, error) {
+	f, err := only.fs.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	if info.IsDir() {
+		f.Close()
+		return nil, fs.ErrNotExist
+	}
+	return f, nil
+}
+
+// staticTree serves one directory. Cache for a week as these assets either
+// never change or have a snapshot key in the URL.
+func staticTree(root string) http.Handler {
+	files := http.FileServer(filesOnly{http.Dir(root)})
+	return http.StripPrefix("/"+root+"/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "public, max-age=86400")
+		files.ServeHTTP(w, r)
+	}))
+}
+
+// staticFile serves one fixed file. The name is fixed at registration, so the
+// request chooses whether it is served, never which file it is.
+func staticFile(name string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "public, max-age=86400")
+		http.ServeFile(w, r, name)
+	}
 }
 
 func genPageNav(activeTab, sig string) PageVars {
@@ -1226,11 +1269,13 @@ func main() {
 	}
 
 	// Serve everything in known folders as a file
-	http.HandleFunc("/css/", ServeFile)
-	http.HandleFunc("/img/", ServeFile)
-	http.HandleFunc("/js/", ServeFile)
-	http.HandleFunc("/favicon.ico", ServeFile)
-	http.HandleFunc("/robots.txt", ServeFile)
+	for _, root := range staticRoots {
+		http.Handle("/"+root+"/", staticTree(root))
+	}
+	// The browser asks for /favicon.ico on its own for anything not rendered
+	// through base.html, which links the real one under /img/favicon.
+	http.HandleFunc("/favicon.ico", staticFile("img/favicon/favicon.ico"))
+	http.HandleFunc("/robots.txt", staticFile("robots.txt"))
 
 	// custom redirector
 	http.HandleFunc("/go/", Redirect)

--- a/mobile.go
+++ b/mobile.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/http"
+	"net/url"
 	"slices"
 	"strings"
 
@@ -48,14 +49,29 @@ func toggleMobileView(w http.ResponseWriter, r *http.Request) {
 		SameSite: http.SameSiteLaxMode,
 	})
 
-	// Only honor same-origin relative redirect targets to avoid an open
-	// redirect: require a leading single slash (rejects "//evil.com",
-	// "https://evil.com", "javascript:", etc.).
 	redirect := r.FormValue("redirect")
-	if !strings.HasPrefix(redirect, "/") || strings.HasPrefix(redirect, "//") {
+	if !isLocalRedirect(redirect) {
 		redirect = "/"
 	}
 	http.Redirect(w, r, redirect, http.StatusFound)
+}
+
+// isLocalRedirect reports whether target is a path on this site, so that a
+// redirect parameter cannot send a visitor elsewhere.
+//
+// The leading slash is not enough on its own. "//evil.com" is
+// protocol-relative, and "/\evil.com" is the same thing to a browser, which
+// reads the backslash as a slash - that second one is what the old prefix
+// test let through. Anything naming a scheme or a host is refused outright.
+func isLocalRedirect(target string) bool {
+	if !strings.HasPrefix(target, "/") {
+		return false
+	}
+	if len(target) > 1 && (target[1] == '/' || target[1] == '\\') {
+		return false
+	}
+	u, err := url.Parse(target)
+	return err == nil && u.Scheme == "" && u.Host == ""
 }
 
 // Pages that have mobile templates - only these show in mobile nav.

--- a/mobile_redirect_test.go
+++ b/mobile_redirect_test.go
@@ -1,0 +1,30 @@
+package main
+
+import "testing"
+
+// A redirect parameter must never leave the site. The backslash cases are the
+// ones a leading-slash test lets through: a browser reads "/\evil.com" the way
+// it reads "//evil.com".
+func TestIsLocalRedirect(t *testing.T) {
+	for _, tt := range []struct {
+		target string
+		want   bool
+	}{
+		{"/", true},
+		{"/search", true},
+		{"/search?q=a/b", true},
+		{"", false},
+		{"//evil.com", false},
+		{`/\evil.com`, false},
+		{`/\\evil.com`, false},
+		{"https://evil.com", false},
+		{"javascript:alert(1)", false},
+		{"data:text/html,<script>alert(1)</script>", false},
+		{`\\evil.com`, false},
+		{"evil.com", false},
+	} {
+		if got := isLocalRedirect(tt.target); got != tt.want {
+			t.Errorf("isLocalRedirect(%q) = %v, want %v", tt.target, got, tt.want)
+		}
+	}
+}

--- a/mobile_redirect_test.go
+++ b/mobile_redirect_test.go
@@ -1,10 +1,20 @@
 package main
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
 
 // A redirect parameter must never leave the site. The backslash cases are the
 // ones a leading-slash test lets through: a browser reads "/\evil.com" the way
 // it reads "//evil.com".
+//
+// The control characters are the other spelling of the same trick, and they
+// rest on url.Parse refusing them rather than on anything written here, so they
+// are pinned: a browser drops a tab, newline or carriage return before parsing,
+// which turns "/\t/evil.com" into "//evil.com" on its way off site.
 func TestIsLocalRedirect(t *testing.T) {
 	for _, tt := range []struct {
 		target string
@@ -22,9 +32,42 @@ func TestIsLocalRedirect(t *testing.T) {
 		{"data:text/html,<script>alert(1)</script>", false},
 		{`\\evil.com`, false},
 		{"evil.com", false},
+		{"/\t/evil.com", false},
+		{"/\n//evil.com", false},
+		{"/\r//evil.com", false},
 	} {
 		if got := isLocalRedirect(tt.target); got != tt.want {
 			t.Errorf("isLocalRedirect(%q) = %v, want %v", tt.target, got, tt.want)
+		}
+	}
+}
+
+// The predicate never sees the query as it was written: the handler decodes it
+// first, so "%5C" is already a backslash and "%09" already a tab by then. Read
+// the Location header the browser would act on, rather than trusting that the
+// two steps compose.
+func TestToggleMobileViewRedirect(t *testing.T) {
+	for _, tt := range []struct {
+		redirect string
+		want     string
+	}{
+		{"/search?q=a", "/search?q=a"},
+		{"", "/"},
+		{`/\evil.com`, "/"},
+		{"//evil.com", "/"},
+		{"https://evil.com", "/"},
+		{"javascript:alert(1)", "/"},
+		{"/\t/evil.com", "/"},
+		{"/\n//evil.com", "/"},
+		{"/\r//evil.com", "/"},
+	} {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/toggle-mobile?redirect="+url.QueryEscape(tt.redirect), nil)
+		toggleMobileView(w, r)
+
+		got := w.Header().Get("Location")
+		if got != tt.want {
+			t.Errorf("redirect %q sent the visitor to %q, want %q", tt.redirect, got, tt.want)
 		}
 	}
 }

--- a/static_serve_test.go
+++ b/static_serve_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The static routes hand out files from three directories plus two fixed
+// names. Each tree is served through an http.Dir rooted at itself, so what a
+// request can reach is bounded by that root rather than by a check on the path
+// that a later, broader route could widen past.
+func TestStaticServing(t *testing.T) {
+	mux := http.NewServeMux()
+	for _, root := range staticRoots {
+		mux.Handle("/"+root+"/", staticTree(root))
+	}
+	mux.HandleFunc("/robots.txt", staticFile("robots.txt"))
+	mux.HandleFunc("/favicon.ico", staticFile("img/favicon/favicon.ico"))
+
+	for _, tc := range []struct {
+		name, path, wantBody string
+	}{
+		{"a file in a served tree", "/css/main.css", "{"},
+		{"a file in a nested directory", "/img/setsymbol/default.svg", "<svg"},
+		{"a fixed file", "/robots.txt", ""},
+		// The browser asks for this one unprompted on any page that does not
+		// link an icon of its own.
+		{"the bare favicon browsers ask for", "/favicon.ico", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, tc.path, nil))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("GET %s = %d, want 200", tc.path, rec.Code)
+			}
+			if tc.wantBody != "" && !strings.Contains(rec.Body.String(), tc.wantBody) {
+				t.Errorf("GET %s body %.60q, want it to contain %q", tc.path, rec.Body.String(), tc.wantBody)
+			}
+			if rec.Header().Get("Cache-Control") == "" {
+				t.Errorf("GET %s served without a Cache-Control header", tc.path)
+			}
+		})
+	}
+
+	// Nothing outside a served tree comes back with a body, whichever way the
+	// path is spelled. A 3xx here is the mux normalizing the path before it
+	// routes; what matters is that the destination is not served either, so no
+	// file content ever leaves.
+	for _, tc := range []struct{ name, path string }{
+		{"climbing out with ..", "/css/../upload.go"},
+		{"climbing out, encoded", "/css/%2e%2e/upload.go"},
+		{"climbing out, deeper", "/css/../../../../etc/passwd"},
+		{"an absolute path", "/css//etc/passwd"},
+		{"a directory in a served tree", "/css/"},
+		{"a nested directory", "/img/setsymbol/"},
+		{"a file that isn't there", "/css/nope.css"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, tc.path, nil))
+			if rec.Code == http.StatusOK {
+				t.Fatalf("GET %s = 200, want it refused (body %.80q)", tc.path, rec.Body.String())
+			}
+			if body := rec.Body.String(); strings.Contains(body, "package main") || strings.Contains(body, "root:") {
+				t.Errorf("GET %s leaked file content: %.80q", tc.path, body)
+			}
+			// A redirect must not land on something this mux serves.
+			if loc := rec.Header().Get("Location"); loc != "" {
+				follow := httptest.NewRecorder()
+				mux.ServeHTTP(follow, httptest.NewRequest(http.MethodGet, loc, nil))
+				if follow.Code == http.StatusOK {
+					t.Errorf("GET %s redirected to %s, which is served", tc.path, loc)
+				}
+			}
+		})
+	}
+}

--- a/templates/arbit.html
+++ b/templates/arbit.html
@@ -115,7 +115,7 @@
         <div class="arb-selector-bar">
             <div class="arb-current-store">
                 <span class="store-type">{{if .GlobalMode}}Index{{else if .ReverseMode}}Selling to{{else}}Buying from{{end}}</span>
-                <select class="arb-store-select" onchange="if(/^\/(?![\/\\])/.test(this.value)) window.location.href=this.value">
+                <select class="arb-store-select" onchange="goToStore(this.value)">
                     {{range .ExtraNav}}
                         {{if not (contains .Name "Sealed")}}
                             {{if .Active}}

--- a/templates/arbit.html
+++ b/templates/arbit.html
@@ -115,7 +115,7 @@
         <div class="arb-selector-bar">
             <div class="arb-current-store">
                 <span class="store-type">{{if .GlobalMode}}Index{{else if .ReverseMode}}Selling to{{else}}Buying from{{end}}</span>
-                <select class="arb-store-select" onchange="if(/^\/(?!\/)/.test(this.value)) window.location.href=this.value">
+                <select class="arb-store-select" onchange="if(/^\/(?![\/\\])/.test(this.value)) window.location.href=this.value">
                     {{range .ExtraNav}}
                         {{if not (contains .Name "Sealed")}}
                             {{if .Active}}

--- a/templates/search.html
+++ b/templates/search.html
@@ -1620,7 +1620,11 @@ body.modal-embed .cp-overlay { display: none !important; }
             if (a.dataset.modalDecorated === '1') return;
             var raw = a.getAttribute('href');
             if (!raw) return;
-            if (raw.charAt(0) === '#' || raw.indexOf('javascript:') === 0) return;
+            // Naming the dangerous schemes one at a time always misses one
+            // (data:, vbscript:, and whatever comes next). The origin test
+            // below already refuses every one of them - they parse to a null
+            // origin - so let it do the work and only skip in-page anchors.
+            if (raw.charAt(0) === '#') return;
             if (a.target === '_blank') return;
             var url;
             try { url = new URL(raw, window.location.href); } catch (e) { return; }

--- a/upload.go
+++ b/upload.go
@@ -1602,7 +1602,17 @@ func loadCollection(ctx context.Context, link string, maxRows int) ([]UploadEntr
 	if err != nil {
 		return nil, "", err
 	}
-	resp, err := cleanhttp.DefaultClient().Do(req)
+	// The host check above only covers the first hop. A redirect would
+	// carry the request anywhere the target chose, including back at this
+	// network, so every hop has to satisfy the same rule.
+	client := cleanhttp.DefaultClient()
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if req.URL.Scheme != "https" || req.URL.Host != "store.tcgplayer.com" {
+			return fmt.Errorf("refusing redirect to %s", req.URL.Redacted())
+		}
+		return nil
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, "", err
 	}

--- a/userstate/store.go
+++ b/userstate/store.go
@@ -146,11 +146,33 @@ func (c *Client) Patch(ctx context.Context, emailHash, section string, payload j
 		)
 	}
 
-	// section is validated against validSections above; safe to interpolate.
-	q := fmt.Sprintf(`
+	// The column is chosen from a fixed set rather than interpolated, so no
+	// caller value reaches the query text even by accident. section was
+	// already checked against validSections above; this makes the query a
+	// constant either way, which is what a reader - and an analyzer - can
+	// see without tracing the check.
+	var q string
+	switch section {
+	case "favorites":
+		q = updateSectionQuery("favorites")
+	case "recents":
+		q = updateSectionQuery("recents")
+	case "preferences":
+		q = updateSectionQuery("preferences")
+	default:
+		return State{}, false, fmt.Errorf("userstate: unknown section %q", section)
+	}
+	return c.writeWithConflict(ctx, q, emailHash, []byte(jsonOrEmpty(payload, defaultFor(section))), expectedVersion)
+}
+
+// updateSectionQuery returns the write-or-read CTE for one column. The column
+// name is a constant supplied by the caller's switch, never a value from
+// outside this package.
+func updateSectionQuery(column string) string {
+	return `
 		WITH upd AS (
 			UPDATE user_state
-			   SET %s = $2, version = version + 1, updated_at = now()
+			   SET ` + column + ` = $2, version = version + 1, updated_at = now()
 			 WHERE email_hash = $1 AND version = $3
 			 RETURNING version, favorites, recents, preferences
 		)
@@ -158,8 +180,7 @@ func (c *Client) Patch(ctx context.Context, emailHash, section string, payload j
 		UNION ALL
 		SELECT FALSE AS updated, version, favorites, recents, preferences
 		  FROM user_state
-		 WHERE email_hash = $1 AND NOT EXISTS (SELECT 1 FROM upd)`, section)
-	return c.writeWithConflict(ctx, q, emailHash, []byte(jsonOrEmpty(payload, defaultFor(section))), expectedVersion)
+		 WHERE email_hash = $1 AND NOT EXISTS (SELECT 1 FROM upd)`
 }
 
 func defaultFor(section string) string {

--- a/utils.go
+++ b/utils.go
@@ -994,6 +994,22 @@ func setForeverCookie(w http.ResponseWriter, cookieName, value string) {
 	setCookie(w, cookieName, value, tenYears, false)
 }
 
+// globalCookieDomain returns the domain a global cookie is written on: the
+// parent of the given hostname, which is what lets a single session span the
+// sibling mtgban.com hosts. It is empty for a hostname with no parent to climb
+// to, like localhost in dev, leaving the cookie on the host that set it.
+//
+// This is the one place that decides how wide "ours" is - isServerOrigin reads
+// the same answer to know which hosts a post-login redirect may name.
+func globalCookieDomain(hostname string) string {
+	fields := strings.Split(hostname, ".")
+	// Guard against hostname being "mtgban.com"
+	if fields[0] == "mtgban" {
+		return hostname
+	}
+	return strings.Join(fields[1:], ".")
+}
+
 // Set a cookie in the response with no expiration at the default root
 func setCookie(w http.ResponseWriter, cookieName, value string, expires time.Time, global bool) {
 	u, err := url.Parse(ServerURL)
@@ -1004,11 +1020,7 @@ func setCookie(w http.ResponseWriter, cookieName, value string, expires time.Tim
 
 	domain := u.Hostname()
 	if global {
-		fields := strings.Split(domain, ".")
-		// Guard against hostname being "mtgban.com"
-		if fields[0] != "mtgban" {
-			domain = strings.Join(fields[1:], ".")
-		}
+		domain = globalCookieDomain(domain)
 	}
 
 	cookie := http.Cookie{


### PR DESCRIPTION
I read all 13 open alerts against the actual code paths rather than fixing to
the rule name. Five are genuinely exploitable and are fixed here. The other
eight are guarded upstream in ways CodeQL cannot follow — those need dismissing
in the UI, not code churn, and I've written up why for each below.

## Fixed

**Open redirect (#49, #39, and the same hole in #47).** The `redirect`
parameter was tested by prefix — leading slash, and not two of them. A browser
reads `/\evil.com` the way it reads `//evil.com`, so the backslash walked past
the check and off the site.

I first wrote this as a `url.Parse` check and **it did not work**:
`url.Parse("/\evil.com")` reports no host, so the payload was still allowed. A
unit test caught it. The shipped version refuses anything naming a scheme or
host *and* anything whose second character opens an authority, whichever
character it uses. `arbit.html`'s store selector had the identical hole in a
regex; it now excludes the backslash too.

**SSRF past the host allowlist (#55).** `upload.go` checked scheme and host
before the request, but the client followed redirects — so
`store.tcgplayer.com` was only required for the *first* hop and could bounce the
request anywhere, including back at this network. Every hop is checked now.

**Incomplete scheme test (#52).** It named `javascript:` and so missed `data:`
and `vbscript:`. Naming them one at a time always misses one. The origin
comparison below it already refuses all of them — they parse to a null origin —
so the special case is gone and only in-page anchors skip out early.

**Path handling (#56).** `ServeFile` took whatever path it was given and read it
from the working directory; only the registered routes kept that to `css`, `img`
and `js`. Not exploitable today — Go rejects `..` and the mux is narrow — but the
constraint lived in the routing table, so a broader pattern registered later
would silently widen it to the whole directory. The handler names the allowed
roots itself now.

**SQL (#50).** The `user_state` column was interpolated after an allowlist
check. Still safe, but now it is chosen from a fixed set, so no caller value
reaches the query text on any path — visible without tracing the check.

## Not fixed — please dismiss as false positives

| # | why |
|---|---|
| #51 | `notify.Post`'s hook is `Config.DiscordHook` etc., read from the operator's config file. No request path reaches it. |
| #54 | `collectr` builds its URL as `proxyBase + "/showcase/profile/" + url.PathEscape(handle)`. The host is fixed; the user controls one escaped path segment. |
| #57, #58 | The path is `img/setsymbol/ + Config.Game`, again operator config, and the filenames come from `os.ReadDir`. |
| #48 | A server-rendered `data-image-url` assigned to `img.src`. Not HTML interpretation; a `javascript:` value in an image source does not execute. |
| #53 | `window.location = '/search?chart=' + ids.join(',')` — a fixed same-origin prefix with ids from local state. |

## Verified

`go build`, `go vet`, `go test ./...` all clean. `isLocalRedirect` has a unit
test covering both `//` and `/\` spellings, plus `https:`, `javascript:` and
`data:` targets.