### PR TITLE
search: Resolve an is: value through the promo type's slug

### DIFF
--- a/searchfilter.go
+++ b/searchfilter.go
@@ -1336,6 +1336,22 @@ func compareReleaseDate(filters []string, co *mtgmatcher.CardObject, cmpFunc fun
 	return cmpFunc(cardDate, releaseDate)
 }
 
+// promoTypeSlug renders a promo type as the token a query can carry: lower
+// case, with everything that is not a letter or a digit dropped. A query is
+// split on whitespace before a filter sees it, and an is: value again on
+// commas, so a tag only survives the trip as one word. Magic's types already
+// are ("boosterfun"), which is why is: has always worked there; this gives
+// the other games' tags the same shape.
+func promoTypeSlug(promoType string) string {
+	var out strings.Builder
+	for _, r := range strings.ToLower(promoType) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			out.WriteRune(r)
+		}
+	}
+	return out.String()
+}
+
 var isKnownPromo = map[string]string{
 	"bf":        magic.PromoTypeBoosterfun,
 	"v":         magic.PromoTypeBoosterfun,
@@ -1936,9 +1952,15 @@ func cardFilterIs(filters []string, co *mtgmatcher.CardObject) bool {
 				value = newValue
 			}
 
-			// Fall back to any promo type currently supported
-			if slices.Contains(mtgmatcher.AllPromoTypes(), value) {
-				if co.HasPromoType(value) {
+			// Fall back to any promo type the card itself carries. The
+			// comparison runs on a slug of the tag rather than the tag:
+			// Magic spells its types as one lower-case word already, so
+			// those are unaffected, while the other games spell theirs the
+			// way the storefront did - "best of", "Premium Card Collection
+			// -Best Selection Vol. 6-" - and a query is split on
+			// whitespace long before it arrives here.
+			for _, promoType := range co.PromoTypes {
+				if promoTypeSlug(promoType) == value {
 					return false
 				}
 			}

--- a/searchfilter_promoslug_test.go
+++ b/searchfilter_promoslug_test.go
@@ -1,0 +1,30 @@
+package main
+
+import "testing"
+
+func TestPromoTypeSlug(t *testing.T) {
+	for _, tt := range []struct{ in, want string }{
+		// Magic's types are already one lower-case word, so an is: query
+		// that worked before this change works unchanged.
+		{"boosterfun", "boosterfun"},
+		{"promopack", "promopack"},
+		{"serialized", "serialized"},
+		// The other games spell theirs the way the storefront did.
+		{"best of", "bestof"},
+		{"prize wall", "prizewall"},
+		{"Alternate Art", "alternateart"},
+		{"Disney Parks & Stores", "disneyparksstores"},
+		{"Illumineer's Quest", "illumineersquest"},
+		{"Premium Card Collection -Best Selection Vol. 6-", "premiumcardcollectionbestselectionvol6"},
+		// Two spellings of one promo answer to one token, which is what
+		// makes the tag askable: the catalog writes this event both with
+		// and without the stray second space.
+		{"English Version 2nd  Anniversary Set", "englishversion2ndanniversaryset"},
+		{"English Version 2nd Anniversary Set", "englishversion2ndanniversaryset"},
+		{"", ""},
+	} {
+		if got := promoTypeSlug(tt.in); got != tt.want {
+			t.Errorf("promoTypeSlug(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
**Mergeable now — no go-mtgban tag or version bump required.** CI green against
the pinned v0.7.7.

## Why

Riftbound, Lorcana and One Piece carry the qualifiers that tell their
promotional printings apart, but none of them can be asked for. `cardFilterIs`
compares the `is:` value against the promo type itself, and those are spelled
the way the storefront wrote them:

```
"best of"        "Disney Parks & Stores"        "Premium Card Collection -Best Selection Vol. 6-"
```

A query is split on whitespace long before it reaches this function, and an
`is:` value again on commas, so only a single word ever arrives. Magic has
always worked here because MTGJSON already ships one lower-case word
(`boosterfun`).

## The change

Two parts, both small:

1. Compare against a **slug** of the tag — everything that isn't a letter or
   digit dropped, the shape Magic's types already have.
2. Read the tags **off the card** rather than from `AllPromoTypes()`. Whether
   this printing answers to this word is the whole question, and the card knows.
   The declared-list lookup was only validating that the word named *some* promo
   type.

```
is:bestof        is:alternateart        is:prizewall        is:metal
```

Point 2 is what makes this independent of a release: the tags already live on
the card in the version we depend on, so nothing has to be declared upstream
first.

## Magic is untouched

Measured against the published AllPrintings rather than assumed:

```
MAGIC: 129 promo types, 0 change under slugging
```

Every Magic promo type is already its own slug, so every `is:` query that worked
before works unchanged — including the `isKnownPromo` shorthands (`is:bf`,
`is:bab`, `is:judge`), which resolve to those same types before the comparison.

## What arrives later, with no further change here

On the next go-mtgban bump, two things start working on their own:

- **Lorcana `is:`** — its cards gained `PromoTypes` (660 printings, 14 tags) in
  [go-mtgban#129](https://github.com/mtgban/go-mtgban/pull/129); at v0.7.7 they
  carry none, so Lorcana is the one game this PR cannot serve yet.
- **`is:promo`** — reads `IsPromo`, which Riftbound and One Piece only began
  setting in that same PR.

Also waiting on the bump, and needing no code change on this side: the
promo-type **labels**, which stop the three distinct `#263` Teemo products from
rendering as one identical line.