### PR TITLE
Fixes from a review of v13.25..v13.26

### DIFF
--- a/chart_resolve.go
+++ b/chart_resolve.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"log"
 	"slices"
 	"strconv"
 	"strings"
@@ -360,7 +361,15 @@ func tcgVariantSearchID(ctx context.Context, vi timeseries.VariantInfo) (string,
 	}
 	subTypes, ok := PricesArchiveDB.CachedTCGSubTypeBanIDs(vi.TCGProductID)
 	if !ok {
-		subTypes, _ = PricesArchiveDB.LookupTCGSubTypeBanIDs(ctx, vi.TCGProductID)
+		// Without the product's sub-types there is nothing to pair the
+		// variant's own against, and tcgFinishIDForSubType reads an unknown
+		// sub-type as the primary foil — which is the wrong finish rather
+		// than no finish. Say so instead.
+		subTypes, err = PricesArchiveDB.LookupTCGSubTypeBanIDs(ctx, vi.TCGProductID)
+		if err != nil {
+			log.Printf("chart: sub-types for product %d: %v", vi.TCGProductID, err)
+			return "", false
+		}
 	}
 	id := tcgFinishIDForSubType(co, subTypes, vi.TCGSubType)
 	if id == "" {

--- a/checkpoints.go
+++ b/checkpoints.go
@@ -440,3 +440,14 @@ func containsFold(list []string, target string) bool {
 	}
 	return false
 }
+
+// refreshCheckpoints is reloadCheckpoints as the crons call it. A reload that
+// fails leaves the markers as they are -- an empty index when the boot-time
+// load failed too -- so it is worth reporting rather than only logging: for
+// Magic the source is a document on someone else's server, and a chart quietly
+// missing every ban marker looks like a chart with nothing to mark.
+func refreshCheckpoints() {
+	if err := reloadCheckpoints(); err != nil {
+		ServerNotify("checkpoints", "reload failed: "+err.Error(), true)
+	}
+}

--- a/discord.go
+++ b/discord.go
@@ -82,16 +82,6 @@ func setupDiscord() error {
 	return nil
 }
 
-// discordRegionFilter keeps the bot to stores a reader can actually buy from,
-// which is a reason to drop a foreign shop and not a reason to drop a foreign
-// price reference — so the index scrapers are exempt. Cardmarket's are the
-// ones flagged EU, and without the exemption its prices never reach an embed.
-var discordRegionFilter = FilterStoreElem{
-	Name:         "region",
-	Values:       []string{"us"},
-	IncludeIndex: true,
-}
-
 // Cleanly close down the Discord session.
 func cleanupDiscord() {
 	if Config.DiscordToken == "" {
@@ -612,7 +602,20 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 	if allBls {
 		config := parseSearchOptionsNG(searchRes.CardId, DiscordRetailBlocklist, DiscordBuylistBlocklist, nil)
 
-		config.StoreFilters = append(config.StoreFilters, discordRegionFilter)
+		// Keep the bot to stores a reader can actually buy from. That is a
+		// reason to drop a foreign shop and not a reason to drop a foreign
+		// price reference, so the index scrapers are exempt — Cardmarket's are
+		// the ones flagged EU, and without the exemption its prices never reach
+		// an embed. Built here rather than shared: filter values are edited in
+		// place further down (parseSearchOptionsNG appends a trailing finish
+		// character to the last regexp filter's first value), so one Values
+		// slice handed to every message is a backing array the bot would be
+		// rewriting under itself.
+		config.StoreFilters = append(config.StoreFilters, FilterStoreElem{
+			Name:         "region",
+			Values:       []string{"us"},
+			IncludeIndex: true,
+		})
 
 		// Skip non-NM buylist prices
 		config.EntryFilters = append(config.EntryFilters, FilterEntryElem{

--- a/discord_region_test.go
+++ b/discord_region_test.go
@@ -32,7 +32,12 @@ func TestDiscordRegionFilterKeepsIndexScrapers(t *testing.T) {
 		{"an EU index stays", seller("Cardmarket Low", "MKMLow", "EU", true), false},
 		{"a JP index stays", seller("Hareruya", "HAR", "JP", true), false},
 	} {
-		got := shouldSkipStoreNG(tc.scraper, []FilterStoreElem{discordRegionFilter})
+		// Mirrors the filter messageCreate appends.
+		got := shouldSkipStoreNG(tc.scraper, []FilterStoreElem{{
+			Name:         "region",
+			Values:       []string{"us"},
+			IncludeIndex: true,
+		}})
 		if got != tc.wantSkip {
 			t.Errorf("%s: skip=%v, want %v", tc.name, got, tc.wantSkip)
 		}

--- a/main.go
+++ b/main.go
@@ -1415,6 +1415,10 @@ func renderTemplateFiles(tmpl string, isMobile bool) (baseName string, files []s
 	}
 	files = append(files, navbarPartial)
 
+	// The set symbol is drawn by desktop and mobile pages alike, and each is
+	// built from its own base, so the block cannot live in one of them.
+	files = append(files, "templates/partials/set-symbol.html")
+
 	// Include settings-modal partial only for desktop pages that define a "settings-content" block.
 	if !isMobile {
 		switch name {

--- a/main.go
+++ b/main.go
@@ -1225,6 +1225,14 @@ func main() {
 			c.AddFunc("0 22 * * 1", stashTCGCSVProducts)
 		}
 
+		// Refresh the chart checkpoints. Magic reads its ban markers from a
+		// document published outside this project, so a B&R announcement only
+		// reaches the charts when something re-reads it -- and the boot-time
+		// load is not that, on a process that stays up for weeks. It doubles as
+		// the retry for a boot-time load that failed: a fetch that never
+		// succeeded leaves the index empty and every chart without its markers.
+		c.AddFunc("15 */6 * * *", refreshCheckpoints)
+
 		c.Start()
 	}
 

--- a/news.go
+++ b/news.go
@@ -401,6 +401,37 @@ func GetNewspaperUUIDs() map[string]struct{} {
 	return *p
 }
 
+// newspaperStaleAfter is how old the cached slices may get before the page says
+// so. The cache refreshes every three hours, so this is four missed runs: past
+// any single hiccup, and soon enough that a reader is told the same day.
+const newspaperStaleAfter = 12 * time.Hour
+
+// newspaperStaleNotice is what a page tells a reader when it has stopped
+// refreshing, or "" while it is current. Every page keeps its last good slice
+// through a bad refresh, which is what stops a gap in the scoring data from
+// blanking the tables -- but it also means the numbers look live when they are
+// not, and the reader is the one acting on them.
+func newspaperStaleNotice(last time.Time) string {
+	if last.IsZero() || time.Since(last) < newspaperStaleAfter {
+		return ""
+	}
+	return "these numbers last refreshed " + last.Format("Jan 2 15:04 MST") + " and are not current"
+}
+
+// noteNewspaperStaleness appends the notice to whatever the page was already
+// saying, since InfoMessage carries the page description.
+func noteNewspaperStaleness(pageVars *PageVars) {
+	notice := newspaperStaleNotice(pageVars.LastUpdate)
+	if notice == "" {
+		return
+	}
+	if pageVars.InfoMessage == "" {
+		pageVars.InfoMessage = notice
+		return
+	}
+	pageVars.InfoMessage += " — " + notice
+}
+
 // refreshNewspaperEdition runs one edition of a page's query. The second
 // return value reports whether the results are good enough to replace what is
 // already cached: a failed query, an empty response, or a response that lost
@@ -467,6 +498,10 @@ func cacheNewspaper() {
 	next := make([]NewspaperPage, len(current))
 	copy(next, current)
 
+	// How many editions actually took new rows this run. The update time is
+	// what the page shows as its own, so it may only move when something did.
+	var refreshed int
+
 	for i := range next {
 		if next[i].Query == "" {
 			continue
@@ -483,12 +518,14 @@ func cacheNewspaper() {
 		if results, ok := refreshNewspaperEdition(next[i].Option, query, next[i].Results); ok {
 			next[i].Results = results
 			next[i].AvailableEditions, next[i].PossibleFinish = newspaperFilterValues(results)
+			refreshed++
 		}
 
 		query3day := strings.ReplaceAll(query, "0 DAY", "3 DAY")
 		if results, ok := refreshNewspaperEdition(next[i].Option+" (3day)", query3day, next[i].Results3Day); ok {
 			next[i].Results3Day = results
 			next[i].AvailableEditions3Day, next[i].PossibleFinish3Day = newspaperFilterValues(results)
+			refreshed++
 		}
 
 		// Cache UUIDs from spike score pages for the "on:newspaper" search filter
@@ -503,7 +540,15 @@ func cacheNewspaper() {
 	newspaperUUIDsPtr.Store(&newspaperUUIDs)
 	log.Println("Newspaper UUIDs cached:", len(newspaperUUIDs))
 
-	SetLastNewspaperUpdate(time.Now())
+	// Only stamp a new update time when an edition actually took new rows.
+	// Every page keeps its last good slice through a bad refresh, so stamping
+	// unconditionally dated stale data to the minute the refresh failed, and the
+	// page then advertised it as current.
+	if refreshed > 0 {
+		SetLastNewspaperUpdate(time.Now())
+	} else {
+		log.Println("newspaper: no edition refreshed, leaving the update time at", GetLastNewspaperUpdate())
+	}
 	log.Println("Newspaper All Ready")
 }
 
@@ -1259,7 +1304,7 @@ func Newspaper(w http.ResponseWriter, r *http.Request) {
 		// live one is cached, and an empty table reads as a broken page
 		if len(results) == 0 {
 			pageVars.InfoMessage = "This data is not ready yet, please try again in a few minutes"
-			pageVars.LastUpdate = time.Now()
+			noteNewspaperStaleness(&pageVars)
 			render(w, "news.html", pageVars)
 			return
 		}
@@ -1354,5 +1399,6 @@ func Newspaper(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	noteNewspaperStaleness(&pageVars)
 	render(w, "news.html", pageVars)
 }

--- a/search.go
+++ b/search.go
@@ -115,15 +115,33 @@ func magicFinishSearchID(uuid string, foil, etched bool) string {
 	return uuid
 }
 
+// noteChartIDsDropped tells the reader that part of the roster could not be
+// matched to a printing, appending to whatever the page already said.
+func noteChartIDsDropped(pageVars *PageVars, dropped, total int) {
+	notice := fmt.Sprintf("%d of the %d charted cards could not be matched to a printing and were left out.", dropped, total)
+	if dropped == 1 {
+		notice = "One of the charted cards could not be matched to a printing and was left out."
+	}
+	if pageVars.InfoMessage == "" {
+		pageVars.InfoMessage = notice
+		return
+	}
+	pageVars.InfoMessage += " " + notice
+}
+
 // chartIDToSearchID maps a chart-roster id to an id the results table (which the
 // embedded chart lives inside) can resolve to a card row, mirroring
 // resolveChartTarget's precedence so anything chartable also renders its row.
 // Magic resolves to the mtgmatcher id of the variant's own finish; non-Magic
 // games (Lorcana, ...) to their mtgmatcher-native id via the TCGplayer external
 // id map.
-func chartIDToSearchID(ctx context.Context, id string) string {
+//
+// ok=false means nothing was resolved and the id is handed back as it came:
+// the results table will find no row for it, so the card drops out of the page
+// it was asked for. The caller says so rather than letting it vanish.
+func chartIDToSearchID(ctx context.Context, id string) (string, bool) {
 	if _, err := mtgmatcher.GetUUID(id); err == nil {
-		return id // already a matcher id (bare uuid / variant string)
+		return id, true // already a matcher id (bare uuid / variant string)
 	}
 	prefix, val := splitIDPrefix(id)
 
@@ -135,14 +153,14 @@ func chartIDToSearchID(ctx context.Context, id string) string {
 			if vi, ok, _ := PricesArchiveDB.LookupVariant(ctx, n); ok {
 				if vi.MtgjsonUUID != "" {
 					// Magic: the uuid, kept on the finish the ban_id names.
-					return magicFinishSearchID(vi.MtgjsonUUID, vi.IsFoil, vi.IsEtched)
+					return magicFinishSearchID(vi.MtgjsonUUID, vi.IsFoil, vi.IsEtched), true
 				}
 				// Non-Magic: the product id maps back to the game's own card id,
 				// on the finish the variant's sub-type names.
 				if matched, ok := tcgVariantSearchID(ctx, vi); ok {
-					return matched
+					return matched, true
 				}
-				return id
+				return id, false
 			}
 			// Not a ban_id: fall through to the external-id lookup below.
 		}
@@ -151,9 +169,9 @@ func chartIDToSearchID(ctx context.Context, id string) string {
 	// tcg:, scryfall:, mtgjson:, or a bare id mtgmatcher maps through its external
 	// id table (a TCGplayer product id, a Scryfall id, or an mtgjson uuid).
 	if matched, merr := mtgmatcher.MatchId(val); merr == nil {
-		return matched
+		return matched, true
 	}
-	return id
+	return id, false
 }
 
 // parseChartIDs splits a chart=... param (comma-separated UUIDs) into a
@@ -333,9 +351,21 @@ func Search(w http.ResponseWriter, r *http.Request) {
 			// ?chart=uuidA,%20uuidB doesn't leave card B off the results/remove
 			// controls just because fixupIDs won't trim the leading space.
 			searchIDs := make([]string, len(chartIds))
+			var unresolved int
 			for i, id := range chartIds {
-				searchIDs[i] = chartIDToSearchID(r.Context(), id)
+				searchID, ok := chartIDToSearchID(r.Context(), id)
+				if !ok {
+					unresolved++
+				}
+				searchIDs[i] = searchID
 				chartSearchIDs[id] = searchIDs[i]
+			}
+			// An id that resolved to nothing matches no row, so the card is
+			// simply absent from the table below the chart. Say which way it
+			// went: a roster the user built by hand, or a link they were sent,
+			// otherwise comes back quietly short.
+			if unresolved > 0 {
+				noteChartIDsDropped(&pageVars, unresolved, len(chartIds))
 			}
 			query = strings.Join(searchIDs, ",")
 			pageVars.Title = strings.Replace(pageVars.Title, "Search", "Chart", 1)

--- a/setsymbol_test.go
+++ b/setsymbol_test.go
@@ -49,7 +49,7 @@ func TestSetSymbolBlock(t *testing.T) {
 	Config.Game = "onepiece"
 	loadRarityBadges()
 
-	tmpl, err := tmplparse.ParseFiles("base.html", []string{"templates/base.html"}, funcMap)
+	tmpl, err := tmplparse.ParseFiles("set-symbol.html", []string{"templates/partials/set-symbol.html"}, funcMap)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tcgcsvd/doc.go
+++ b/tcgcsvd/doc.go
@@ -86,7 +86,7 @@ As a library, from a process that already has a *timeseries.Client:
 
 	svc, err := tcgcsvd.New(*cfg.TCGCSVConfig, db,
 	    tcgcsvd.WithLongFormWrites(true),
-	    tcgcsvd.WithNotifier(ServerNotify))
+	    tcgcsvd.WithNotifier(func(kind, message string) { ServerNotify(kind, message) }))
 	go svc.StashPrices(ctx)
 
 The context is the caller's own shutdown one, not a request's: the run outlives

--- a/tcgcsvd/service.go
+++ b/tcgcsvd/service.go
@@ -157,6 +157,10 @@ const crawlLockKey = 0x7463675f_63726177 // "tcg_craw"
 // WithCrawlLock runs fn only if this process can take the shared crawl lock,
 // and returns fn's error. A run that never happened is not a failure: when
 // another process holds the lock the reason is logged and the return is nil.
+// A database that cannot answer whether the lock is free is a different thing
+// and comes back as an error -- the run is just as skipped, but nobody chose to
+// skip it, and a daily ingest that quietly stops happening is what the
+// notification channel exists for.
 // A read-only database can't ingest, so it skips without taking the lock (else
 // it could win the lock and starve the writable process).
 //
@@ -175,8 +179,7 @@ func (s *Service) WithCrawlLock(ctx context.Context, job string, fn func() error
 	}
 	acquired, release, err := s.store.TryAdvisoryLock(ctx, crawlLockKey)
 	if err != nil {
-		log.Printf("%s: could not acquire crawl lock: %v", job, err)
-		return nil
+		return fmt.Errorf("%s: could not take the crawl lock: %w", job, err)
 	}
 	if !acquired {
 		log.Printf("%s: another process holds the tcgcsv crawl lock, skipping", job)

--- a/tcgcsvd/service_test.go
+++ b/tcgcsvd/service_test.go
@@ -213,3 +213,44 @@ func TestStashDoesNotNotifyOnShutdown(t *testing.T) {
 		})
 	}
 }
+
+// lockFailStore cannot answer whether the crawl lock is free.
+type lockFailStore struct {
+	stubStore
+	err error
+}
+
+func (s lockFailStore) TryAdvisoryLock(context.Context, int64) (bool, func(), error) {
+	return false, nil, s.err
+}
+
+// A lock another process holds is a skip, and a lock we could not ask about is
+// a failure. Both leave the ingest un-run, but only one of them was a decision:
+// a database that stops answering silently stops the daily pull, which is the
+// case the channel is for. A stop still stays quiet, as everywhere else.
+func TestCrawlLockErrorIsNotASilentSkip(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		store      Store
+		wantNotify bool
+	}{
+		{"another process holds the lock", stubStore{}, false},
+		{"the database cannot answer", lockFailStore{err: errors.New("connection refused")}, true},
+		{"cancelled by shutdown", lockFailStore{err: context.Canceled}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var notified []string
+			svc, err := New(tcgcsv.Config{Games: []tcgcsv.GameConfig{{Name: "Disney Lorcana", CategoryID: 71}}},
+				tc.store, WithNotifier(func(kind, message string) { notified = append(notified, message) }))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			svc.StashPrices(context.Background())
+
+			if got := len(notified) > 0; got != tc.wantNotify {
+				t.Errorf("notified=%v (%v), want %v", got, notified, tc.wantNotify)
+			}
+		})
+	}
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -42,47 +42,7 @@
 <script>(function(){try{var v=localStorage.getItem('theme');var pref=(v==='light'||v==='dark'||v==='system')?v:'system';var dark=pref==='dark'||(pref==='system'&&window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches);if(dark){document.body.classList.remove('light-theme');document.body.classList.add('dark-theme');}}catch(e){}})();</script>
 {{if not .ModalMode}}{{template "navbar" .}}{{end}}
 
-{{/* The paint every foil rarity badge fills itself with. It lives here
-     because more than one page draws that badge, and a page that referenced
-     the gradient without carrying this block rendered the badges hollow.
-
-     The stops are keyrune's own .ss-foil.ss-grad, so a foil badge and the
-     foil keyrune a Magic page draws beside it are the same rainbow. Keyrune
-     writes it as linear-gradient(135deg, ...), which on a square runs corner
-     to corner — hence x1,y1 to x2,y2 rather than a rotation. */}}
-<svg height="0" width="0" xmlns="http://www.w3.org/2000/svg">
-    <defs>
-        <linearGradient id="gradient-foil" x1="0" y1="0" x2="1" y2="1">
-            <stop offset="0%"   stop-color="#ea8d66" />
-            <stop offset="15%"  stop-color="#ea8d66" />
-            <stop offset="28%"  stop-color="#fdef8a" />
-            <stop offset="42%"  stop-color="#8bcc93" />
-            <stop offset="55%"  stop-color="#a6dced" />
-            <stop offset="68%"  stop-color="#6f75aa" />
-            <stop offset="84%"  stop-color="#e599c2" />
-            <stop offset="100%" stop-color="#e599c2" />
-        </linearGradient>
-    </defs>
-</svg>
-
-{{/* The icon that stands for one set. Callers hand it what they have — a
-     keyrune class, a set code, and for a card its rarity and finish — and it
-     paints the keyrune where the game defines one and the rarity badge where
-     it draws those instead. A deployment with no drawings loaded is a keyrune
-     one, so it keeps the font's fallback glyph for a set the font does not
-     know. Deciding here is the point: no page has to know which kind of game
-     it is serving. */}}
-{{define "set-symbol"}}
-    {{$badge := rarity_badge .Rarity .Code}}
-    {{if or .Keyrune (not $badge.Path)}}
-        <i class="ss {{.Keyrune}} {{if gt .Size 20}}ss-2x{{else}}ss-1x{{end}} ss-fw {{.Class}}"></i>
-    {{else if .Color}}
-        <svg class="{{.Class}}" width="{{.Size}}" height="{{.Size}}" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-            <path d="{{$badge.Path}}" fill="{{if .Foil}}url(#gradient-foil){{else}}{{.Color}}{{end}}" stroke="{{if .Foil}}black{{else}}{{.Color}}{{end}}" stroke-width="0.75"/>
-            <text font-size="{{$badge.Font}}" font-family="monospace" font-weight="bold" x="10" y="{{$badge.TextY}}" text-anchor="middle" dominant-baseline="central" fill="{{if .Foil}}black{{else}}var(--background){{end}}">{{.Code}}</text>
-        </svg>
-    {{end}}
-{{end}}
+{{template "set-symbol-defs"}}
 
 <div class="page-content">
     {{if ne .ErrorMessage ""}}

--- a/templates/mobile/base-mobile.html
+++ b/templates/mobile/base-mobile.html
@@ -30,6 +30,8 @@
 </svg>
 {{template "navbar" .}}
 
+{{template "set-symbol-defs"}}
+
 <div class="page-content">
     {{if ne .ErrorMessage ""}}
         <div class="page-error">{{.ErrorMessage}}</div>

--- a/templates/mobile/home.html
+++ b/templates/mobile/home.html
@@ -52,8 +52,6 @@
             <a href="https://mtgban.com">Magic: the Gathering</a>
             <span>|</span>
             <a href="https://lorcana.mtgban.com">Disney Lorcana</a>
-            <span>|</span>
-            <a href="https://riftbound.mtgban.com">Riftbound</a>
         </div>
 
         <div class="m-home-login-row">

--- a/templates/partials/set-symbol.html
+++ b/templates/partials/set-symbol.html
@@ -1,0 +1,46 @@
+{{/* The set symbol, and the paint its foil variant fills itself with.
+
+     Both live in a partial rather than in a base layout because there is more
+     than one base: a page rendered on mobile is built from base-mobile.html and
+     never sees base.html, so a block defined only there is missing from exactly
+     the pages that call it. renderTemplateFiles adds this file to every set. */}}
+
+{{/* The stops are keyrune's own .ss-foil.ss-grad, so a foil badge and the
+     foil keyrune a Magic page draws beside it are the same rainbow. Keyrune
+     writes it as linear-gradient(135deg, ...), which on a square runs corner
+     to corner — hence x1,y1 to x2,y2 rather than a rotation. */}}
+{{define "set-symbol-defs"}}
+<svg height="0" width="0" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <linearGradient id="gradient-foil" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%"   stop-color="#ea8d66" />
+            <stop offset="15%"  stop-color="#ea8d66" />
+            <stop offset="28%"  stop-color="#fdef8a" />
+            <stop offset="42%"  stop-color="#8bcc93" />
+            <stop offset="55%"  stop-color="#a6dced" />
+            <stop offset="68%"  stop-color="#6f75aa" />
+            <stop offset="84%"  stop-color="#e599c2" />
+            <stop offset="100%" stop-color="#e599c2" />
+        </linearGradient>
+    </defs>
+</svg>
+{{end}}
+
+{{/* The icon that stands for one set. Callers hand it what they have — a
+     keyrune class, a set code, and for a card its rarity and finish — and it
+     paints the keyrune where the game defines one and the rarity badge where
+     it draws those instead. A deployment with no drawings loaded is a keyrune
+     one, so it keeps the font's fallback glyph for a set the font does not
+     know. Deciding here is the point: no page has to know which kind of game
+     it is serving. */}}
+{{define "set-symbol"}}
+    {{$badge := rarity_badge .Rarity .Code}}
+    {{if or .Keyrune (not $badge.Path)}}
+        <i class="ss {{.Keyrune}} {{if gt .Size 20}}ss-2x{{else}}ss-1x{{end}} ss-fw {{.Class}}"></i>
+    {{else if .Color}}
+        <svg class="{{.Class}}" width="{{.Size}}" height="{{.Size}}" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+            <path d="{{$badge.Path}}" fill="{{if .Foil}}url(#gradient-foil){{else}}{{.Color}}{{end}}" stroke="{{if .Foil}}black{{else}}{{.Color}}{{end}}" stroke-width="0.75"/>
+            <text font-size="{{$badge.Font}}" font-family="monospace" font-weight="bold" x="10" y="{{$badge.TextY}}" text-anchor="middle" dominant-baseline="central" fill="{{if .Foil}}black{{else}}var(--background){{end}}">{{.Code}}</text>
+        </svg>
+    {{end}}
+{{end}}

--- a/templates_test.go
+++ b/templates_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"html/template"
+	"testing"
+	"text/template/parse"
+)
 
 // TestTemplatesParse parses every template the way production does (via the
 // shared funcMap), catching syntax errors and references to unregistered
@@ -12,5 +16,94 @@ func TestTemplatesParse(t *testing.T) {
 
 	if _, err := buildTemplateCache(); err != nil {
 		t.Fatalf("templates failed to parse: %v", err)
+	}
+}
+
+// TestTemplatesResolveEveryReference checks that each {{template "x"}} a page
+// can actually reach resolves in that page's own set.
+//
+// TestTemplatesParse cannot see this: html/template resolves a reference when
+// it executes, not when it parses, so a block that no file in the set defines
+// parses clean and fails on the first request. That is how the set symbol block
+// came to be defined in base.html alone while the mobile pages, which are built
+// from base-mobile.html, kept calling it -- every one of them 500'd.
+//
+// Reachability is the same rule the renderer follows, walking out from the base
+// the page is built on. A block the base never invokes is never resolved, so a
+// reference inside one is not a broken page: arbit.html defines a settings block
+// that only the desktop settings modal calls, and rendering it on mobile is fine.
+func TestTemplatesResolveEveryReference(t *testing.T) {
+	saved := DevMode
+	DevMode = false
+	defer func() { DevMode = saved }()
+
+	cache, err := buildTemplateCache()
+	if err != nil {
+		t.Fatalf("templates failed to parse: %v", err)
+	}
+
+	for key, tmpl := range cache {
+		// The root carries the base's name, which is where rendering starts.
+		for _, missing := range unresolvedRefs(tmpl, tmpl.Name()) {
+			t.Errorf("%s: {{template %q}} is reachable but not defined in its set", key, missing)
+		}
+	}
+}
+
+// unresolvedRefs walks out from the named template and returns every reference
+// it can reach that nothing in the set defines.
+func unresolvedRefs(tmpl *template.Template, root string) []string {
+	var missing []string
+	seen := map[string]bool{}
+
+	var visit func(name string)
+	visit = func(name string) {
+		if seen[name] {
+			return
+		}
+		seen[name] = true
+
+		assoc := tmpl.Lookup(name)
+		if assoc == nil {
+			missing = append(missing, name)
+			return
+		}
+		if assoc.Tree == nil {
+			return
+		}
+		var refs []string
+		collectTemplateRefs(assoc.Tree.Root, &refs)
+		for _, ref := range refs {
+			visit(ref)
+		}
+	}
+	visit(root)
+
+	return missing
+}
+
+// collectTemplateRefs walks the node types that can hold a template reference.
+// {{block}} parses into a TemplateNode plus its own definition, so it is
+// covered by the same case.
+func collectTemplateRefs(node parse.Node, out *[]string) {
+	switch n := node.(type) {
+	case *parse.ListNode:
+		if n == nil {
+			return
+		}
+		for _, child := range n.Nodes {
+			collectTemplateRefs(child, out)
+		}
+	case *parse.TemplateNode:
+		*out = append(*out, n.Name)
+	case *parse.IfNode:
+		collectTemplateRefs(n.List, out)
+		collectTemplateRefs(n.ElseList, out)
+	case *parse.RangeNode:
+		collectTemplateRefs(n.List, out)
+		collectTemplateRefs(n.ElseList, out)
+	case *parse.WithNode:
+		collectTemplateRefs(n.List, out)
+		collectTemplateRefs(n.ElseList, out)
 	}
 }


### PR DESCRIPTION
Findings from reviewing the 62 commits between `v13.25` and `v13.26`, one commit per fix. Each builds and tests clean on its own.

## The blocker

**`templates: define the set symbol where every base can reach it`**

Every mobile page that draws a set symbol has been failing to render:

```
html/template:sets.html:36:11: no such template "set-symbol"
```

`4f807e49` centralised the block into `base.html` and converted the mobile templates to call it, but a mobile page is built from `base-mobile.html` and never sees that file. `mobile/search.html`, `mobile/sets.html`, `mobile/news.html` and `mobile/sleep.html` all call it. At `v13.25` these rendered the glyph inline, so this is a regression in the release.

The block and the foil gradient move to `templates/partials/set-symbol.html`, which goes into every set.

`TestTemplatesParse` could not catch this — `html/template` resolves a `{{template}}` reference when it *executes*, not when it parses, so the set parses clean and fails on the first request. The new test walks the parse trees out from the base the page renders through, which is the same path the renderer takes: a block the base never invokes is not reported as broken, so `arbit.html`'s desktop-only settings block is correctly left alone. Verified against the bug — reverting the fix makes the test fail on all four pages.

## Correctness

- **`home:`** `c05a44dd` pulled the Riftbound link from `home.html` only. The mobile landing is its own template and still linked it.
- **`news:`** since `3347725f` an edition keeps its last good slice on a bad refresh, which is what stops a gap in the scoring data from blanking four pages — but nothing said so. `cacheNewspaper` stamped the update time whether or not anything refreshed, the handler stamped `time.Now()` outright on the not-ready path, and `07ed81e2` had turned the last signal into log lines. The time now moves only when an edition took new rows, and the page tells the reader when its slices have gone twelve hours without refreshing. No ping — the reader is who needed this, and `07ed81e2` was right that a merely-late slice is not ops' problem.
- **`chart:`** `tcgVariantSearchID` discarded the error from `LookupTCGSubTypeBanIDs`, leaving the sub-type map nil, which made `tcgFinishIDForSubType` return the primary foil — a Lorcana Holofoil rendering as its Cold Foil printing. Refusing to guess means the id resolves to nothing and the card stops appearing under the chart, so `chartIDToSearchID` now reports that rather than handing the raw id back indistinguishably, and the page says how much of the roster was left out.

## Operational

- **`checkpoints:`** `b4c1555f` repointed Magic's markers at a document published outside this project, and `reloadCheckpoints` runs once at boot with no cron behind it — a B&R announcement reached the charts only on a restart or an admin button press. The same call is also the retry the new source needs: a failed startup load leaves the index nil for the life of the process and every Magic chart silently loses every marker. Now reloads every six hours and reports a failure.
- **`tcgcsvd:`** `WithCrawlLock` returned nil whether another process held the lock or the database could not be asked at all. The first is a decision, the second means nobody ran the daily ingest and nobody was told. A stop still stays quiet — cancelling fails the lock attempt with `context.Canceled`, which the existing shutdown check recognises.

## Smaller

- **`tcgcsvd:`** `39331501` fixed the `StashPrices` call in the doc snippet, but the line above it does not compile either — `ServerNotify` is variadic and so is not assignable to the func type `WithNotifier` takes.
- **`discord:`** `cb21ba1e` lifted the region filter to a package-level value sharing one `Values` slice; `parseSearchOptionsNG` edits filter values in place. Nothing reaches it today (the filter is appended after parsing), so this is the shape of the thing rather than a live bug. There was only ever one call site, so the value goes back into it.

## Reported but not fixed here

- **Shutdown does not wait for background jobs.** `0fd9d6ed` cancels `ServerContext` at shutdown, but nothing waits for the jobs to notice, so the process still exits through whatever is unwinding — the "stops at its next checkpoint" guarantee is not enforced. Left alone by request; worth noting that the droplet unit's `TimeoutStopSec=15s` is the budget any future fix has to fit inside, alongside `srv.Shutdown`'s 5s.
- **Cardmarket link.** `GameIdFromName` answers 0 for a game Cardmarket does not carry and the URL builders then return `""`, but `search.go` appends the `SearchEntry` anyway, so the entry renders with an empty `href`. Latent — all four current games are covered.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` and `gofmt -l .` are clean at every commit.

## Note for reviewers

The container clones shallow, which makes `git log v13.25..v13.26` report 50 commits and shows `e9ad3ffb` as a parentless 271-file commit. Both are graft artifacts — `git fetch --unshallow` gives the real 62.