### PR TITLE
palette: Serve the loaded game's promo types, and spell them properly

### DIFF
--- a/internal/palette/palette.go
+++ b/internal/palette/palette.go
@@ -44,8 +44,15 @@ type Service struct {
 	// ArbitFilters returns the arbitrage filter options, in display order.
 	ArbitFilters func() []ArbitFilter
 
+	// PromoAliases returns the shorthands a promo type also answers to, so
+	// the endpoint can offer them beside the type itself.
+	PromoAliases func() map[string]string
+
 	setsCache   []byte
 	setsCacheMu sync.RWMutex
+
+	promosCache   []byte
+	promosCacheMu sync.RWMutex
 }
 
 type Set struct {
@@ -101,6 +108,91 @@ func (s *Service) BuildSetsCache() {
 	s.setsCacheMu.Lock()
 	s.setsCache = data
 	s.setsCacheMu.Unlock()
+}
+
+// Promo is a promo type as the palette and the guide offer it: the token an
+// "is:" query carries, the words a reader is shown, and how much of the game
+// wears it.
+type Promo struct {
+	Value   string   `json:"value"`
+	Label   string   `json:"label"`
+	Count   int      `json:"count"`
+	Aliases []string `json:"aliases,omitempty"`
+}
+
+// BuildPromosCache rebuilds the promo type list from the loaded game. Called
+// on datastore load, beside the sets cache.
+//
+// The list is the loaded game's own: Magic answers with its 129 types,
+// Riftbound with 10, One Piece with 464. Nothing here knows which game it is
+// serving, which is the point - the guide and the palette can offer what the
+// datastore actually holds instead of a table written for one game.
+func (s *Service) BuildPromosCache() {
+	// One pass over the printings, rather than a scan per type: with a few
+	// hundred types and a few thousand printings the difference is real.
+	counts := map[string]int{}
+	for _, uuid := range mtgmatcher.GetUUIDs() {
+		co, err := mtgmatcher.GetUUID(uuid)
+		if err != nil {
+			continue
+		}
+		for _, promoType := range co.PromoTypes {
+			counts[promoType]++
+		}
+	}
+
+	var aliases map[string]string
+	if s.PromoAliases != nil {
+		aliases = s.PromoAliases()
+	}
+
+	promos := []Promo{}
+	for _, promoType := range mtgmatcher.AllPromoTypes() {
+		entry := Promo{
+			Value: promoType,
+			Label: mtgmatcher.PromoTypeLabel(promoType),
+			Count: counts[promoType],
+		}
+		for shorthand, target := range aliases {
+			if target == promoType {
+				entry.Aliases = append(entry.Aliases, shorthand)
+			}
+		}
+		sort.Strings(entry.Aliases)
+		promos = append(promos, entry)
+	}
+	// Commonest first, so a caller showing only the head of the list shows
+	// the types most of the game actually wears.
+	sort.Slice(promos, func(i, j int) bool {
+		if promos[i].Count != promos[j].Count {
+			return promos[i].Count > promos[j].Count
+		}
+		return promos[i].Value < promos[j].Value
+	})
+
+	data, err := json.Marshal(promos)
+	if err != nil {
+		return
+	}
+	s.promosCacheMu.Lock()
+	s.promosCache = data
+	s.promosCacheMu.Unlock()
+}
+
+// Promos returns the loaded game's promo types.
+func (s *Service) Promos(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	s.promosCacheMu.RLock()
+	data := s.promosCache
+	s.promosCacheMu.RUnlock()
+	// cache not warm - dont serve [] for an hour
+	if len(data) == 0 {
+		w.Header().Set("Cache-Control", "no-store")
+		w.Write([]byte(`[]`))
+		return
+	}
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	w.Write(data)
 }
 
 type CardMetaResponse struct {

--- a/main.go
+++ b/main.go
@@ -624,6 +624,9 @@ var ConfigBucket simplecloud.ReadWriter
 // paletteService wires the command-palette endpoints to the live scraper lists,
 // the newspaper page registry, and the arbit filter options.
 var paletteService = &palette.Service{
+	PromoAliases: func() map[string]string {
+		return isKnownPromo
+	},
 	Sellers: GetSellers,
 	Vendors: GetVendors,
 	NewspaperPages: func() []palette.NewspaperPage {
@@ -1042,6 +1045,7 @@ func loadDatastore(bucket simplecloud.Reader, ds string) error {
 	go updateStaticData()
 	go cacheNewspaper()
 	go paletteService.BuildSetsCache()
+	go paletteService.BuildPromosCache()
 
 	return nil
 }
@@ -1316,6 +1320,7 @@ func main() {
 	http.Handle("/api/palette/sealed/", noSigning(http.HandlerFunc(paletteService.Sealed)))
 	http.Handle("/api/palette/sets.json", noSigning(http.HandlerFunc(paletteService.Sets)))
 	http.Handle("/api/palette/stores.json", noSigning(http.HandlerFunc(paletteService.Stores)))
+	http.Handle("/api/palette/promos.json", noSigning(http.HandlerFunc(paletteService.Promos)))
 
 	http.Handle("/monroecards", http.RedirectHandler("/screener", http.StatusFound))
 

--- a/palette_promos_test.go
+++ b/palette_promos_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+
+	"github.com/mtgban/go-mtgban/mtgmatcher"
+	"github.com/mtgban/mtgban-website/internal/palette"
+)
+
+// TestPromosEndpoint exercises the promo type list the guide and the palette
+// read instead of a hardcoded table. It asks the loaded game, so what it
+// answers with depends on which datastore is up - only that it answers at
+// all, spells every type, and puts the commonest first, is fixed.
+func TestPromosEndpoint(t *testing.T) {
+	if len(mtgmatcher.AllPromoTypes()) == 0 {
+		t.Skip("no datastore loaded; skipping promo endpoint test")
+	}
+
+	paletteService.BuildPromosCache()
+
+	rec := httptest.NewRecorder()
+	paletteService.Promos(rec, httptest.NewRequest(http.MethodGet, "/api/palette/promos.json", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Cache-Control"); got == "no-store" {
+		t.Fatal("cache never warmed, so the endpoint served an empty list")
+	}
+
+	var promos []palette.Promo
+	if err := json.Unmarshal(rec.Body.Bytes(), &promos); err != nil {
+		t.Fatal(err)
+	}
+	if len(promos) != len(mtgmatcher.AllPromoTypes()) {
+		t.Errorf("served %d types, the game declares %d", len(promos), len(mtgmatcher.AllPromoTypes()))
+	}
+
+	for _, promo := range promos {
+		if promo.Value == "" || promo.Label == "" {
+			t.Errorf("%+v has no value or no label", promo)
+		}
+		// The value is what an is: query carries, so it has to survive
+		// being typed: one word, no capitals.
+		if mtgmatcher.PromoTypeSlug(promo.Value) != promo.Value {
+			t.Errorf("value %q is not a token a query can carry", promo.Value)
+		}
+	}
+
+	// Commonest first, so a caller showing only the head shows the types
+	// most of the game wears.
+	for i := 1; i < len(promos); i++ {
+		if promos[i-1].Count < promos[i].Count {
+			t.Errorf("%q (%d) sorts before %q (%d)",
+				promos[i-1].Value, promos[i-1].Count, promos[i].Value, promos[i].Count)
+			break
+		}
+	}
+
+	// A shorthand is offered beside the type it stands for, so the guide can
+	// show "is:bf" without a table of its own.
+	for _, promo := range promos {
+		if promo.Value != "boosterfun" {
+			continue
+		}
+		for _, shorthand := range []string{"bf", "v"} {
+			if !slices.Contains(promo.Aliases, shorthand) {
+				t.Errorf("boosterfun does not offer the shorthand %q (got %v)", shorthand, promo.Aliases)
+			}
+		}
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -656,7 +656,12 @@ func uuid2card(cardId string, useThumbs, genPrints, preferFlavorName bool) Gener
 				variant += strings.ToUpper(promoType) + " "
 				continue
 			}
-			variant += mtgmatcher.Title(promoType) + " "
+			// The promo type is a token so that it can be typed into a
+			// search, which cost it the spaces: title-casing it back gives
+			// "Bestof" where the storefront wrote "Best Of". Ask the game
+			// how it is spelled - Magic keeps no fuller spelling and falls
+			// back to the same title-casing, so nothing there moves.
+			variant += mtgmatcher.PromoTypeLabel(promoType) + " "
 		}
 	}
 	variant = strings.TrimSpace(variant)


### PR DESCRIPTION
Two commits. The first is backend-only; the second is the visible fix for the
Teemo report that started this.

## 1. `/api/palette/promos.json` — serve the list instead of shipping it

`js/guide-data.js` carries a table of **50 Magic promo types and shorthands**,
shipped to every page of every site via `base.html`. On riftbound.mtgban.com and
onepiece.mtgban.com it describes a game that isn't loaded, and no amount of
hand-editing keeps three games right.

The endpoint answers from the datastore that's actually up:

```json
[
  {"value":"universesbeyond","label":"Universesbeyond","count":17183},
  {"value":"boosterfun","label":"Boosterfun","count":15694,"aliases":["bf","v"]},
  {"value":"promopack","label":"Promopack","count":5187,"aliases":["pp"]}
]
```

Magic answers with its 129 types, Riftbound with 10, One Piece with 464 — the
endpoint knows about none of them, which is the point.

- **`value`** is the token an `is:` query carries, asserted to survive being
  typed (one word, no capitals).
- **`count`** is computed in one pass over the printings, and sorts commonest
  first — so a caller showing only the head shows the types most of the game
  wears. That's what makes One Piece's 464 usable.
- **`aliases`** stay in `isKnownPromo` and are handed to the service rather than
  duplicated: they're search syntax, not datastore knowledge.

Cached and rebuilt on datastore load beside the sets cache, and serves
`no-store` + `[]` while cold rather than letting a browser keep an empty answer
for an hour — the same guard `Sets` uses.

**Nothing renders this yet.** The guide and palette JS are untouched; that's
phase 3.

## 2. The label — the actual Teemo fix

A promo type is a token so it can be typed, which cost it the spaces.
Title-casing it back gives `Bestof`, and
`Premiumcardcollectionbestselectionvol6` for an event with a name — so the three
Teemo printings sharing collector number #263 would be told apart by a label
nobody can read.

One line, at the one call site every game reaches:

```go
variant += mtgmatcher.PromoTypeLabel(promoType) + " "
```

**Magic renders exactly as before** — its types are tokens at the source, it
keeps no fuller spelling, and `PromoTypeLabel` falls back to the same
title-casing. Verified rather than assumed: all **129** Magic promo types
compared, **0** render differently.

The other three `Title(promoType)` call sites stay as they are. One trims a
`foil` suffix off the token before showing it, so it needs the token; the other
two sit behind `altFoilTags`, a Magic-only list of foil treatments.

## Verified

`TestPromosEndpoint` drives the real handler against the loaded Magic datastore:
every type spelled, every value a valid query token, sort order checked,
`boosterfun` confirmed to offer `bf` and `v`. Full `go test ./...` green.

## Note for phase 3

The hardcoded table carries *descriptions* — "Judge Gift program", "Buy-a-Box
promo" — richer than anything derivable from a token. The front end should keep
a small description map keyed by value for Magic rather than expecting the
endpoint to supply prose. This is authoritative for *which* types exist and how
common they are; it isn't a glossary.