### PR TITLE
tcgcsvd and chart finish resolution: the five review follow-ups

### DIFF
--- a/chart_resolve.go
+++ b/chart_resolve.go
@@ -301,8 +301,9 @@ func tcgSubTypeForCard(co *mtgmatcher.CardObject, subTypes map[string]int64) str
 }
 
 // tcgFinishIDForSubType is the inverse: given a product's base card, the id of
-// the finish the sub-type names. An unknown sub-type resolves to the primary
-// foil, since "Normal" is the only nonfoil name.
+// the finish the sub-type names, or "" when the card carries no finish for it.
+// A sub-type the product doesn't list resolves to the primary foil, since
+// "Normal" is the only nonfoil name.
 func tcgFinishIDForSubType(co *mtgmatcher.CardObject, subTypes map[string]int64, subType string) string {
 	if subType == "" || subType == "Normal" {
 		if id, ok := co.FoilUUIDs[mtgmatcher.FinishNonfoil]; ok {
@@ -311,9 +312,16 @@ func tcgFinishIDForSubType(co *mtgmatcher.CardObject, subTypes map[string]int64,
 		return co.UUID
 	}
 	if idx := slices.Index(foilSubTypes(subTypes), subType); idx > 0 {
-		if extras := extraFoilFinishes(co); idx-1 < len(extras) {
-			return co.FoilUUIDs[extras[idx-1]]
+		extras := extraFoilFinishes(co)
+		if idx-1 >= len(extras) {
+			// The mirror of tcgSubTypeForCard's refusal to map an extra
+			// sub-type onto the primary foil: a product priced under one more
+			// foil than the card has finishes would otherwise hand both
+			// sub-types the same id, and a roster holding both would render
+			// two rows for one printing.
+			return ""
 		}
+		return co.FoilUUIDs[extras[idx-1]]
 	}
 	if id, ok := co.FoilUUIDs[mtgmatcher.FinishFoil]; ok {
 		return id
@@ -327,7 +335,8 @@ func tcgFinishIDForSubType(co *mtgmatcher.CardObject, subTypes map[string]int64,
 // tcgVariantSearchID maps a non-Magic variant to the mtgmatcher id of the card
 // and finish it names, for the results table the chart lives inside. ok=false
 // when mtgmatcher doesn't know the product (a game it doesn't carry, or a
-// product with no card).
+// product with no card), or when the card has no finish for the variant's
+// sub-type — charting the wrong finish is worse than charting nothing.
 func tcgVariantSearchID(ctx context.Context, vi timeseries.VariantInfo) (string, bool) {
 	matched, err := mtgmatcher.MatchId(strconv.Itoa(vi.TCGProductID))
 	if err != nil {
@@ -341,7 +350,11 @@ func tcgVariantSearchID(ctx context.Context, vi timeseries.VariantInfo) (string,
 	if !ok {
 		subTypes, _ = PricesArchiveDB.LookupTCGSubTypeBanIDs(ctx, vi.TCGProductID)
 	}
-	return tcgFinishIDForSubType(co, subTypes, vi.TCGSubType), true
+	id := tcgFinishIDForSubType(co, subTypes, vi.TCGSubType)
+	if id == "" {
+		return "", false
+	}
+	return id, true
 }
 
 // tcgProductID extracts a card's TCGplayer product id from its identifiers.

--- a/chart_resolve.go
+++ b/chart_resolve.go
@@ -247,6 +247,15 @@ func tcgBanIDForCard(co *mtgmatcher.CardObject, subTypes map[string]int64) int64
 // foilSubTypes returns a product's foil sub-types in the order they pair with a
 // card's foil finishes: alphabetical, which puts the primary foil ("Cold Foil",
 // "Foil") ahead of the "Holofoil" the extra sub-types are sold as.
+//
+// The pairing is positional over this list and the sorted one extraFoilFinishes
+// returns, so it rests on an invariant nothing in the data enforces: on a
+// product priced under more than one foil, the primary foil's name sorts before
+// the extras'. It holds for every name in use, but that is a naming coincidence
+// carrying structural weight — a new foil sub-type sorting ahead of "Cold Foil"
+// would re-pair every finish on its product. TestFoilSubTypeOrdering pins the
+// names we know, so a new one gets added there and the order gets checked
+// rather than assumed.
 func foilSubTypes(subTypes map[string]int64) []string {
 	foils := make([]string, 0, len(subTypes))
 	for subType := range subTypes {
@@ -260,6 +269,9 @@ func foilSubTypes(subTypes map[string]int64) []string {
 
 // extraFoilFinishes returns the keys of a card's foil finishes past the primary
 // one (Lorcana's RainbowPillars and friends), ordered to match foilSubTypes.
+// Sorted, so with more than one extra the pairing would also depend on the
+// finish keys sorting into the same order as the sub-type names; today no
+// product carries a second extra, so the ordering above is the live constraint.
 func extraFoilFinishes(co *mtgmatcher.CardObject) []string {
 	extras := make([]string, 0, len(co.FoilUUIDs))
 	for finish := range co.FoilUUIDs {

--- a/chart_resolve_test.go
+++ b/chart_resolve_test.go
@@ -85,6 +85,25 @@ var tcgFinishCases = []struct {
 	},
 }
 
+// foilSubTypes and extraFoilFinishes pair positionally over two sorted lists,
+// so the mapping is only right while the primary foil's sub-type sorts before
+// the extras' on the same product. That is a property of the names, not of the
+// data, and a name breaking it would re-pair a product's finishes with nothing
+// else failing. These are the names TCGplayer prices our games under; a new one
+// belongs here, where the order is checked.
+func TestFoilSubTypeOrdering(t *testing.T) {
+	primaries := []string{"Cold Foil", "Foil"} // Lorcana, Riftbound
+	extras := []string{"Holofoil"}             // what Lorcana's extra foils are sold as
+	for _, primary := range primaries {
+		for _, extra := range extras {
+			if primary >= extra {
+				t.Errorf("primary foil sub-type %q does not sort before extra sub-type %q; "+
+					"the positional pairing in foilSubTypes would swap them", primary, extra)
+			}
+		}
+	}
+}
+
 // A non-Magic product is priced per finish under a sub-type, so a card's finish
 // has to pick its own variant — otherwise every finish charts the product's
 // canonical ("Normal") prices (issue #295).

--- a/chart_resolve_test.go
+++ b/chart_resolve_test.go
@@ -34,6 +34,7 @@ var tcgFinishCases = []struct {
 	subTypes []string          // what the product is priced under
 	finishes map[string]string // mtgmatcher finish -> uuid
 	want     map[string]string // uuid -> sub-type ("" = no data for that finish)
+	unmapped []string          // sub-types the card has no finish for
 }{
 	{
 		name:     "primary foil sold as cold foil",
@@ -52,6 +53,17 @@ var tcgFinishCases = []struct {
 		subTypes: []string{"Normal", "Cold Foil", "Holofoil"},
 		finishes: map[string]string{"nonfoil": "2800", "foil": "2800_f", "rainbowpillars": "2800_rainbowpillars"},
 		want:     map[string]string{"2800": "Normal", "2800_f": "Cold Foil", "2800_rainbowpillars": "Holofoil"},
+	},
+	{
+		// The product is priced under one more foil than the card has finishes,
+		// so nothing maps to "Holofoil" in either direction. Mapping it onto the
+		// plain foil would give a roster carrying both variants two rows for the
+		// same printing.
+		name:     "extra sub-type the card has no finish for",
+		subTypes: []string{"Normal", "Cold Foil", "Holofoil"},
+		finishes: map[string]string{"nonfoil": "2810", "foil": "2810_f"},
+		want:     map[string]string{"2810": "Normal", "2810_f": "Cold Foil"},
+		unmapped: []string{"Holofoil"},
 	},
 	{
 		name:     "foil-only card",
@@ -116,6 +128,13 @@ func TestTCGFinishIDForSubType(t *testing.T) {
 			}
 			if got := tcgFinishIDForSubType(co, subTypes, subType); got != uuid {
 				t.Errorf("%s: tcgFinishIDForSubType(%q) = %q, want %q", tc.name, subType, got, uuid)
+			}
+		}
+		// And the other half of the symmetry: a sub-type the card has no finish
+		// for maps to nothing, rather than landing on the primary foil.
+		for _, subType := range tc.unmapped {
+			if got := tcgFinishIDForSubType(co, subTypes, subType); got != "" {
+				t.Errorf("%s: tcgFinishIDForSubType(%q) = %q, want no id", tc.name, subType, got)
 			}
 		}
 	}

--- a/cmd/tcgcsvd/main.go
+++ b/cmd/tcgcsvd/main.go
@@ -167,9 +167,9 @@ func main() {
 		// Under the crawl lock, so a server whose crons are still armed and this
 		// process never crawl tcgcsv.com at the same time. A skipped run (the
 		// other process holds the lock) is logged and exits 0.
-		err = svc.WithCrawlLock("tcgcsvd -daily", func() error { return svc.IngestLatest(ctx) })
+		err = svc.WithCrawlLock(ctx, "tcgcsvd -daily", func() error { return svc.IngestLatest(ctx) })
 	case *products:
-		err = svc.WithCrawlLock("tcgcsvd -products", func() error { return svc.SyncProducts(ctx) })
+		err = svc.WithCrawlLock(ctx, "tcgcsvd -products", func() error { return svc.SyncProducts(ctx) })
 	case *backfill:
 		// Outside the lock on purpose: hours of archives under a session
 		// advisory lock would block every daily ingest for the whole run.

--- a/cmd/tcgcsvd/main.go
+++ b/cmd/tcgcsvd/main.go
@@ -1,9 +1,13 @@
 // Command tcgcsvd runs the tcgcsv ingestion jobs on their own, without the web
 // server: the daily price pull, the weekly product catalog sync, and the
 // historical backfill. It reads the same config.json the server does, uses only
-// the sql_config and tcgcsv_config sections of it, and takes the same
-// cross-process crawl lock, so it can run beside a server that still has its
-// crons enabled without both crawling tcgcsv.com at once.
+// the sql_config and tcgcsv_config sections of it, and runs the two scheduled
+// jobs under the same cross-process crawl lock, so it can run beside a server
+// that still has its crons enabled without both crawling tcgcsv.com at once.
+// The backfill stays outside that lock, as it does everywhere else: it is
+// operator-driven and runs for hours, and holding the lock for that long would
+// starve the daily pull. Time a long backfill so it doesn't sit on top of a
+// server's 21:00 ingest.
 //
 //	go install github.com/mtgban/mtgban-website/cmd/tcgcsvd@latest
 //
@@ -167,6 +171,8 @@ func main() {
 	case *products:
 		err = svc.WithCrawlLock("tcgcsvd -products", func() error { return svc.SyncProducts(ctx) })
 	case *backfill:
+		// Outside the lock on purpose: hours of archives under a session
+		// advisory lock would block every daily ingest for the whole run.
 		err = svc.Backfill(ctx, tcgcsvd.BackfillOptions{
 			From: *from, To: *to, Categories: *categories, Force: *force,
 		})

--- a/main.go
+++ b/main.go
@@ -1101,6 +1101,7 @@ func main() {
 		if err := initTCGCSVService(); err != nil {
 			log.Fatalln("tcgcsv:", err)
 		}
+		var err error
 		switch {
 		case *tcgcsvBackfill:
 			err = TCGCSVService.Backfill(context.Background(), tcgcsvd.BackfillOptions{

--- a/main.go
+++ b/main.go
@@ -601,6 +601,13 @@ func loadTime(p *time.Time) time.Time {
 	return *p
 }
 
+// ServerContext lives as long as this process serves and is cancelled when the
+// shutdown signal arrives, at the same moment the HTTP server starts draining.
+// Background work that belongs to the process rather than to a request — the
+// crons, the admin buttons that hand a job to a goroutine — runs under it, so a
+// stop reaches a job that is mid-crawl instead of only reaching the listener.
+var ServerContext, stopServerContext = context.WithCancel(context.Background())
+
 var NewNewspaperDB *sql.DB
 
 var PricesArchiveDB *timeseries.Client
@@ -1345,6 +1352,10 @@ func main() {
 	}()
 
 	<-done
+
+	// Wind down the background jobs alongside the listener: an ingest that is
+	// mid-crawl stops at its next checkpoint instead of running into the exit.
+	stopServerContext()
 
 	// Close any zombie connection and perform any extra cleanup
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/tcgcsv_service.go
+++ b/tcgcsv_service.go
@@ -49,12 +49,17 @@ func IsTCGCSVStashing() bool {
 // stashTCGCSVPrices and stashTCGCSVProducts are the cron and admin entry
 // points. They are registered only when the service exists, and stay nil-safe
 // so an admin button on an unconfigured deployment logs instead of panicking.
+//
+// Both run under ServerContext rather than a request's: the admin button starts
+// the ingest in a goroutine that outlives the request that pressed it, and a
+// cron fire has no request at all. What they must not outlive is the process,
+// hence not context.Background().
 func stashTCGCSVPrices() {
 	if TCGCSVService == nil {
 		log.Println("stashTCGCSVPrices: tcgcsv ingestion is not configured")
 		return
 	}
-	TCGCSVService.StashPrices()
+	TCGCSVService.StashPrices(ServerContext)
 }
 
 func stashTCGCSVProducts() {
@@ -62,7 +67,7 @@ func stashTCGCSVProducts() {
 		log.Println("stashTCGCSVProducts: tcgcsv ingestion is not configured")
 		return
 	}
-	TCGCSVService.StashProducts()
+	TCGCSVService.StashProducts(ServerContext)
 }
 
 // logTCGProductMatchReport reports how many synced products resolve to a loaded

--- a/tcgcsvd/prices.go
+++ b/tcgcsvd/prices.go
@@ -233,15 +233,19 @@ func (s *Service) IsStashingPrices() bool { return s.pricesStashing.Load() }
 // tcg_prices. It is the cron/admin entry point: only one run proceeds at a time
 // per process, only the process holding the crawl lock crawls, and it no-ops
 // when the current snapshot is already stored.
-func (s *Service) StashPrices() {
+//
+// Pass a context that outlives a request but not the process — the caller's
+// shutdown context — so a stop ends the ingest where it is instead of leaving
+// it running into the exit.
+func (s *Service) StashPrices(ctx context.Context) {
 	if !s.pricesStashing.CompareAndSwap(false, true) {
 		log.Println("tcgcsv StashPrices: another ingest is already running, skipping")
 		return
 	}
 	defer s.pricesStashing.Store(false)
 
-	err := s.WithCrawlLock("tcgcsv StashPrices", func() error {
-		return s.IngestLatest(context.Background())
+	err := s.WithCrawlLock(ctx, "tcgcsv StashPrices", func() error {
+		return s.IngestLatest(ctx)
 	})
 	if err != nil {
 		log.Println("tcgcsv daily ingest:", err)

--- a/tcgcsvd/products.go
+++ b/tcgcsvd/products.go
@@ -32,16 +32,17 @@ func productToRow(categoryID int, p tcgcsv.Product) timeseries.TCGProduct {
 func (s *Service) IsStashingProducts() bool { return s.productsStashing.Load() }
 
 // StashProducts runs SyncProducts under the single-flight guard and the shared
-// crawl lock. It is the cron/CLI entry point.
-func (s *Service) StashProducts() {
+// crawl lock. It is the cron/CLI entry point, and takes the same kind of
+// context StashPrices does.
+func (s *Service) StashProducts(ctx context.Context) {
 	if !s.productsStashing.CompareAndSwap(false, true) {
 		log.Println("tcgcsv StashProducts: another product sync is already running, skipping")
 		return
 	}
 	defer s.productsStashing.Store(false)
 
-	err := s.WithCrawlLock("tcgcsv StashProducts", func() error {
-		return s.SyncProducts(context.Background())
+	err := s.WithCrawlLock(ctx, "tcgcsv StashProducts", func() error {
+		return s.SyncProducts(ctx)
 	})
 	if err != nil {
 		log.Println("tcgcsv product sync:", err)

--- a/tcgcsvd/service.go
+++ b/tcgcsvd/service.go
@@ -165,12 +165,15 @@ const crawlLockKey = 0x7463675f_63726177 // "tcg_craw"
 // whose crons are still armed. Backfill is the one exception: it is
 // operator-driven and runs for hours, and holding the lock across that would
 // starve the daily pull, which is the run that must not be missed.
-func (s *Service) WithCrawlLock(job string, fn func() error) error {
+//
+// ctx covers taking the lock only; fn gets whatever context its caller closed
+// over, which is normally the same one.
+func (s *Service) WithCrawlLock(ctx context.Context, job string, fn func() error) error {
 	if s.store.ReadOnly() {
 		log.Printf("%s: price database is read-only, skipping", job)
 		return nil
 	}
-	acquired, release, err := s.store.TryAdvisoryLock(context.Background(), crawlLockKey)
+	acquired, release, err := s.store.TryAdvisoryLock(ctx, crawlLockKey)
 	if err != nil {
 		log.Printf("%s: could not acquire crawl lock: %v", job, err)
 		return nil

--- a/tcgcsvd/service.go
+++ b/tcgcsvd/service.go
@@ -160,9 +160,11 @@ const crawlLockKey = 0x7463675f_63726177 // "tcg_craw"
 // A read-only database can't ingest, so it skips without taking the lock (else
 // it could win the lock and starve the writable process).
 //
-// Wrap any crawling job in it — the daily ingest and the product sync do, and a
-// standalone process should too, so it stays coordinated with a server whose
-// crons are still armed.
+// Wrap the scheduled crawls in it — the daily ingest and the product sync do,
+// and a standalone process should too, so it stays coordinated with a server
+// whose crons are still armed. Backfill is the one exception: it is
+// operator-driven and runs for hours, and holding the lock across that would
+// starve the daily pull, which is the run that must not be missed.
 func (s *Service) WithCrawlLock(job string, fn func() error) error {
 	if s.store.ReadOnly() {
 		log.Printf("%s: price database is read-only, skipping", job)


### PR DESCRIPTION
Closes #329. One commit per item.

**1. The crawl-lock claim** (`05dae3f9`) — doc, not code. `tcgcsvd/doc.go` already says backfill deliberately stays outside the lock: it is operator-driven, runs for hours, and holding a session advisory lock across that would starve the daily pull. So the `cmd/tcgcsvd` package doc was the one that was wrong. Corrected there, with the reason repeated at the `-backfill` case and the exception noted where `WithCrawlLock` tells you to wrap crawling jobs in it.

**2. The dropped context** (`143ae929`) — `WithCrawlLock` now takes a ctx for the lock attempt, and `StashPrices`/`StashProducts` take the context they run the job under. The server side needed a context that outlives a request but not the process — the admin button hands the ingest to a goroutine that outlives the request that pressed it, and a cron fire has no request at all — so this adds `ServerContext`, cancelled right after `<-done`, alongside the listener drain. `cmd/tcgcsvd` passes its `signal.NotifyContext` through to all three.

**3. The asymmetric pairing** (`289400ea`) — `tcgFinishIDForSubType` now returns `""` for a sub-type the card carries no finish for, mirroring `tcgSubTypeForCard`'s refusal to map one onto the primary foil, and `tcgVariantSearchID` reports that as not-found so the caller keeps its own id. A sub-type the product doesn't list at all still resolves to the primary foil, as before. The test table grows an `unmapped` field and the `{"Normal", "Cold Foil", "Holofoil"}`-over-two-finishes case; it fails on the old code with `tcgFinishIDForSubType("Holofoil") = "2810_f"`.

**4. The alphabetical invariant** (`45429ad0`) — written down next to `foilSubTypes` and checked in `TestFoilSubTypeOrdering`, so a new foil sub-type name has a place to be added and gets verified there. `extraFoilFinishes` also notes that a second extra finish would make the finish-key ordering load-bearing too; today nothing carries one.

**5. `var err error`** (`611d7395`) in the maintenance block.

Build, `go vet ./...` and the full suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Npq8MYkYsHrxABKtL7rEMJ