### PR TITLE
charts: chart the finish, not the printing

### DIFF
--- a/chart_resolve.go
+++ b/chart_resolve.go
@@ -39,10 +39,19 @@ type chartTarget struct {
 //
 // The integer id spaces overlap — a ban_id, a TCGplayer product id, and a game's
 // own numeric id (e.g. LorcanaJSON) can all be the same number — so a bare integer
-// is resolved most-specific first: our ban_id, then the game-native id through
-// mtgmatcher (a LorcanaJSON id matches directly, a TCGplayer id via the external
-// map), then a non-Magic product in the variants table. Prefix ban: or tcg: to
-// force one interpretation.
+// is resolved in this order: the game-native id through mtgmatcher, then our
+// ban_id, then a TCGplayer product (via mtgmatcher's external map, else the
+// variants table). Prefix ban: or tcg: to force one interpretation.
+//
+// The game's own id has to win, because it is the one that travels in urls: the
+// search UI charts a card by its mtgmatcher id ("Chart the top results", the
+// sidebar's foil switch, any shared link), and a game that numbers its cards
+// (LorcanaJSON) hands us a bare integer from the same small range our ban_id
+// sequence starts in — sampling 60 Lorcana ids against the live variants table,
+// all 60 also existed as a ban_id, so those links charted an unrelated card
+// rather than failing. A ban_id only ever leaves this process carrying its ban:
+// marker, so it loses nothing by yielding. Magic is untouched either way: an
+// mtgjson uuid never parses as an integer.
 func resolveChartTarget(ctx context.Context, raw string) (*chartTarget, error) {
 	// Every resolution branch can reach the variants table (targetFromBanID,
 	// targetFromTCGID, and matcherTarget's retired-uuid fallback dereference
@@ -71,13 +80,15 @@ func resolveChartTarget(ctx context.Context, raw string) (*chartTarget, error) {
 		}
 		return targetFromTCGID(ctx, n)
 	case "", "mtgjson", "scryfall":
-		// A bare integer tries our ban_id first (the internal primary key); on a
-		// miss it falls through to the game-native / product resolution below.
+		// An integer mtgmatcher doesn't carry as a card of its own can still be
+		// our ban_id; on a miss it falls through to the product resolution below.
 		if n, err := strconv.ParseInt(val, 10, 64); err == nil {
-			if t, berr := targetFromBanID(ctx, n); berr == nil {
-				return t, nil
-			} else if !errors.Is(berr, errChartIDNotFound) {
-				return nil, berr
+			if _, gerr := mtgmatcher.GetUUID(val); gerr != nil {
+				if t, berr := targetFromBanID(ctx, n); berr == nil {
+					return t, nil
+				} else if !errors.Is(berr, errChartIDNotFound) {
+					return nil, berr
+				}
 			}
 		}
 		return matcherTarget(ctx, val)

--- a/chart_resolve.go
+++ b/chart_resolve.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -158,6 +159,12 @@ func cachedBanIDForCard(co *mtgmatcher.CardObject) int64 {
 		return banID
 	}
 	if pid, ok := tcgProductID(co); ok {
+		// One product covers every finish, so the card's own sub-type decides
+		// which variant it charts; without it a foil would read the product's
+		// canonical ("Normal") prices.
+		if subTypes, ok := PricesArchiveDB.CachedTCGSubTypeBanIDs(pid); ok {
+			return tcgBanIDForCard(co, subTypes)
+		}
 		if banID, ok := PricesArchiveDB.CachedTCGBanID(pid); ok {
 			return banID
 		}
@@ -198,11 +205,132 @@ func resolveBanIDForCard(ctx context.Context, co *mtgmatcher.CardObject) int64 {
 		return 0
 	}
 	if pid, ok := tcgProductID(co); ok {
-		if vi, ok, err := PricesArchiveDB.LookupTCGBanID(ctx, pid); err == nil && ok {
-			return vi.BanID
+		if subTypes, err := PricesArchiveDB.LookupTCGSubTypeBanIDs(ctx, pid); err == nil {
+			return tcgBanIDForCard(co, subTypes)
 		}
 	}
 	return 0
+}
+
+// tcgBanIDForCard is the ban_id of the variant carrying a card's own finish, or
+// 0 when the product has no listing for it.
+func tcgBanIDForCard(co *mtgmatcher.CardObject, subTypes map[string]int64) int64 {
+	subType := tcgSubTypeForCard(co, subTypes)
+	if subType == "" {
+		return 0
+	}
+	return subTypes[subType]
+}
+
+// TCGplayer prices one product under several sub-types, one per finish, and the
+// variants table keys a non-Magic printing on (product, sub-type) — so a
+// non-Magic card's finish lives in the sub-type, while mtgmatcher gives each
+// finish a uuid of its own. tcgSubTypeForCard and tcgFinishIDForSubType are
+// inverses that bridge the two, and both read the finish off the sub-types the
+// product is actually priced under, since the names vary by game: "Normal" is
+// the nonfoil, the first foil sub-type is the primary foil ("Foil" for
+// Riftbound, "Cold Foil" for Lorcana), and the ones after it are Lorcana's
+// extra foil sub-types, which TCGplayer calls "Holofoil" (mtgmatcher/lorcana's
+// selectFinish reads the same naming from the other direction).
+
+// foilSubTypes returns a product's foil sub-types in the order they pair with a
+// card's foil finishes: alphabetical, which puts the primary foil ("Cold Foil",
+// "Foil") ahead of the "Holofoil" the extra sub-types are sold as.
+func foilSubTypes(subTypes map[string]int64) []string {
+	foils := make([]string, 0, len(subTypes))
+	for subType := range subTypes {
+		if subType != "" && subType != "Normal" {
+			foils = append(foils, subType)
+		}
+	}
+	slices.Sort(foils)
+	return foils
+}
+
+// extraFoilFinishes returns the keys of a card's foil finishes past the primary
+// one (Lorcana's RainbowPillars and friends), ordered to match foilSubTypes.
+func extraFoilFinishes(co *mtgmatcher.CardObject) []string {
+	extras := make([]string, 0, len(co.FoilUUIDs))
+	for finish := range co.FoilUUIDs {
+		if finish != mtgmatcher.FinishNonfoil && finish != mtgmatcher.FinishFoil {
+			extras = append(extras, finish)
+		}
+	}
+	slices.Sort(extras)
+	return extras
+}
+
+// tcgSubTypeForCard names the sub-type a card's own finish is priced under.
+// Returns "" when the product carries no sub-type for that finish (a foil with
+// no foil listing yet), so the caller charts nothing rather than the wrong
+// finish's prices.
+func tcgSubTypeForCard(co *mtgmatcher.CardObject, subTypes map[string]int64) string {
+	if !co.Foil {
+		if _, ok := subTypes["Normal"]; ok {
+			return "Normal"
+		}
+		return ""
+	}
+	foils := foilSubTypes(subTypes)
+	if len(foils) == 0 {
+		return ""
+	}
+	for i, finish := range extraFoilFinishes(co) {
+		if co.FoilUUIDs[finish] != co.UUID {
+			continue
+		}
+		// An extra sub-type the product isn't priced under is not the primary
+		// foil's data in disguise, so leave it unmapped.
+		if i+1 < len(foils) {
+			return foils[i+1]
+		}
+		return ""
+	}
+	return foils[0]
+}
+
+// tcgFinishIDForSubType is the inverse: given a product's base card, the id of
+// the finish the sub-type names. An unknown sub-type resolves to the primary
+// foil, since "Normal" is the only nonfoil name.
+func tcgFinishIDForSubType(co *mtgmatcher.CardObject, subTypes map[string]int64, subType string) string {
+	if subType == "" || subType == "Normal" {
+		if id, ok := co.FoilUUIDs[mtgmatcher.FinishNonfoil]; ok {
+			return id
+		}
+		return co.UUID
+	}
+	if idx := slices.Index(foilSubTypes(subTypes), subType); idx > 0 {
+		if extras := extraFoilFinishes(co); idx-1 < len(extras) {
+			return co.FoilUUIDs[extras[idx-1]]
+		}
+	}
+	if id, ok := co.FoilUUIDs[mtgmatcher.FinishFoil]; ok {
+		return id
+	}
+	if id, err := mtgmatcher.MatchId(co.UUID, true); err == nil {
+		return id
+	}
+	return co.UUID
+}
+
+// tcgVariantSearchID maps a non-Magic variant to the mtgmatcher id of the card
+// and finish it names, for the results table the chart lives inside. ok=false
+// when mtgmatcher doesn't know the product (a game it doesn't carry, or a
+// product with no card).
+func tcgVariantSearchID(ctx context.Context, vi timeseries.VariantInfo) (string, bool) {
+	matched, err := mtgmatcher.MatchId(strconv.Itoa(vi.TCGProductID))
+	if err != nil {
+		return "", false
+	}
+	co, err := mtgmatcher.GetUUID(matched)
+	if err != nil {
+		return matched, true
+	}
+	subTypes, ok := PricesArchiveDB.CachedTCGSubTypeBanIDs(vi.TCGProductID)
+	if !ok {
+		subTypes, _ = PricesArchiveDB.LookupTCGSubTypeBanIDs(ctx, vi.TCGProductID)
+	}
+	return tcgFinishIDForSubType(co, subTypes, vi.TCGSubType), true
 }
 
 // tcgProductID extracts a card's TCGplayer product id from its identifiers.

--- a/chart_resolve_test.go
+++ b/chart_resolve_test.go
@@ -24,6 +24,103 @@ func TestSplitIDPrefix(t *testing.T) {
 	}
 }
 
+// The finish shapes below are the ones Lorcana actually ships, paired with the
+// sub-types tcgcsv prices those products under: a plain foil sold as "Cold
+// Foil", one sold as "Holofoil" (LorcanaJSON's FreeForm1 printings), a card
+// with an extra foil sub-type on top of both, a foil-only card, and a card
+// whose foil has no listing yet.
+var tcgFinishCases = []struct {
+	name     string
+	subTypes []string          // what the product is priced under
+	finishes map[string]string // mtgmatcher finish -> uuid
+	want     map[string]string // uuid -> sub-type ("" = no data for that finish)
+}{
+	{
+		name:     "primary foil sold as cold foil",
+		subTypes: []string{"Normal", "Cold Foil"},
+		finishes: map[string]string{"nonfoil": "2790", "foil": "2790_f"},
+		want:     map[string]string{"2790": "Normal", "2790_f": "Cold Foil"},
+	},
+	{
+		name:     "primary foil sold as holofoil",
+		subTypes: []string{"Normal", "Holofoil"},
+		finishes: map[string]string{"nonfoil": "2206", "foil": "2206_f"},
+		want:     map[string]string{"2206": "Normal", "2206_f": "Holofoil"},
+	},
+	{
+		name:     "extra foil sub-type",
+		subTypes: []string{"Normal", "Cold Foil", "Holofoil"},
+		finishes: map[string]string{"nonfoil": "2800", "foil": "2800_f", "rainbowpillars": "2800_rainbowpillars"},
+		want:     map[string]string{"2800": "Normal", "2800_f": "Cold Foil", "2800_rainbowpillars": "Holofoil"},
+	},
+	{
+		name:     "foil-only card",
+		subTypes: []string{"Holofoil"},
+		finishes: map[string]string{"foil": "2937"},
+		want:     map[string]string{"2937": "Holofoil"},
+	},
+	{
+		name:     "foil not priced yet",
+		subTypes: []string{"Normal"},
+		finishes: map[string]string{"nonfoil": "2900", "foil": "2900_f"},
+		want:     map[string]string{"2900": "Normal", "2900_f": ""},
+	},
+	{
+		name:     "single foil sub-type, as riftbound names it",
+		subTypes: []string{"Normal", "Foil"},
+		finishes: map[string]string{"nonfoil": "abc_nonfoil", "foil": "abc_foil"},
+		want:     map[string]string{"abc_nonfoil": "Normal", "abc_foil": "Foil"},
+	},
+}
+
+// A non-Magic product is priced per finish under a sub-type, so a card's finish
+// has to pick its own variant — otherwise every finish charts the product's
+// canonical ("Normal") prices (issue #295).
+func TestTCGSubTypeForCard(t *testing.T) {
+	for _, tc := range tcgFinishCases {
+		subTypes := map[string]int64{}
+		for i, subType := range tc.subTypes {
+			subTypes[subType] = int64(i + 1)
+		}
+		for finish, uuid := range tc.finishes {
+			co := &mtgmatcher.CardObject{
+				Card: mtgmatcher.Card{UUID: uuid, FoilUUIDs: tc.finishes},
+				Foil: finish != "nonfoil",
+			}
+			if got := tcgSubTypeForCard(co, subTypes); got != tc.want[uuid] {
+				t.Errorf("%s: tcgSubTypeForCard(%s) = %q, want %q", tc.name, finish, got, tc.want[uuid])
+			}
+		}
+	}
+}
+
+// And back: charting a variant has to land on the card row of the finish its
+// sub-type names, not on the product's base printing.
+func TestTCGFinishIDForSubType(t *testing.T) {
+	for _, tc := range tcgFinishCases {
+		subTypes := map[string]int64{}
+		for i, subType := range tc.subTypes {
+			subTypes[subType] = int64(i + 1)
+		}
+		// The card mtgmatcher resolves a bare product id to, as the callers get it.
+		base := tc.finishes["nonfoil"]
+		if base == "" {
+			base = tc.finishes["foil"]
+		}
+		co := &mtgmatcher.CardObject{
+			Card: mtgmatcher.Card{UUID: base, FoilUUIDs: tc.finishes},
+		}
+		for uuid, subType := range tc.want {
+			if subType == "" {
+				continue // no variant to chart
+			}
+			if got := tcgFinishIDForSubType(co, subTypes, subType); got != uuid {
+				t.Errorf("%s: tcgFinishIDForSubType(%q) = %q, want %q", tc.name, subType, got, uuid)
+			}
+		}
+	}
+}
+
 // A ban_id names one finish, but the variants table stores the finish next to
 // the base uuid, so handing that uuid straight to the search used to render the
 // nonfoil row for a foil chart (issue #295).

--- a/chart_resolve_test.go
+++ b/chart_resolve_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/mtgban/go-mtgban/mtgmatcher"
+)
 
 func TestSplitIDPrefix(t *testing.T) {
 	cases := []struct{ in, prefix, val string }{
@@ -17,5 +21,41 @@ func TestSplitIDPrefix(t *testing.T) {
 		if p != tc.prefix || v != tc.val {
 			t.Errorf("splitIDPrefix(%q) = (%q, %q), want (%q, %q)", tc.in, p, v, tc.prefix, tc.val)
 		}
+	}
+}
+
+// A ban_id names one finish, but the variants table stores the finish next to
+// the base uuid, so handing that uuid straight to the search used to render the
+// nonfoil row for a foil chart (issue #295).
+func TestMagicFinishSearchID(t *testing.T) {
+	if !datastoreLoaded() {
+		t.Skip("mtgmatcher datastore not loaded")
+	}
+
+	// Any printing that carries both finishes will do.
+	var uuid, foilId string
+	for _, id := range mtgmatcher.GetUUIDs() {
+		co, err := mtgmatcher.GetUUID(id)
+		if err != nil || co.Sealed || co.Foil || co.Etched {
+			continue
+		}
+		alt, err := mtgmatcher.MatchId(id, true)
+		if err != nil || alt == id {
+			continue
+		}
+		if altCo, err := mtgmatcher.GetUUID(alt); err == nil && altCo.Foil {
+			uuid, foilId = id, alt
+			break
+		}
+	}
+	if uuid == "" {
+		t.Skip("no card with both a foil and a nonfoil printing")
+	}
+
+	if got := magicFinishSearchID(uuid, true, false); got != foilId {
+		t.Errorf("magicFinishSearchID(%q, foil) = %q, want %q", uuid, got, foilId)
+	}
+	if got := magicFinishSearchID(uuid, false, false); got != uuid {
+		t.Errorf("magicFinishSearchID(%q, nonfoil) = %q, want %q", uuid, got, uuid)
 	}
 }

--- a/search.go
+++ b/search.go
@@ -127,7 +127,9 @@ func chartIDToSearchID(ctx context.Context, id string) string {
 	}
 	prefix, val := splitIDPrefix(id)
 
-	// ban: or a bare integer — our ban_id first, matching the chart resolver.
+	// ban: or a bare integer — our ban_id, on the chart resolver's precedence: a
+	// game-native id returned above already, and Lorcana numbers its cards, so an
+	// integer reaching here is not one of those.
 	if (prefix == "ban" || prefix == "") && PricesArchiveDB != nil {
 		if n, perr := strconv.ParseInt(val, 10, 64); perr == nil {
 			if vi, ok, _ := PricesArchiveDB.LookupVariant(ctx, n); ok {

--- a/search.go
+++ b/search.go
@@ -103,11 +103,24 @@ func isValidChartID(part string) bool {
 	return err == nil
 }
 
+// magicFinishSearchID re-tags an mtgjson uuid with the finish of the variant it
+// came from. The variants table stores the finish beside the base uuid, while
+// mtgmatcher gives each finish its own id ("_f", "_e"), so handing the bare uuid
+// back to the search always lands on the nonfoil printing. Falls back to the
+// uuid when the finish has no id of its own.
+func magicFinishSearchID(uuid string, foil, etched bool) string {
+	if matched, err := mtgmatcher.MatchId(uuid, foil, etched); err == nil {
+		return matched
+	}
+	return uuid
+}
+
 // chartIDToSearchID maps a chart-roster id to an id the results table (which the
 // embedded chart lives inside) can resolve to a card row, mirroring
 // resolveChartTarget's precedence so anything chartable also renders its row.
-// Magic resolves to an mtgjson uuid; non-Magic games (Lorcana, ...) to their
-// mtgmatcher-native id via the TCGplayer external id map.
+// Magic resolves to the mtgmatcher id of the variant's own finish; non-Magic
+// games (Lorcana, ...) to their mtgmatcher-native id via the TCGplayer external
+// id map.
 func chartIDToSearchID(ctx context.Context, id string) string {
 	if _, err := mtgmatcher.GetUUID(id); err == nil {
 		return id // already a matcher id (bare uuid / variant string)
@@ -119,7 +132,8 @@ func chartIDToSearchID(ctx context.Context, id string) string {
 		if n, perr := strconv.ParseInt(val, 10, 64); perr == nil {
 			if vi, ok, _ := PricesArchiveDB.LookupVariant(ctx, n); ok {
 				if vi.MtgjsonUUID != "" {
-					return vi.MtgjsonUUID // Magic: the mtgjson uuid
+					// Magic: the uuid, kept on the finish the ban_id names.
+					return magicFinishSearchID(vi.MtgjsonUUID, vi.IsFoil, vi.IsEtched)
 				}
 				// Non-Magic: the product id maps back to the game's own card id.
 				if matched, merr := mtgmatcher.MatchId(strconv.Itoa(vi.TCGProductID)); merr == nil {
@@ -930,23 +944,26 @@ func Search(w http.ResponseWriter, r *http.Request) {
 
 		// Sidebar foil/etched switch and Stocks link are inherently per-card,
 		// and sealed products have no foil/etched variants, so leave them empty
-		// and let the sidebar's self-checks hide them.
+		// and let the sidebar's self-checks hide them. The switches key off the
+		// resolved mtgmatcher id, since a ban:<id> roster entry means nothing to
+		// the matcher.
 		if !isMultiChart {
-			co, gerr := mtgmatcher.GetUUID(chartId)
+			searchId := chartSearchIDs[chartId]
+			co, gerr := mtgmatcher.GetUUID(searchId)
 			if gerr == nil && !co.Sealed {
 				altId, err := mtgmatcher.Match(&mtgmatcher.InputCard{
-					Id:   chartId,
+					Id:   searchId,
 					Foil: !co.Foil,
 				})
-				if err == nil && altId != chartId {
+				if err == nil && altId != searchId {
 					pageVars.Alternative = altId
 				}
 
 				altId, err = mtgmatcher.Match(&mtgmatcher.InputCard{
-					Id:        chartId,
+					Id:        searchId,
 					Variation: "Etched",
 				})
-				if err == nil && altId != chartId {
+				if err == nil && altId != searchId {
 					pageVars.AltEtchedId = altId
 				}
 

--- a/search.go
+++ b/search.go
@@ -135,8 +135,9 @@ func chartIDToSearchID(ctx context.Context, id string) string {
 					// Magic: the uuid, kept on the finish the ban_id names.
 					return magicFinishSearchID(vi.MtgjsonUUID, vi.IsFoil, vi.IsEtched)
 				}
-				// Non-Magic: the product id maps back to the game's own card id.
-				if matched, merr := mtgmatcher.MatchId(strconv.Itoa(vi.TCGProductID)); merr == nil {
+				// Non-Magic: the product id maps back to the game's own card id,
+				// on the finish the variant's sub-type names.
+				if matched, ok := tcgVariantSearchID(ctx, vi); ok {
 					return matched
 				}
 				return id

--- a/timeseries/prices_long_live_test.go
+++ b/timeseries/prices_long_live_test.go
@@ -163,5 +163,22 @@ func TestLongFormLive(t *testing.T) {
 	if tcgBan2, err := c.ResolveTCGBanID(ctx, TCGVariant{CategoryID: liveSentinelCatLong, ProductID: liveSentinelProdLong, SubType: "Normal"}); err != nil || tcgBan2 != tcgBan {
 		t.Fatalf("tcg resolve not idempotent: %d vs %d err=%v", tcgBan, tcgBan2, err)
 	}
+
+	// A second sub-type on the same product: the finishes a non-Magic card is
+	// charted by, which the read path has to tell apart.
+	foilBan, err := c.ResolveTCGBanID(ctx, TCGVariant{CategoryID: liveSentinelCatLong, ProductID: liveSentinelProdLong, SubType: "Cold Foil"})
+	if err != nil {
+		t.Fatalf("ResolveTCGBanID (foil): %v", err)
+	}
+	if foilBan == tcgBan {
+		t.Fatalf("sub-types share a ban_id: %d", foilBan)
+	}
+	subTypes, err := c.LookupTCGSubTypeBanIDs(ctx, liveSentinelProdLong)
+	if err != nil {
+		t.Fatalf("LookupTCGSubTypeBanIDs: %v", err)
+	}
+	if subTypes["Normal"] != tcgBan || subTypes["Cold Foil"] != foilBan {
+		t.Errorf("LookupTCGSubTypeBanIDs = %+v, want Normal=%d Cold Foil=%d", subTypes, tcgBan, foilBan)
+	}
 	_ = banJa
 }

--- a/timeseries/variants.go
+++ b/timeseries/variants.go
@@ -65,6 +65,14 @@ type variantCache struct {
 	// of magic's uuid-keyed lookup, with no per-card DB round-trip. Mirrors
 	// LookupTCGBanID's precedence.
 	tcgByProduct sync.Map // int (product id) -> int64
+	// tcgSubTypesByProduct maps a TCGplayer product id to every sub-type it is
+	// priced under and that sub-type's ban_id. One product covers all of a card's
+	// finishes (Lorcana's "Normal" / "Cold Foil" / "Holofoil", Riftbound's
+	// "Normal" / "Foil"), so a caller that knows which finish it is rendering
+	// needs the whole set to pick its own row instead of the canonical one.
+	// Warm-time only, like tcgByProduct: the maps are built once and never
+	// mutated, so readers can use them without copying.
+	tcgSubTypesByProduct sync.Map // int (product id) -> map[string]int64
 }
 
 // WarmVariantCache bulk-loads every existing variant into the in-memory cache in
@@ -88,6 +96,7 @@ func (c *Client) WarmVariantCache(ctx context.Context) error {
 		normal bool
 	}
 	byProduct := map[int]tcgBest{}
+	subTypesByProduct := map[int]map[string]int64{}
 
 	var loadedMagic, loadedTCG int
 	for rows.Next() {
@@ -121,6 +130,14 @@ func (c *Client) WarmVariantCache(ctx context.Context) error {
 				(isNormal == cur.normal && banID < cur.banID) {
 				byProduct[pid] = tcgBest{banID: banID, normal: isNormal}
 			}
+			if subTypesByProduct[pid] == nil {
+				subTypesByProduct[pid] = map[string]int64{}
+			}
+			// A duplicate sub-type can only come from a second category filing
+			// the same product id; keep the smaller ban_id, as above.
+			if cur, ok := subTypesByProduct[pid][subType.String]; !ok || banID < cur {
+				subTypesByProduct[pid][subType.String] = banID
+			}
 		}
 	}
 	if err := rows.Err(); err != nil {
@@ -128,6 +145,9 @@ func (c *Client) WarmVariantCache(ctx context.Context) error {
 	}
 	for pid, best := range byProduct {
 		c.variants.tcgByProduct.Store(pid, best.banID)
+	}
+	for pid, subTypes := range subTypesByProduct {
+		c.variants.tcgSubTypesByProduct.Store(pid, subTypes)
 	}
 	return nil
 }
@@ -143,6 +163,47 @@ func (c *Client) CachedTCGBanID(productID int) (int64, bool) {
 		return id.(int64), true
 	}
 	return 0, false
+}
+
+// CachedTCGSubTypeBanIDs returns every sub-type a product is priced under and
+// that sub-type's ban_id, from the in-memory cache. A card's finish is not in
+// the variants row itself — it is the sub-type — so this is what lets a caller
+// chart the foil printing instead of the product's canonical (usually "Normal")
+// one. The returned map is shared and must not be modified. A miss (new product,
+// unwarmed cache) returns ok=false.
+func (c *Client) CachedTCGSubTypeBanIDs(productID int) (map[string]int64, bool) {
+	if m, ok := c.variants.tcgSubTypesByProduct.Load(productID); ok {
+		return m.(map[string]int64), true
+	}
+	return nil, false
+}
+
+// LookupTCGSubTypeBanIDs is CachedTCGSubTypeBanIDs against the DB, for the
+// single-card paths where a round-trip is affordable and a cold cache (or a
+// product ingested since warm-up) should still chart the right finish.
+func (c *Client) LookupTCGSubTypeBanIDs(ctx context.Context, productID int) (map[string]int64, error) {
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT ban_id, tcgp_sub_type FROM variants
+		 WHERE tcgp_product_id=$1 ORDER BY ban_id ASC`, productID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	subTypes := map[string]int64{}
+	for rows.Next() {
+		var banID int64
+		var subType sql.NullString
+		if err := rows.Scan(&banID, &subType); err != nil {
+			return nil, err
+		}
+		// Ascending ban_id, so the first row of a sub-type duplicated across
+		// categories wins, matching the warm cache.
+		if _, ok := subTypes[subType.String]; !ok {
+			subTypes[subType.String] = banID
+		}
+	}
+	return subTypes, rows.Err()
 }
 
 // ResolveMagicBanID returns the ban_id for a Magic variant, minting it if new.


### PR DESCRIPTION
Fixes #295. A chart link carried the card but not its finish, so a foil charted as a nonfoil. That went wrong in two different places, one per commit.

**Magic** (`search: keep a chart id's finish when it becomes a query`) — the variants table stores a printing as its mtgjson uuid beside `is_foil`/`is_etched`, while mtgmatcher gives each finish its own id (`_f`, `_e`). Turning a `ban:<id>` back into a query handed over the bare uuid, so the chart page rebuilt itself around the nonfoil: `f:nonfoil` query, nonfoil row, nonfoil metadata. The chart line itself was right — it reads by ban_id — which is why this looked like a display quirk. The sidebar's foil/etched switch is in the same commit: it had been asking mtgmatcher about a `ban:<id>` and getting nothing, which took the switch off every chart page.

**Lorcana and the other non-Magic games** (`charts: chart the finish a non-Magic card is sold as`) — worse, and the reason this is more than a display fix. A non-Magic printing has no uuid, so the variants table keys it on `(product, sub_type)`, and one TCGplayer product covers every finish of the card. The read path resolved a rendered card to the product's *canonical* variant, so every finish charted the "Normal" prices — foil and nonfoil plotted the same line.

The awkward part is that which sub-type is the foil varies by game and by card:

| card's finishes | TCGplayer sub-types |
|---|---|
| None + Silver | Normal + **Cold Foil** |
| None + FreeForm1 | Normal + **Holofoil** |
| None + Silver + RainbowPillars | Normal + Cold Foil + Holofoil |
| Satin only (enchanted) | Holofoil only |
| Riftbound | Normal + Foil |

So the pairing reads the sub-types a product is actually priced under instead of matching on a name: "Normal" is the nonfoil, and the foil sub-types line up in order with the card's foil finishes — the same naming `mtgmatcher/lorcana`'s `selectFinish` reads from the other side. A finish the product has no sub-type for now charts nothing rather than another finish's prices.

## Verification

Ran a local Lorcana instance against the prices DB (read-only), with the pre-fix binary beside it. `Buzz Lightyear - On the Way`:

| row | before | after |
|---|---|---|
| `2800` (nonfoil) | ban:289106 | ban:289106 |
| `2800_f` (Cold Foil) | ban:289106 | ban:229689 |
| `2800_rainbowpillars` (Holofoil) | ban:289106 | ban:297339 |

and those three now plot different series (TCG Market last points 3.63 / 5.69 / 20). Before, opening a foil ban_id directly rendered `row=2800`, `f:nonfoil`, and a chart link back to the nonfoil. Also checked `Ariel - Ethereal Voice`, the FreeForm1 card whose primary foil is sold as "Holofoil" — a hardcoded "foil means Cold Foil" would have missed it.

Unit tests cover the finish/sub-type pairing in both directions for every shape in the table above (no datastore needed); the live test covers the new query when `TCGLIVE_HOST` is set.

## Bare ids (`charts: let a game's own card id outrank our ban_id`)

Added after review. A bare integer in `?chart=` tried our ban_id first, and Lorcana numbers its cards, so a Lorcana id landed on whatever variant held that ban_id. Sampling 60 Lorcana card ids against the live variants table, **all 60** also existed as a ban_id — every one a Magic printing, since the low ban_ids came from the Magic backfill. On a Lorcana instance `?chart=1` charted a Magic card under "Ariel - On Human Legs".

Those ids reach the URL through the UI, not only by hand: "Chart the top results" links `AllKeys`, the sidebar's foil switch links `Alternative`, and both are raw mtgmatcher ids — a bare integer for a nonfoil Lorcana card (a foil carries `_f`/`_rainbowpillars` and was never ambiguous). `chartIDForCard` also falls back to the raw id whenever the ban_id isn't cached yet.

A bare integer now asks mtgmatcher first and only tries the ban_id when the game carries no card under that id. `ban:` still forces the ban_id reading, and a bare ban_id keeps working when it isn't also a card id, so "ban: is optional" survives for Magic (uuids never parse as integers). `chartIDToSearchID` already resolved matcher ids first, so the results row and the chart line now agree.

Verified against the prices DB with the Lorcana datastore loaded:

| `?chart=` | before | after |
|---|---|---|
| `1` (Ariel - On Human Legs) | ban:1, a Magic uuid | ban:265640 |
| `2` (Ariel - Spectacular Singer) | ban:2, a Magic uuid | ban:325125 |
| `ban:1` | ban:1 | ban:1 (forcing still works) |
| `289106` (a ban_id, no Lorcana card) | ban:289106 | ban:289106 |
| `2800` / `2800_f` / `2800_rainbowpillars` | — | 289106 / 229689 / 297339 |

No unit test: the ordering only differs when mtgmatcher holds a game that numbers its cards, which needs a Lorcana datastore *and* the variants table, neither of which the test suite has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013KxchJxCZBRuXuafjhtRam
