### PR TITLE
palette: Offer the loaded game's promo types, not a written list

### DIFF
--- a/js/palette-providers.js
+++ b/js/palette-providers.js
@@ -216,6 +216,13 @@
     });
 
     // Property tags (is: and not: share the same list)
+    // Property tags (is: and not: share the same list).
+    //
+    // These are the predicates the search implements itself - a reserved-list
+    // check, a frame, a land cycle - so they are written out here. The promo
+    // types are not: every game declares its own, and there are 129 of them
+    // in Magic alone, so they are fetched from the datastore that is loaded
+    // and appended below.
     var isTagOptions = [
         { value: 'reserved', label: 'Reserved List', group: 'Legal' },
         { value: 'token', label: 'Token', group: 'Generic' },
@@ -249,66 +256,57 @@
         { value: 'power9', label: 'Power 9', sublabel: 'p9', group: 'Known sets' },
         { value: 'abu4h', label: 'ABU + 4 Horsemen', group: 'Known sets' },
         { value: 'promo', label: 'Any promo', group: 'Promo' },
-        { value: 'prerelease', label: 'Prerelease', sublabel: 'pre', group: 'Promo' },
-        { value: 'promopack', label: 'Promo Pack', sublabel: 'pp', group: 'Promo' },
-        { value: 'buyabox', label: 'Buy-a-Box', sublabel: 'bab', group: 'Promo' },
-        { value: 'bundle', label: 'Bundle', group: 'Promo' },
-        { value: 'release', label: 'Release / launch', group: 'Promo' },
-        { value: 'draftweekend', label: 'Draft Weekend', group: 'Promo' },
-        { value: 'gameday', label: 'Game Day', group: 'Promo' },
-        { value: 'fnm', label: 'Friday Night Magic', group: 'Promo' },
-        { value: 'judgegift', label: 'Judge Gift', sublabel: 'judge', group: 'Promo' },
-        { value: 'arenaleague', label: 'Arena League', sublabel: 'arena', group: 'Promo' },
-        { value: 'playerrewards', label: 'Player Rewards', sublabel: 'mpr', group: 'Promo' },
-        { value: 'wizardsplaynetwork', label: 'WPN / Gateway', group: 'Promo' },
-        { value: 'storechampionship', label: 'Store Championship', group: 'Promo' },
-        { value: 'convention', label: 'Convention', group: 'Promo' },
-        { value: 'tourney', label: 'Tournament', group: 'Promo' },
-        { value: 'intropack', label: 'Intro Pack', group: 'Promo' },
-        { value: 'starterdeck', label: 'Starter Deck', group: 'Promo' },
-        { value: 'glossy', label: 'Glossy', group: 'Promo' },
-        { value: 'serialized', label: 'Serialized', group: 'Promo' },
-        { value: 'concept', label: 'Concept art', group: 'Promo' },
-        { value: 'poster', label: 'Poster art', group: 'Promo' },
-        { value: 'scroll', label: 'Scroll', group: 'Promo' },
-        { value: 'schinesealtart', label: 'S-Chinese alt art', group: 'Promo' },
-        { value: 'draculaseries', label: 'Dracula series', group: 'Promo' },
-        { value: 'godzillaseries', label: 'Godzilla series', group: 'Promo' },
-        { value: 'ruderiders', label: 'Rude Riders', group: 'Promo' },
-        { value: 'boosterfun', label: 'Booster Fun', sublabel: 'bf', group: 'Promo' },
-        { value: 'altfoil', label: 'Any special foil', group: 'Foil' },
-        { value: 'surgefoil', label: 'Surge foil', sublabel: 'surge', group: 'Foil' },
-        { value: 'galaxyfoil', label: 'Galaxy foil', sublabel: 'galaxy', group: 'Foil' },
-        { value: 'ripplefoil', label: 'Ripple foil', sublabel: 'ripple', group: 'Foil' },
-        { value: 'rainbowfoil', label: 'Rainbow foil', sublabel: 'rainbow', group: 'Foil' },
-        { value: 'raisedfoil', label: 'Raised foil', sublabel: 'raised', group: 'Foil' },
-        { value: 'halofoil', label: 'Halo foil', sublabel: 'halo', group: 'Foil' },
-        { value: 'manafoil', label: 'Mana foil', sublabel: 'mana', group: 'Foil' },
-        { value: 'silverfoil', label: 'Silver foil', sublabel: 'silver', group: 'Foil' },
-        { value: 'fracturefoil', label: 'Fracture foil', sublabel: 'fracture', group: 'Foil' },
-        { value: 'confettifoil', label: 'Confetti foil', sublabel: 'confetti', group: 'Foil' },
-        { value: 'neonink', label: 'Neon Ink', sublabel: 'neon', group: 'Foil' },
-        { value: 'gilded', label: 'Gilded foil', group: 'Foil' },
-        { value: 'textured', label: 'Textured foil', group: 'Foil' },
-        { value: 'oilslick', label: 'Oil Slick foil', group: 'Foil' },
-        { value: 'invisibleink', label: 'Invisible Ink foil', group: 'Foil' },
-        { value: 'doubleexposure', label: 'Double Exposure', group: 'Foil' },
-        { value: 'doublerainbow', label: 'Double Rainbow', group: 'Foil' },
-        { value: 'stepandcompleat', label: 'Step-and-Compleat', group: 'Foil' },
-        { value: 'embossed', label: 'Embossed foil', group: 'Foil' },
-        { value: 'thick', label: 'Thick display', sublabel: 'thicc', group: 'Foil' }
+        { value: 'altfoil', label: 'Any special foil', group: 'Foil' }
     ];
+    // Promo types come from the loaded game rather than from a list written
+    // for one of them. Until the answer arrives the predicates above stand on
+    // their own, and if it never arrives they still do.
+    var promoTagsMerged = false;
+    var promosFetching = null;
+    function ensurePromoTags() {
+        if (promoTagsMerged || promosFetching) return promosFetching;
+        promosFetching = fetch('/api/palette/promos.json')
+            .then(function (r) { return r.ok ? r.json() : []; })
+            .then(function (data) { mergePromoTags(data); })
+            .catch(function () { mergePromoTags([]); });
+        return promosFetching;
+    }
+    function mergePromoTags(promos) {
+        promoTagsMerged = true;
+        promosFetching = null;
+        var seen = {};
+        for (var i = 0; i < isTagOptions.length; i++) seen[isTagOptions[i].value] = true;
+        for (var j = 0; j < (promos || []).length; j++) {
+            var promo = promos[j];
+            if (!promo || !promo.value || seen[promo.value]) continue;
+            seen[promo.value] = true;
+            isTagOptions.push({
+                value: promo.value,
+                label: promo.label || promo.value,
+                sublabel: (promo.aliases || []).join(' '),
+                group: 'Promo'
+            });
+        }
+        fireOnDataReady();
+    }
+
     register({
         prefix: 'is:',
         name: 'Has Tag',
         icon: 'tag',
-        getCandidates: function (query) { return filterEntries(isTagOptions, query); }
+        getCandidates: function (query) {
+            ensurePromoTags();
+            return filterEntries(isTagOptions, query);
+        }
     });
     register({
         prefix: 'not:',
         name: "Doesn't Have Tag",
         icon: 'tag',
-        getCandidates: function (query) { return filterEntries(isTagOptions, query); }
+        getCandidates: function (query) {
+            ensurePromoTags();
+            return filterEntries(isTagOptions, query);
+        }
     });
 
     // Skip

--- a/templates/guide.html
+++ b/templates/guide.html
@@ -201,6 +201,85 @@
         }
     }
 
+    // ── Promo types, from the loaded game ──
+    //
+    // The table above lists the predicates the search implements itself, and
+    // describes them. The promo types are the datastore's, and every game
+    // declares its own - 129 in Magic, 464 in One Piece - so they are asked
+    // for rather than written down. If the request fails the page keeps the
+    // table it rendered.
+    var MAX_PROMOS_LISTED = 50;
+    fetch('/api/palette/promos.json')
+        .then(function(r) { return r.ok ? r.json() : []; })
+        .then(function(promos) {
+            if (!promos || !promos.length) return;
+            var section = document.getElementById('promos');
+            if (!section) return;
+
+            var offered = {};
+            for (var o = 0; o < promos.length; o++) {
+                offered[promos[o].value] = true;
+                var alias = promos[o].aliases || [];
+                for (var a = 0; a < alias.length; a++) offered[alias[a]] = true;
+            }
+
+            // The written table describes the predicates the search
+            // implements itself, which every game has, plus promo types that
+            // only Magic has. Drop the rows naming a type the loaded game
+            // does not declare, so the guide stops describing another game.
+            var PREDICATES = { promo: true, altfoil: true };
+            var described = {};
+            var staticRows = section.querySelectorAll('.guide-table tbody tr');
+            for (var i = 0; i < staticRows.length; i++) {
+                var code = staticRows[i].querySelector('code');
+                if (!code) continue;
+                var listed = code.textContent.split('/');
+                var keep = false;
+                for (var j = 0; j < listed.length; j++) {
+                    var name = listed[j].trim();
+                    if (PREDICATES[name] || offered[name]) keep = true;
+                }
+                if (!keep) {
+                    staticRows[i].parentNode.removeChild(staticRows[i]);
+                    continue;
+                }
+                for (var k2 = 0; k2 < listed.length; k2++) {
+                    described[listed[k2].trim()] = true;
+                }
+            }
+
+            var rows = [];
+            for (var k = 0; k < promos.length && rows.length < MAX_PROMOS_LISTED; k++) {
+                if (described[promos[k].value]) continue;
+                rows.push(promos[k]);
+            }
+            if (!rows.length) return;
+
+            var html = '<h4 class="guide-examples-heading">Promo types in this game</h4>';
+            html += '<p>' + promos.length + ' in total, commonest first';
+            if (promos.length > rows.length + Object.keys(described).length) {
+                html += ' - type in the palette to reach the rest';
+            }
+            html += '.</p>';
+            html += '<table class="guide-table">';
+            html += '<thead><tr><th>Option</th><th>Description</th></tr></thead><tbody>';
+            for (var m = 0; m < rows.length; m++) {
+                var value = rows[m].value;
+                if (rows[m].aliases && rows[m].aliases.length) {
+                    value += ' / ' + rows[m].aliases.join(' / ');
+                }
+                html += '<tr><td><code>' + escapeHtml(value) + '</code></td>';
+                html += '<td>' + escapeHtml(rows[m].label || rows[m].value)
+                     + ' (' + rows[m].count + ')</td></tr>';
+            }
+            html += '</tbody></table>';
+
+            var block = document.createElement('div');
+            block.innerHTML = html;
+            section.appendChild(block);
+        })
+        .catch(function() {});
+
     // ── Scroll spy ──
     var navLinks = sidebarNav.querySelectorAll('.guide-nav-link');
     var sectionEls = sectionsContainer.querySelectorAll('.guide-section');


### PR DESCRIPTION
Phase 3 — the front end finally reads the endpoint from #334. Verified in a
browser against a locally running site, not by inspection.

## What was hardcoded

Two lists, both Magic, both shipped to every site:

| where | entries |
|---|---|
| `js/palette-providers.js` → `isTagOptions` | **80** |
| `js/guide-data.js` → the `is:` table | **49 rows** |

On riftbound.mtgban.com and onepiece.mtgban.com most of those name nothing.

## The split that matters

Only *part* of each list was ever promo types. Measured against the datastore:
**47 of the 80** chip entries are promo types; the other **33** are predicates
the search implements itself — `reserved`, `token`, `foil`, `fullart`,
`borderless`, `dual`, `fetchland`, `power9`, `abu4h`. Nothing in a datastore
declares those, so they stay written down.

The promo types are asked for instead.

## Result, measured live

Chip dropdown, Magic:

```
before:  80 entries  (33 predicates + 47 promo types)
after:  162 entries  (33 predicates + 129 promo types)
groups: Legal 1, Generic 10, Frame 7, Language 2, Land cycle 9,
        Known sets 2, Foil 1, Promo 130
sample: boosterfun = Boosterfun [bf v]
```

**It offered 47 of Magic's 129 promo types; it now offers all of them**, with
the shorthands beside them — and the other games get their own instead of
Magic's.

Guide page, Magic: the 49 written rows are kept (every one names a type Magic
declares), followed by a generated table — *"129 in total, commonest first -
type in the palette to reach the rest"*, capped at 50 rows with printing counts.
On another game, the rows describing types it doesn't declare are dropped
instead.

## Fallbacks

If the request never answers, both fall back to the predicates alone rather than
to another game's promos. The guide keeps whatever it rendered.

## Verified

Ran the site locally against the Magic datastore and drove both surfaces in a
browser: the endpoint served 129 types, the guide rendered both tables with the
right note, and `getProvider('is:')` returned 162 candidates with labels and
aliases. Full `go test ./...` green; `node --check` on the changed JS.