### PR TITLE
Follow go-mtgban's renames

### DIFF
--- a/api.go
+++ b/api.go
@@ -65,7 +65,7 @@ func getDirectQty(ctx context.Context, cardId string) ([]tcgplayer.ListingData, 
 		return nil, err
 	}
 
-	return tcgplayer.GetDirectQtysForProductId(ctx, tcgId, true), nil
+	return tcgplayer.GetDirectQtysForProductID(ctx, tcgId, true), nil
 }
 
 func getDecklist(uuid string) ([]string, error) {
@@ -186,7 +186,7 @@ func UUID2SCGCSV(w *csv.Writer, ids, qtys []string) error {
 		if !found {
 			continue
 		}
-		productId := blEntries[0].InstanceId
+		productId := blEntries[0].InstanceID
 		name := blEntries[0].CustomFields["SCGName"]
 		edition := blEntries[0].CustomFields["SCGEdition"]
 		language := blEntries[0].CustomFields["SCGLanguage"]

--- a/api_banprice.go
+++ b/api_banprice.go
@@ -252,7 +252,7 @@ func PriceAPI(w http.ResponseWriter, r *http.Request) {
 				// Check for nonfoil, foil, etched
 				[]bool{false, false}, []bool{true, false}, []bool{false, true},
 			} {
-				uuid, err := mtgmatcher.MatchId(base, opts...)
+				uuid, err := mtgmatcher.MatchID(base, opts...)
 				if err != nil {
 					continue
 				}

--- a/api_csv_test.go
+++ b/api_csv_test.go
@@ -33,7 +33,7 @@ func TestSimplePrice2CSVTCGSKU(t *testing.T) {
 	// One SKU per condition, so a wrong condition would pick the wrong one
 	inventory := mtgban.InventoryRecord{}
 	for cond, sku := range map[string]string{"NM": "111", "SP": "222"} {
-		inventory.Add(id, &mtgban.InventoryEntry{Conditions: cond, InstanceId: sku})
+		inventory.Add(id, &mtgban.InventoryEntry{Conditions: cond, InstanceID: sku})
 	}
 	prev := sellersPtr.Load()
 	t.Cleanup(func() { sellersPtr.Store(prev) })

--- a/arbit.go
+++ b/arbit.go
@@ -292,7 +292,7 @@ func init() {
 func arbitCardIds(entries []mtgban.ArbitEntry) []string {
 	cardIds := make([]string, len(entries))
 	for i := range entries {
-		cardIds[i] = entries[i].CardId
+		cardIds[i] = entries[i].CardID
 	}
 	return cardIds
 }
@@ -339,18 +339,18 @@ func arbitLess(entries []mtgban.ArbitEntry, mode string, globalMode, preferFlavo
 	case "edition":
 		sortData := resolveSortingData(arbitCardIds(entries))
 		return func(a, b *mtgban.ArbitEntry) bool {
-			if a.CardId == b.CardId {
+			if a.CardID == b.CardID {
 				return a.InventoryEntry.Conditions < b.InventoryEntry.Conditions
 			}
-			return cmpSets(sortData[a.CardId], sortData[b.CardId])
+			return cmpSets(sortData[a.CardID], sortData[b.CardID])
 		}
 	case "alpha":
 		sortData := resolveSortingData(arbitCardIds(entries))
 		return func(a, b *mtgban.ArbitEntry) bool {
-			if a.CardId == b.CardId {
+			if a.CardID == b.CardID {
 				return a.InventoryEntry.Conditions < b.InventoryEntry.Conditions
 			}
-			return cmpSetsAlphabetical(sortData[a.CardId], sortData[b.CardId], preferFlavor)
+			return cmpSetsAlphabetical(sortData[a.CardID], sortData[b.CardID], preferFlavor)
 		}
 	}
 	return nil
@@ -871,9 +871,9 @@ func scraperCompare(w http.ResponseWriter, r *http.Request, pageVars PageVars, a
 
 			tcgMarket, _ := findSellerInventory("TCGMarket")
 			for _, res := range arbit {
-				isSussy := invalidDirectIn(tcgMarket, res.CardId, res.ReferenceEntry.Price)
+				isSussy := invalidDirectIn(tcgMarket, res.CardID, res.ReferenceEntry.Price)
 				if isSussy {
-					sussy[res.CardId] = tcgMarketPriceIn(tcgMarket, res.CardId)
+					sussy[res.CardID] = tcgMarketPriceIn(tcgMarket, res.CardID)
 				}
 			}
 		}
@@ -881,9 +881,9 @@ func scraperCompare(w http.ResponseWriter, r *http.Request, pageVars PageVars, a
 			sussy = map[string]float64{}
 
 			for _, res := range arbit {
-				iqr := getTCGSimulationIQR(res.CardId)
+				iqr := getTCGSimulationIQR(res.CardID)
 				if iqr > 150 {
-					sussy[res.CardId] = iqr
+					sussy[res.CardID] = iqr
 				}
 			}
 		}
@@ -930,7 +930,7 @@ func scraperCompare(w http.ResponseWriter, r *http.Request, pageVars PageVars, a
 
 		pageVars.Arb = append(pageVars.Arb, entry)
 		for i := range arbit {
-			cardId := arbit[i].CardId
+			cardId := arbit[i].CardID
 			_, found := pageVars.Metadata[cardId]
 			if found {
 				continue

--- a/arbit_bestof_test.go
+++ b/arbit_bestof_test.go
@@ -30,7 +30,7 @@ func renderArbit(t *testing.T, pageVars PageVars) string {
 func arbitPageVars() PageVars {
 	entry := func(id string, sell, buy, diff, spread float64) mtgban.ArbitEntry {
 		return mtgban.ArbitEntry{
-			CardId:         id,
+			CardID:         id,
 			InventoryEntry: mtgban.InventoryEntry{Price: sell, Conditions: "NM", Quantity: 1},
 			BuylistEntry:   mtgban.BuylistEntry{BuyPrice: buy},
 			Difference:     diff,

--- a/chart_resolve.go
+++ b/chart_resolve.go
@@ -122,7 +122,7 @@ func matcherTarget(ctx context.Context, id string) (*chartTarget, error) {
 	co, err := mtgmatcher.GetUUID(id)
 	if err != nil {
 		// Not a direct mtgmatcher id; try the external id map (Scryfall/TCGplayer).
-		if matched, merr := mtgmatcher.MatchId(id); merr == nil {
+		if matched, merr := mtgmatcher.MatchID(id); merr == nil {
 			co, err = mtgmatcher.GetUUID(matched)
 		}
 	}
@@ -339,7 +339,7 @@ func tcgFinishIDForSubType(co *mtgmatcher.CardObject, subTypes map[string]int64,
 	if id, ok := co.FoilUUIDs[mtgmatcher.FinishFoil]; ok {
 		return id
 	}
-	if id, err := mtgmatcher.MatchId(co.UUID, true); err == nil {
+	if id, err := mtgmatcher.MatchID(co.UUID, true); err == nil {
 		return id
 	}
 	return co.UUID
@@ -351,7 +351,7 @@ func tcgFinishIDForSubType(co *mtgmatcher.CardObject, subTypes map[string]int64,
 // product with no card), or when the card has no finish for the variant's
 // sub-type — charting the wrong finish is worse than charting nothing.
 func tcgVariantSearchID(ctx context.Context, vi timeseries.VariantInfo) (string, bool) {
-	matched, err := mtgmatcher.MatchId(strconv.Itoa(vi.TCGProductID))
+	matched, err := mtgmatcher.MatchID(strconv.Itoa(vi.TCGProductID))
 	if err != nil {
 		return "", false
 	}
@@ -395,7 +395,7 @@ func tcgProductID(co *mtgmatcher.CardObject) (int, bool) {
 // Magic TCGplayer ids), otherwise a non-Magic product in the variants table.
 func targetFromTCGID(ctx context.Context, tcgID int) (*chartTarget, error) {
 	idStr := strconv.Itoa(tcgID)
-	if matched, err := mtgmatcher.MatchId(idStr); err == nil {
+	if matched, err := mtgmatcher.MatchID(idStr); err == nil {
 		if co, err := mtgmatcher.GetUUID(matched); err == nil {
 			return &chartTarget{
 				UUID: co.UUID, Foil: co.Foil, Etched: co.Etched, Name: co.Name,

--- a/chart_resolve_test.go
+++ b/chart_resolve_test.go
@@ -174,7 +174,7 @@ func TestMagicFinishSearchID(t *testing.T) {
 		if err != nil || co.Sealed || co.Foil || co.Etched {
 			continue
 		}
-		alt, err := mtgmatcher.MatchId(id, true)
+		alt, err := mtgmatcher.MatchID(id, true)
 		if err != nil || alt == id {
 			continue
 		}

--- a/discord.go
+++ b/discord.go
@@ -320,7 +320,7 @@ var AffiliateStores []AffiliateConfig = []AffiliateConfig{
 					break
 				}
 			}
-			cardId, err := mtgmatcher.MatchId(id, v.Get("Printing") == "Foil")
+			cardId, err := mtgmatcher.MatchID(id, v.Get("Printing") == "Foil")
 			if err != nil {
 				return "Your search"
 			}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/lib/pq v1.11.1
 	github.com/mackerelio/go-osstat v0.2.4
 	github.com/mileusna/useragent v1.3.5
-	github.com/mtgban/go-mtgban v0.7.8
+	github.com/mtgban/go-mtgban v0.7.10-0.20260822114729-1a8715a3e184
 	github.com/mtgban/simplecloud v0.0.11
 	github.com/xuri/excelize/v2 v2.11.0
 	golang.org/x/oauth2 v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,8 @@ github.com/mroth/weightedrand/v2 v2.1.0 h1:o1ascnB1CIVzsqlfArQQjeMy1U0NcIbBO5rfd
 github.com/mroth/weightedrand/v2 v2.1.0/go.mod h1:f2faGsfOGOwc1p94wzHKKZyTpcJUW7OJ/9U4yfiNAOU=
 github.com/mtgban/go-mtgban v0.7.8 h1:MkXstY8s3Hzuez4qmoFeHXimrhV/G1XP2Euy5F8Op14=
 github.com/mtgban/go-mtgban v0.7.8/go.mod h1:4qvfc2fe5KLGYgb808rT85Jpg7R5fcYtrKDgMu9x7B8=
+github.com/mtgban/go-mtgban v0.7.10-0.20260822114729-1a8715a3e184 h1:MWO0Qgiwry+s1hjSiD9UGTC03icROP6H058nTvH8F5E=
+github.com/mtgban/go-mtgban v0.7.10-0.20260822114729-1a8715a3e184/go.mod h1:4qvfc2fe5KLGYgb808rT85Jpg7R5fcYtrKDgMu9x7B8=
 github.com/mtgban/go-tcgplayer v0.1.0 h1:jHrqn8dA6O8Y0eDftsBdz7YrdHVLYgezwGF2JV+8MzQ=
 github.com/mtgban/go-tcgplayer v0.1.0/go.mod h1:KaXcyjC/Y1M9itmWcjGcZi0ao40RkHAGua1nLML+4xA=
 github.com/mtgban/simplecloud v0.0.11 h1:KkMyHnLtWVuypnasJeE/eTm3LIx0lCvwHQUwghS+gHI=

--- a/internal/docparse/docparse.go
+++ b/internal/docparse/docparse.go
@@ -409,7 +409,7 @@ func (p *Parser) ParseRow(indexMap map[string]int, record []string) (Entry, erro
 
 	idx, found = indexMap["id"]
 	if found && idx < len(record) {
-		res.Card.Id = record[idx]
+		res.Card.ID = record[idx]
 	}
 
 	// Try looking up using the TCGSkuId if we found an id and it's not among
@@ -419,7 +419,7 @@ func (p *Parser) ParseRow(indexMap map[string]int, record []string) (Entry, erro
 	idx, found = indexMap["tcgSku"]
 	if found && idx < len(record) && p.TCGSkuToUUID != nil {
 		tcgSkuId = record[idx]
-		res.Card.Id = p.TCGSkuToUUID(tcgSkuId)
+		res.Card.ID = p.TCGSkuToUUID(tcgSkuId)
 	}
 
 	res.Card.Name = record[indexMap["cardName"]]

--- a/news.go
+++ b/news.go
@@ -332,7 +332,7 @@ func getResults(db *sql.DB, query string) ([]NewspaperResult, error) {
 
 		// Override a few fields for better integration with the site
 		if db == NewNewspaperDB {
-			uuid, err := mtgmatcher.MatchId(raw[1], raw[6] != "Normal")
+			uuid, err := mtgmatcher.MatchID(raw[1], raw[6] != "Normal")
 			if err != nil {
 				LogPages["Newspaper"].Println("match", raw[1], raw[6], "as", raw[3], raw[4], raw[5], "failed:", err)
 				continue
@@ -1186,7 +1186,7 @@ func Newspaper(w http.ResponseWriter, r *http.Request) {
 					URL:        entry.URL,
 				}
 				arbit = append(arbit, mtgban.ArbitEntry{
-					CardId:         cardId,
+					CardID:         cardId,
 					InventoryEntry: converted,
 					Quantity:       entry.Quantity,
 				})
@@ -1197,18 +1197,18 @@ func Newspaper(w http.ResponseWriter, r *http.Request) {
 		default:
 			sortData := resolveSortingData(arbitCardIds(arbit))
 			sort.Slice(arbit, func(i, j int) bool {
-				if arbit[i].CardId == arbit[j].CardId {
+				if arbit[i].CardID == arbit[j].CardID {
 					return arbit[i].InventoryEntry.Conditions < arbit[j].InventoryEntry.Conditions
 				}
-				return cmpSets(sortData[arbit[i].CardId], sortData[arbit[j].CardId])
+				return cmpSets(sortData[arbit[i].CardID], sortData[arbit[j].CardID])
 			})
 		case "alpha":
 			sortData := resolveSortingData(arbitCardIds(arbit))
 			sort.Slice(arbit, func(i, j int) bool {
-				if arbit[i].CardId == arbit[j].CardId {
+				if arbit[i].CardID == arbit[j].CardID {
 					return arbit[i].InventoryEntry.Conditions < arbit[j].InventoryEntry.Conditions
 				}
-				return cmpSetsAlphabetical(sortData[arbit[i].CardId], sortData[arbit[j].CardId], preferFlavor)
+				return cmpSetsAlphabetical(sortData[arbit[i].CardID], sortData[arbit[j].CardID], preferFlavor)
 			})
 		case "available":
 			sort.Slice(arbit, func(i, j int) bool {
@@ -1231,11 +1231,11 @@ func Newspaper(w http.ResponseWriter, r *http.Request) {
 		// runs to tens of thousands of cards and all the template reads are
 		// keyed by the paginated entries.
 		for _, entry := range arbit {
-			_, found := pageVars.Metadata[entry.CardId]
+			_, found := pageVars.Metadata[entry.CardID]
 			if found {
 				continue
 			}
-			pageVars.Metadata[entry.CardId] = uuid2card(entry.CardId, true, false, preferFlavor)
+			pageVars.Metadata[entry.CardID] = uuid2card(entry.CardID, true, false, preferFlavor)
 		}
 
 		entry := Arbitrage{

--- a/product.go
+++ b/product.go
@@ -765,7 +765,7 @@ func runSealedAnalysis() {
 
 	// Index every TCGplayer SKU (singles + sealed) to its card so callers can
 	// resolve a SKU in O(1) instead of scanning the whole inventory. The entry
-	// is keyed by its InstanceId (SKU); the card uuid is stashed in OriginalId,
+	// is keyed by its InstanceID (SKU); the card uuid is stashed in OriginalID,
 	// and Price/Conditions are preserved for callers that need them.
 	tcgSealed, _ := findSellerInventory("TCGSealed")
 	tcgPlayer, _ := findSellerInventory("TCGPlayer")
@@ -773,11 +773,11 @@ func runSealedAnalysis() {
 	for _, inv := range []mtgban.InventoryRecord{tcgPlayer, tcgSealed} {
 		for uuid, entries := range inv {
 			for _, entry := range entries {
-				if entry.InstanceId == "" {
+				if entry.InstanceID == "" {
 					continue
 				}
-				entry.OriginalId = uuid
-				skuIndex.Add(entry.InstanceId, &entry)
+				entry.OriginalID = uuid
+				skuIndex.Add(entry.InstanceID, &entry)
 			}
 		}
 	}

--- a/screener.go
+++ b/screener.go
@@ -477,7 +477,7 @@ func Screener(w http.ResponseWriter, r *http.Request) {
 
 	for _, res := range paged {
 		// DB uuid is finish-agnostic; resolve the priced foil/etched variant.
-		cardId, err := mtgmatcher.MatchId(res.UUID, res.IsFoil, res.IsEtched)
+		cardId, err := mtgmatcher.MatchID(res.UUID, res.IsFoil, res.IsEtched)
 		if err != nil {
 			cardId = res.UUID
 		}

--- a/search.go
+++ b/search.go
@@ -158,7 +158,7 @@ func isValidChartID(part string) bool {
 // back to the search always lands on the nonfoil printing. Falls back to the
 // uuid when the finish has no id of its own.
 func magicFinishSearchID(uuid string, foil, etched bool) string {
-	if matched, err := mtgmatcher.MatchId(uuid, foil, etched); err == nil {
+	if matched, err := mtgmatcher.MatchID(uuid, foil, etched); err == nil {
 		return matched
 	}
 	return uuid
@@ -217,7 +217,7 @@ func chartIDToSearchID(ctx context.Context, id string) (string, bool) {
 
 	// tcg:, scryfall:, mtgjson:, or a bare id mtgmatcher maps through its external
 	// id table (a TCGplayer product id, a Scryfall id, or an mtgjson uuid).
-	if matched, merr := mtgmatcher.MatchId(val); merr == nil {
+	if matched, merr := mtgmatcher.MatchID(val); merr == nil {
 		return matched, true
 	}
 	return id, false
@@ -829,7 +829,7 @@ func Search(w http.ResponseWriter, r *http.Request) {
 			if err == nil {
 				var link string
 
-				game := cardmarket.GameIdFromName(Config.Game)
+				game := cardmarket.GameFromName(Config.Game)
 				id, err := strconv.Atoi(co.Identifiers["mcmId"])
 				if err != nil || id == 0 {
 					// Cardmarket names the game in every product path, so the
@@ -1041,7 +1041,7 @@ func Search(w http.ResponseWriter, r *http.Request) {
 			co, gerr := mtgmatcher.GetUUID(searchId)
 			if gerr == nil && !co.Sealed {
 				altId, err := mtgmatcher.Match(&mtgmatcher.InputCard{
-					Id:   searchId,
+					ID:   searchId,
 					Foil: !co.Foil,
 				})
 				if err == nil && altId != searchId {
@@ -1049,7 +1049,7 @@ func Search(w http.ResponseWriter, r *http.Request) {
 				}
 
 				altId, err = mtgmatcher.Match(&mtgmatcher.InputCard{
-					Id:        searchId,
+					ID:        searchId,
 					Variation: "Etched",
 				})
 				if err == nil && altId != searchId {
@@ -1591,8 +1591,8 @@ func editionsForSearch(allKeys []string) []EditionEntry {
 // addFinishVariants appends id's foil and etched finishes to uuids, skipping
 // any that don't exist, equal id, or are already present.
 func addFinishVariants(uuids []string, id string) []string {
-	foilId, _ := mtgmatcher.MatchId(id, true)
-	etchedId, _ := mtgmatcher.MatchId(id, false, true)
+	foilId, _ := mtgmatcher.MatchID(id, true)
+	etchedId, _ := mtgmatcher.MatchID(id, false, true)
 	for _, otherFinishId := range []string{foilId, etchedId} {
 		if otherFinishId != "" && otherFinishId != id && !slices.Contains(uuids, otherFinishId) {
 			uuids = append(uuids, otherFinishId)

--- a/searchfilter.go
+++ b/searchfilter.go
@@ -1403,7 +1403,7 @@ func findInDeck(sealedUUID, opt string) []string {
 				isEtched := strings.HasSuffix(deck.Name, "etched")
 
 				for _, card := range board {
-					uuid, err := mtgmatcher.MatchId(card.UUID, card.IsFoil, isEtched)
+					uuid, err := mtgmatcher.MatchID(card.UUID, card.IsFoil, isEtched)
 					if err != nil {
 						continue
 					}

--- a/sleep.go
+++ b/sleep.go
@@ -18,7 +18,7 @@ import (
 )
 
 type Sleeper struct {
-	CardId string
+	CardID string
 	Level  int
 }
 
@@ -408,7 +408,7 @@ func getTiers(blocklistRetail, blocklistBuylist, skipEditions []string) map[stri
 
 			// Load the tiers
 			for i := range arbit {
-				tiers[arbit[i].CardId]++
+				tiers[arbit[i].CardID]++
 			}
 		}
 
@@ -417,7 +417,7 @@ func getTiers(blocklistRetail, blocklistBuylist, skipEditions []string) map[stri
 
 			// Load the tiers
 			for i := range mismatch {
-				tiers[mismatch[i].CardId]++
+				tiers[mismatch[i].CardID]++
 			}
 		}
 	}
@@ -466,7 +466,7 @@ func getGap(blocklistRetail []string, ref, target string, skipEditions []string)
 
 	// Filter out entries that are invalid
 	for i := range mismatch {
-		cardId := mismatch[i].CardId
+		cardId := mismatch[i].CardID
 
 		co, err := mtgmatcher.GetUUID(cardId)
 		if err != nil {
@@ -510,7 +510,7 @@ func sleepersLayout(tiers map[string]int) (map[string][]string, error) {
 	for c := range tiers {
 		if tiers[c] > 1 {
 			results = append(results, Sleeper{
-				CardId: c,
+				CardID: c,
 				Level:  tiers[c],
 			})
 		}
@@ -549,7 +549,7 @@ func sleepersLayout(tiers map[string]int) (map[string][]string, error) {
 		level := int(math.Floor(r*exp) + maxrange)
 
 		if DevMode {
-			cc, _ := mtgmatcher.GetUUID(res.CardId)
+			cc, _ := mtgmatcher.GetUUID(res.CardID)
 			log.Println(level, res.Level, cc)
 		}
 
@@ -559,7 +559,7 @@ func sleepersLayout(tiers map[string]int) (map[string][]string, error) {
 
 		letter := SleeperLetters[level]
 
-		sleepers[letter] = append(sleepers[letter], res.CardId)
+		sleepers[letter] = append(sleepers[letter], res.CardID)
 	}
 
 	// Sort sleepers by price

--- a/templates.go
+++ b/templates.go
@@ -155,7 +155,7 @@ var funcMap = template.FuncMap{
 		if !found {
 			return ""
 		}
-		return entries[0].OriginalId
+		return entries[0].OriginalID
 	},
 	"uuid2tcgid": func(s string) string {
 		return findTCGproductId(s)

--- a/templates/arbit.html
+++ b/templates/arbit.html
@@ -207,7 +207,7 @@
                     if (scraper === {{$scraperKey}}) {
                         run = async () => {
                             {{range $entries}}
-                                getDirectQty(null, {{.CardId}});
+                                getDirectQty(null, {{.CardID}});
                                 await delay(1000);
                             {{end}}
                         }
@@ -244,7 +244,7 @@
                 {{range $.Arb}}
                     {{if not .HasNoArbit}}
                         {{$top := index .Arbit 0}}
-                        {{$card := index $.Metadata $top.CardId}}
+                        {{$card := index $.Metadata $top.CardID}}
                         <tr>
                             <td><a class="arb-best-store" href="#{{.Name}}">{{.Name}}</a></td>
                             <td>
@@ -308,7 +308,7 @@
                     {{if eq $sourceKey "CK"}}
                         <form action="https://www.cardkingdom.com/builder?utm_campaign={{load_partner $sourceKey}}&utm_medium=arbit&utm_source={{load_partner $sourceKey}}" method="post" id="{{$sourceKey}}{{$scraperKey}}deckbuilder" style="display: inline;" target="_blank">
                             <input type="hidden" name="partner" value="{{load_partner $sourceKey}}"/>
-                            <input type="hidden" name="c" value="{{range $entries}}{{if .Quantity}}{{.Quantity}}{{else}}1{{end}} {{(index $.Metadata .CardId).Name}}||{{end}}"/>
+                            <input type="hidden" name="c" value="{{range $entries}}{{if .Quantity}}{{.Quantity}}{{else}}1{{end}} {{(index $.Metadata .CardID).Name}}||{{end}}"/>
                             <a class="arb-load-btn buy" href='javascript:void(0)' onclick='document.getElementById("{{$sourceKey}}{{$scraperKey}}deckbuilder").submit();'>Load at {{$sourceKey}}</a>
                             <noscript>
                                 <input type="submit" value="Load at {{$sourceKey}}"/>
@@ -317,7 +317,7 @@
                     {{else if eq $sourceKey "CSI"}}
                         <form action="https://www.coolstuffinc.com/main_deckBuilder.php" method="post" id="{{$sourceKey}}{{$scraperKey}}deckbuilder" style="display: inline;" target="_blank">
                             <input type="hidden" name="partner" value="{{load_partner $sourceKey}}"/>
-                            <input type="hidden" name="sList" value="{{range $entries}}{{if .Quantity}}{{.Quantity}}{{else}}1{{end}} {{(index $.Metadata .CardId).Name}}|{{end}}"/>
+                            <input type="hidden" name="sList" value="{{range $entries}}{{if .Quantity}}{{.Quantity}}{{else}}1{{end}} {{(index $.Metadata .CardID).Name}}|{{end}}"/>
                             <a class="arb-load-btn buy" href='javascript:void(0)' onclick='document.getElementById("{{$sourceKey}}{{$scraperKey}}deckbuilder").submit();'>Load at {{$sourceKey}}</a>
                             <noscript>
                                 <input type="submit" value="Load at {{$sourceKey}}"/>
@@ -326,7 +326,7 @@
                     {{else if has_prefix $sourceKey "TCG"}}
                         <form action='https://api.tcgplayer.com/massentry' method="post" id="{{$sourceKey}}{{$scraperKey}}deckbuilder" style="display: inline;" target="_blank">
                             <input type="hidden" name="affiliateurl" value='https://tcgplayer.pxf.io/c/{{load_partner "TCG"}}/1830156/21018'/>
-                            <input type="hidden" name="c" value="{{range $entries}}{{if .Quantity}}{{.Quantity}}{{else}}1{{end}}-{{uuid2tcgid .CardId}}||{{end}}"/>
+                            <input type="hidden" name="c" value="{{range $entries}}{{if .Quantity}}{{.Quantity}}{{else}}1{{end}}-{{uuid2tcgid .CardID}}||{{end}}"/>
                             <a class="arb-load-btn buy" href='javascript:void(0)' onclick='document.getElementById("{{$sourceKey}}{{$scraperKey}}deckbuilder").submit();'>Load at TCG</a>
                             <noscript>
                                 <input type="submit" value="Load at TCG"/>
@@ -336,7 +336,7 @@
                     {{if eq $sourceKey "MP"}}
                         {{$deck := ""}}
                         {{range $entries}}
-                            {{$card := (index $.Metadata .CardId)}}
+                            {{$card := (index $.Metadata .CardID)}}
                             {{$qty := 1}}
                             {{if .Quantity}}
                                 {{$qty = .Quantity}}
@@ -362,7 +362,7 @@
                             <input type="hidden" name="tag" value="{{$sourceKey}}Retail"/>
                             <input type="hidden" name="mode" value="false"/>
                             {{range $entries}}
-                                <input type="hidden" name="{{$sourceKey}}Retailhashes" value="{{.CardId}}"/>
+                                <input type="hidden" name="{{$sourceKey}}Retailhashes" value="{{.CardID}}"/>
                                 <input type="hidden" name="{{$sourceKey}}RetailhashesQtys" value="{{.Quantity}}"/>
                                 <input type="hidden" name="{{$sourceKey}}RetailhashesCond" value="{{.InventoryEntry.Conditions}}"/>
                             {{end}}
@@ -380,7 +380,7 @@
                                 {"contents": [
                                     {{range $entries}}
                                     {
-                                       "id": {{uuid2ckid .CardId}},
+                                       "id": {{uuid2ckid .CardID}},
                                        "qty": {{if .Quantity}}{{.Quantity}}{{else}}1{{end}}
                                     },
                                     {{end}}
@@ -399,7 +399,7 @@
                             <input type="hidden" name="tag" value="{{$scraperKey}}"/>
                             <input type="hidden" name="mode" value="false"/>
                             {{range $entries}}
-                                <input type="hidden" name="{{$scraperKey}}hashes" value="{{.CardId}}"/>
+                                <input type="hidden" name="{{$scraperKey}}hashes" value="{{.CardID}}"/>
                                 <input type="hidden" name="{{$scraperKey}}hashesQtys" value="{{if .Quantity}}{{.Quantity}}{{else}}1{{end}}"/>
                             {{end}}
                             <a class="arb-load-btn csv" href='javascript:void(0)' onclick='document.getElementById("{{$scraperKey}}{{$sourceKey}}hashes").submit();'>Download {{$scraperKey}} CSV</a>
@@ -476,8 +476,8 @@
                 <tbody>
                 {{$arbitContainer := .}}
                 {{range .Arbit}}
-                    {{$card := (index $.Metadata .CardId)}}
-                    <tr data-arb-id="{{.CardId}}" data-arb-qty="{{if .Quantity}}{{.Quantity}}{{else}}1{{end}}" data-arb-name="{{$card.Name}}" data-arb-cond="{{.InventoryEntry.Conditions}}" data-arb-ckid="{{uuid2ckid .CardId}}" data-arb-tcgid="{{uuid2tcgid .CardId}}" onmouseover="document.getElementById('hoverImage').src='{{$card.ImageURL}}';var hw=document.getElementById('hoverWrap');hw.setAttribute('data-foil','{{$card.Foil}}');hw.setAttribute('data-etched','{{$card.Etched}}');hw.setAttribute('data-set','{{$card.SetCode}}');hw.setAttribute('data-date','{{$card.Date}}');hw.setAttribute('data-name','{{$card.Name}}');hw.classList.toggle('content-warning',{{$card.HasContentWarning}});">
+                    {{$card := (index $.Metadata .CardID)}}
+                    <tr data-arb-id="{{.CardID}}" data-arb-qty="{{if .Quantity}}{{.Quantity}}{{else}}1{{end}}" data-arb-name="{{$card.Name}}" data-arb-cond="{{.InventoryEntry.Conditions}}" data-arb-ckid="{{uuid2ckid .CardID}}" data-arb-tcgid="{{uuid2tcgid .CardID}}" onmouseover="document.getElementById('hoverImage').src='{{$card.ImageURL}}';var hw=document.getElementById('hoverWrap');hw.setAttribute('data-foil','{{$card.Foil}}');hw.setAttribute('data-etched','{{$card.Etched}}');hw.setAttribute('data-set','{{$card.SetCode}}');hw.setAttribute('data-date','{{$card.Date}}');hw.setAttribute('data-name','{{$card.Name}}');hw.classList.toggle('content-warning',{{$card.HasContentWarning}});">
                         <td>
                             <div class="arb-card-cell">
                                 {{template "set-symbol" dict "Keyrune" $card.Keyrune "Code" $card.SetCode "Rarity" $card.Rarity "Color" $card.RarityColor "Foil" $card.Foil "Size" 24 "Class" "set-icon"}}
@@ -497,7 +497,7 @@
                             </td>
                         {{end}}
                         {{if not $save.HasNoQty}}
-                            <td {{if eq $sourceKey "TCGDirect"}}id="qty-{{$sourceKey}}-{{.InventoryEntry.Conditions}}-{{.CardId}}"{{end}}>
+                            <td {{if eq $sourceKey "TCGDirect"}}id="qty-{{$sourceKey}}-{{.InventoryEntry.Conditions}}-{{.CardID}}"{{end}}>
                                 {{.InventoryEntry.Quantity}}
                                 {{if ne .BuylistEntry.Quantity 0}}
                                     / {{.BuylistEntry.Quantity}}
@@ -511,8 +511,8 @@
                             <td class="m">
                                 {{if eq .BuylistEntry.BuyPrice 0.0}}
                                     $ {{printf "%.2f" .ReferenceEntry.Price}}
-                                    {{if (isSussy $arbitContainer.SussyList .CardId)}}
-                                        {{$susPrice := (index $arbitContainer.SussyList .CardId)}}
+                                    {{if (isSussy $arbitContainer.SussyList .CardID)}}
+                                        {{$susPrice := (index $arbitContainer.SussyList .CardID)}}
                                         <span class=emoji title="CAUTION - This price looks a bit off, {{if $sealedSource}}the contents of this product have a very uneven distribution, and simulation or data may be wrong (IQR: {{printf "%.2f" $susPrice}}){{else}}TCG Market is {{if $susPrice}}${{printf "%.2f" $susPrice}}{{else}}missing{{end}}{{end}}">‼️ </span>
                                     {{end}}
                                 {{else}}

--- a/upload.go
+++ b/upload.go
@@ -1517,7 +1517,7 @@ func loadCollectr(ctx context.Context, link string, maxRows int) ([]UploadEntry,
 		// Try matching via TCGplayer product ID first
 		uuid := mtgmatcher.ExternalUUID(item.ProductID)
 		if uuid != "" {
-			cardId, matchErr = mtgmatcher.MatchId(uuid, item.IsFoil)
+			cardId, matchErr = mtgmatcher.MatchID(uuid, item.IsFoil)
 		}
 
 		// Fall back to name-based matching
@@ -1572,14 +1572,14 @@ func loadCollectr(ctx context.Context, link string, maxRows int) ([]UploadEntry,
 // on top.
 func resolveMoxItem(item moxfield.Item) (string, error) {
 	if item.ScryfallID != "" {
-		return mtgmatcher.MatchId(item.ScryfallID, item.IsFoil, item.IsEtched)
+		return mtgmatcher.MatchID(item.ScryfallID, item.IsFoil, item.IsEtched)
 	}
 
 	printings := mtgmatcher.MatchWithNumber(item.Name, strings.ToUpper(item.SetCode), item.Number)
 	if len(printings) == 0 {
 		return "", fmt.Errorf("unknown printing %s (%s) %s", item.Name, item.SetCode, item.Number)
 	}
-	return mtgmatcher.MatchId(printings[0].UUID, item.IsFoil, item.IsEtched)
+	return mtgmatcher.MatchID(printings[0].UUID, item.IsFoil, item.IsEtched)
 }
 
 func loadCollection(ctx context.Context, link string, maxRows int) ([]UploadEntry, string, error) {

--- a/utils.go
+++ b/utils.go
@@ -497,7 +497,7 @@ func findTCGproductId(cardId string) string {
 			entries, found = tcgMarket[co.UUID]
 		}
 		if found {
-			tcgId = entries[0].OriginalId
+			tcgId = entries[0].OriginalID
 		}
 	}
 
@@ -509,7 +509,7 @@ func findInstanceId(sellerName, cardId, cond string) string {
 	tcgplayer, _ := findSellerInventory(sellerName)
 	for _, entry := range tcgplayer[cardId] {
 		if entry.Conditions == cond {
-			return entry.InstanceId
+			return entry.InstanceID
 		}
 	}
 	return ""
@@ -531,13 +531,13 @@ func uuid2TCGSKU(cardId string, sealed bool, cond string) string {
 
 // tcgSKU2UUID resolves a TCGplayer SKU (instance id) to a card uuid using the
 // precomputed "tcgskuid" index from runSealedAnalysis (O(1)), where the uuid is
-// stored in each entry's OriginalId. Returns "" if the SKU is unknown.
+// stored in each entry's OriginalID. Returns "" if the SKU is unknown.
 func tcgSKU2UUID(sku string) string {
 	entries := GetInfos()["tcgskuid"][sku]
 	if len(entries) == 0 {
 		return ""
 	}
-	return entries[0].OriginalId
+	return entries[0].OriginalID
 }
 
 // tcgSKU2Condition resolves a TCGplayer SKU (instance id) to the condition it
@@ -556,7 +556,7 @@ func findOriginalId(sellerName, cardId string) string {
 	tcgplayer, _ := findSellerInventory(sellerName)
 	entries, found := tcgplayer[cardId]
 	if found {
-		return entries[0].OriginalId
+		return entries[0].OriginalID
 	}
 	return ""
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -13,9 +13,9 @@ func TestTCGSKU2UUID(t *testing.T) {
 
 	infos := map[string]mtgban.InventoryRecord{
 		"tcgskuid": {
-			"12345": {{OriginalId: "uuid-aaa"}},
+			"12345": {{OriginalID: "uuid-aaa"}},
 			// Multiple entries for one SKU: the first one wins.
-			"67890": {{OriginalId: "uuid-bbb"}, {OriginalId: "uuid-ccc"}},
+			"67890": {{OriginalID: "uuid-bbb"}, {OriginalID: "uuid-ccc"}},
 		},
 	}
 	infosPtr.Store(&infos)


### PR DESCRIPTION
Follows `mtgban/go-mtgban#164`. Pinned to the merged commit for now, since
`v0.8.0` is not tagged yet — the `go.mod` line wants one more edit before this
merges.

Almost all of it is compile errors, applied from what the build named. Two
places needed judgement.

### arbit.html — the part the compiler cannot see

A template resolves a field while rendering, so its 16 mentions of `.CardId`
would have kept building and rendered **nothing**: an arbitrage row losing the
card it is about, in production, silently.

`TestArbitBestOf` renders arbit.html against real entries, so it does cover
this. Putting a single `.CardId` back:

```
rendering arbit.html: template: arbit.html:458:19: executing "arbit-results"
at <.CardId>: can't evaluate field CardId in type mtgban.ArbitEntry
```

### upload.html keeps all 18 of its .CardId

**They are not the same field.** `UploadEntry` is `docparse.Entry` and
`OptimizedUploadEntry` is ours — both carry a `CardId` of their own, and
`upload.go` never mentions `ArbitEntry`. Renaming every `.CardId` on sight
would have broken the upload page in order to fix the arbit one.

The same care applies in the tests: `api_csv_test.go` builds `[]UploadEntry`
and keeps `CardId`, while `arbit_bestof_test.go` builds `ArbitEntry` and moves
to `CardID`.

### Verification

`go build ./...` and `go vet ./...` clean; 15 packages pass, 0 fail.